### PR TITLE
Fix connect to server loading

### DIFF
--- a/Shared/ViewModels/ConnectToServerViewModel.swift
+++ b/Shared/ViewModels/ConnectToServerViewModel.swift
@@ -27,11 +27,6 @@ final class ConnectToServerViewModel: ViewModel {
     @Published var servers: [ServerDiscovery.ServerLookupResponse] = []
     @Published var searching = false
 
-    override init() {
-        super.init()
-        getPublicUsers()
-    }
-
     func getPublicUsers() {
         if ServerEnvironment.current.server != nil {
             LogManager.shared.log.debug("Attempting to read public users from \(ServerEnvironment.current.server.baseURI!)", tag: "getPublicUsers")

--- a/Shared/ViewModels/ViewModel.swift
+++ b/Shared/ViewModels/ViewModel.swift
@@ -14,7 +14,7 @@ import JellyfinAPI
 
 class ViewModel: ObservableObject {
 
-    @Published var isLoading = true
+    @Published var isLoading = false
     @Published var errorMessage: ErrorMessage?
 
     let loading = ActivityIndicator()


### PR DESCRIPTION
This is fixed from removing `getPublicUsers()` in the `init` for the `ConnectToServerViewModel`. This was unnecessary because it would be called when there isn't a server to get public users from and would block the login button when a person is attempting to login, both blocks were ~20-30 seconds.

We should:
- split `ConnectToServerX` into two views/viewmodels: `ConnectToServerX` and `LoginToServerX`
- make the `getPublicUsers()` call asynchronous (it is, just don't block the `login` button) and populate user list once completed