### PR TITLE
QOL - Set server keyboard for URL input

### DIFF
--- a/JellyfinPlayer tvOS/ConnectToServerView.swift
+++ b/JellyfinPlayer tvOS/ConnectToServerView.swift
@@ -111,6 +111,7 @@ struct ConnectToServerView: View {
                             TextField(NSLocalizedString("Server URL", comment: ""), text: $uri)
                                 .disableAutocorrection(true)
                                 .autocapitalization(.none)
+                                .keyboardType(.URL)
                             Button {
                                 viewModel.connectToServer()
                             } label: {

--- a/JellyfinPlayer/ConnectToServerView.swift
+++ b/JellyfinPlayer/ConnectToServerView.swift
@@ -109,6 +109,7 @@ struct ConnectToServerView: View {
                         TextField(NSLocalizedString("Server URL", comment: ""), text: $uri)
                             .disableAutocorrection(true)
                             .autocapitalization(.none)
+                            .keyboardType(.URL)
                         Button {
                             viewModel.connectToServer()
                         } label: {


### PR DESCRIPTION
Quality of life improvement to have the server textfield keyboard to be for URL input.