### PR TITLE
Change some ObservedObject to StateObject

### DIFF
--- a/JellyfinPlayer/LibraryListView.swift
+++ b/JellyfinPlayer/LibraryListView.swift
@@ -13,7 +13,7 @@ struct LibraryListView: View {
     private var viewContext
     @EnvironmentObject
     var globalData: GlobalData
-    @ObservedObject
+    @StateObject
     var viewModel: LibraryListViewModel
 
     var body: some View {

--- a/JellyfinPlayer/LibrarySearchView.swift
+++ b/JellyfinPlayer/LibrarySearchView.swift
@@ -15,7 +15,7 @@ struct LibrarySearchView: View {
     private var viewContext
     @EnvironmentObject
     var globalData: GlobalData
-    @ObservedObject
+    @StateObject
     var viewModel: LibrarySearchViewModel
     
     @State

--- a/JellyfinPlayer/LibraryView.swift
+++ b/JellyfinPlayer/LibraryView.swift
@@ -13,7 +13,7 @@ struct LibraryView: View {
     private var viewContext
     @EnvironmentObject
     var globalData: GlobalData
-    @ObservedObject
+    @StateObject
     var viewModel: LibraryViewModel
 
     @State
@@ -27,7 +27,7 @@ struct LibraryView: View {
     private var tracks: [GridItem] = []
 
     init(viewModel: LibraryViewModel, title: String) {
-        self.viewModel = viewModel
+        _viewModel = StateObject(wrappedValue: viewModel)
         self.title = title
     }
 


### PR DESCRIPTION
View is currently regenerated unwantedly under certain circumstances.
As a result, ViewModel, an ObservedObject, is regenerated and is making problems.
To resolve this issue, I changed it to StateObject, which was introduced in iOS 14.
ex. When the app enters the background and returns to the foreground.

See also: https://developer.apple.com/documentation/swiftui/managing-model-data-in-your-app