### PR TITLE
Temporarily remove widget

### DIFF
--- a/WidgetExtension/NextUpWidget.swift
+++ b/WidgetExtension/NextUpWidget.swift
@@ -337,7 +337,9 @@ struct NextUpWidget: Widget {
         }
         .configurationDisplayName("Next Up")
         .description("Keep watching where you left off or see what's up next.")
-        .supportedFamilies([.systemSmall, .systemMedium, .systemLarge])
+        .supportedFamilies([])
+        // Removed officially until working
+        // .supportedFamilies([.systemSmall, .systemMedium, .systemLarge])
     }
 }
 


### PR DESCRIPTION
Remove the widget from being shipped with the app. Right now, it doesn't have full functionality and I don't want something to be shipped that people will complain about since it doesn't work.

Just a temporary measure until it's in a good spot.