### PR TITLE
Fix for Swift 5.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Check out our [Weblate instance](https://translate.jellyfin.org/projects/swiftfi
 
 ## ⚙️ Development
 
-Xcode 13.0 with command line tools.
+Xcode 12.5 with command line tools.
 
 ### Build Process
 

--- a/Shared/Extensions/SearchBarView.swift
+++ b/Shared/Extensions/SearchBarView.swift
@@ -16,13 +16,21 @@ struct SearchBar: View {
 
     var body: some View {
         HStack(spacing: 8) {
+            // TODO: Clean up the statement as previously done
+            //       in commit 93a25eb9c43eddd03e09df87722c086fb6cb6da4
+            //       after Swift 5.5 is released.
+            #if os(iOS)
             TextField(NSLocalizedString("Search...", comment: ""), text: $text)
                 .padding(8)
                 .padding(.horizontal, 16)
-            #if os(iOS)
                 .background(Color(.systemGray6))
-            #endif
                 .cornerRadius(8)
+            #else
+            TextField(NSLocalizedString("Search...", comment: ""), text: $text)
+                .padding(8)
+                .padding(.horizontal, 16)
+                .cornerRadius(8)
+            #endif
             if !text.isEmpty {
                 Button(action: {
                     self.text = ""


### PR DESCRIPTION
The compiler flag feature that was previously used is only in Swift 5.5 as noted here:
https://github.com/apple/swift-evolution/blob/main/proposals/0308-postfix-if-config-expressions.md

Please stop using beta Xcodes/languages for official development.