### PR TITLE
Fix checkmark view

### DIFF
--- a/JellyfinPlayer/Components/PortraitItemView.swift
+++ b/JellyfinPlayer/Components/PortraitItemView.swift
@@ -46,8 +46,8 @@ struct PortraitItemView: View {
                             if item.userData?.played ?? false {
                                 Image(systemName: "checkmark.circle.fill")
                                     .foregroundColor(.accentColor)
-                                    .background(Color(.white).clipShape(Circle().scale(0.8)))
-                                    .clipShape(Circle())
+                                    .background(Color(.white))
+                                    .clipShape(Circle().scale(0.8))
                             } else {
                                 if item.userData?.unplayedItemCount != nil {
                                     Capsule()

--- a/JellyfinPlayer/Components/PortraitItemView.swift
+++ b/JellyfinPlayer/Components/PortraitItemView.swift
@@ -46,8 +46,8 @@ struct PortraitItemView: View {
                             if item.userData?.played ?? false {
                                 Image(systemName: "checkmark.circle.fill")
                                     .foregroundColor(.accentColor)
-                                    .background(Color(.white))
-                                    .cornerRadius(.infinity)
+                                    .background(Color(.white).clipShape(Circle().scale(0.8)))
+                                    .clipShape(Circle())
                             } else {
                                 if item.userData?.unplayedItemCount != nil {
                                     Capsule()


### PR DESCRIPTION
Scales the background shape for the checkmark symbol such that it fills in the center transparent checkmark while staying inside the circle.

iOS 15 _looks like_ it will allow us to set the transparent checkmark white but I'm not entirely sure, we'll figure it out when we get there.