### PR TITLE
tvOS fixes

### DIFF
--- a/JellyfinPlayer tvOS/Components/LandscapeItemElement.swift
+++ b/JellyfinPlayer tvOS/Components/LandscapeItemElement.swift
@@ -92,13 +92,13 @@ struct LandscapeItemElement: View {
                 .shadow(radius: focused ? 10.0 : 0, y: focused ? 10.0 : 0)
             if focused {
                 if inSeasonView ?? false {
-                    Text("\(item.getEpisodeLocator()) • \(item.name ?? "")")
+                  Text("\(item.getEpisodeLocator() ?? "") • \(item.name ?? "")")
                         .font(.callout)
                         .fontWeight(.semibold)
                         .lineLimit(1)
                         .frame(width: 445)
                 } else {
-                    Text(item.type == "Episode" ? "\(item.seriesName ?? "") • \(item.getEpisodeLocator())" : item.name ?? "")
+                    Text(item.type == "Episode" ? "\(item.seriesName ?? "") • \(item.getEpisodeLocator() ?? "")" : item.name ?? "")
                         .font(.callout)
                         .fontWeight(.semibold)
                         .lineLimit(1)

--- a/JellyfinPlayer tvOS/MainTabView.swift
+++ b/JellyfinPlayer tvOS/MainTabView.swift
@@ -46,7 +46,7 @@ struct MainTabView: View {
                     Image(systemName: "house")
 
                 }
-                .tag(Tab.allMedia)
+                .tag(Tab.home)
 
                 Text("Library")
                 .tabItem {

--- a/JellyfinPlayer tvOS/SeriesItemView.swift
+++ b/JellyfinPlayer tvOS/SeriesItemView.swift
@@ -53,11 +53,7 @@ struct SeriesItemView: View {
                         .fontWeight(.bold)
                         .foregroundColor(.primary)
                     HStack {
-                        Text(viewModel.getRunYears()).font(.subheadline)
-                            .fontWeight(.medium)
-                            .foregroundColor(.secondary)
-                            .lineLimit(1)
-                        if viewModel.item.officialRating != nil {
+                       if viewModel.item.officialRating != nil {
                             Text(viewModel.item.officialRating!).font(.subheadline)
                                 .fontWeight(.semibold)
                                 .foregroundColor(.secondary)
@@ -137,16 +133,6 @@ struct SeriesItemView: View {
                             Spacer()
                         }
                     }.padding(.top, 50)
-
-                    if viewModel.nextUpItem != nil {
-                        Text("Next Up")
-                            .font(.headline)
-                            .fontWeight(.semibold)
-                        NavigationLink(destination: ItemView(item: viewModel.nextUpItem!)) {
-                            LandscapeItemElement(item: viewModel.nextUpItem!)
-                        }.buttonStyle(PlainNavigationLinkButtonStyle()).padding(.bottom, 1)
-                    }
-
                     if !viewModel.seasons.isEmpty {
                         Text("Seasons")
                             .font(.headline)

--- a/JellyfinPlayer tvOS/VideoPlayer/MediaInfoView.swift
+++ b/JellyfinPlayer tvOS/VideoPlayer/MediaInfoView.swift
@@ -55,7 +55,7 @@ struct MediaInfoView: View {
                             Text(item.name ?? "Episode")
                                 .foregroundColor(.secondary)
 
-                            Text(item.getEpisodeLocator())
+                            Text(item.getEpisodeLocator() ?? "")
 
                             if let date = item.premiereDate {
                                 Text(formatDate(date: date))

--- a/JellyfinPlayer.xcodeproj/project.pbxproj
+++ b/JellyfinPlayer.xcodeproj/project.pbxproj
@@ -230,6 +230,7 @@
 		62EC353226766849000E9F2D /* SessionManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 62EC352E267666A5000E9F2D /* SessionManager.swift */; };
 		62EC353426766B03000E9F2D /* DeviceRotationViewModifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = 62EC353326766B03000E9F2D /* DeviceRotationViewModifier.swift */; };
 		AE8C3159265D6F90008AA076 /* bitrates.json in Resources */ = {isa = PBXBuildFile; fileRef = AE8C3158265D6F90008AA076 /* bitrates.json */; };
+		C45B29BB26FAC5B600CEF5E0 /* ColorExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = E173DA5126D04AAF00CC4EB7 /* ColorExtension.swift */; };
 		E100720726BDABC100CE3E31 /* MediaPlayButtonRowView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E100720626BDABC100CE3E31 /* MediaPlayButtonRowView.swift */; };
 		E131691726C583BC0074BFEE /* LogConstructor.swift in Sources */ = {isa = PBXBuildFile; fileRef = E131691626C583BC0074BFEE /* LogConstructor.swift */; };
 		E131691826C583BC0074BFEE /* LogConstructor.swift in Sources */ = {isa = PBXBuildFile; fileRef = E131691626C583BC0074BFEE /* LogConstructor.swift */; };
@@ -244,7 +245,6 @@
 		E18845F826DEA9C900B0C5B7 /* ItemViewBody.swift in Sources */ = {isa = PBXBuildFile; fileRef = E18845F726DEA9C900B0C5B7 /* ItemViewBody.swift */; };
 		E188460026DECB9E00B0C5B7 /* ItemLandscapeTopBarView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E18845FF26DECB9E00B0C5B7 /* ItemLandscapeTopBarView.swift */; };
 		E188460426DEF04800B0C5B7 /* CardVStackView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E188460326DEF04800B0C5B7 /* CardVStackView.swift */; };
-		E188460526DEF04800B0C5B7 /* CardVStackView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E188460326DEF04800B0C5B7 /* CardVStackView.swift */; };
 		E1AD104A26D94822003E4A08 /* DetailItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1AD104926D94822003E4A08 /* DetailItem.swift */; };
 		E1AD104B26D94822003E4A08 /* DetailItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1AD104926D94822003E4A08 /* DetailItem.swift */; };
 		E1AD104D26D96CE3003E4A08 /* BaseItemDtoExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1AD104C26D96CE3003E4A08 /* BaseItemDtoExtensions.swift */; };
@@ -254,11 +254,8 @@
 		E1AD105726D981CE003E4A08 /* PortraitHStackView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1AD105526D981CE003E4A08 /* PortraitHStackView.swift */; };
 		E1AD105926D9A543003E4A08 /* LazyView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 621338B22660A07800A81A2A /* LazyView.swift */; };
 		E1AD105C26D9ABDD003E4A08 /* PillHStackView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1AD105B26D9ABDD003E4A08 /* PillHStackView.swift */; };
-		E1AD105D26D9ABDD003E4A08 /* PillHStackView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1AD105B26D9ABDD003E4A08 /* PillHStackView.swift */; };
 		E1AD105F26D9ADDD003E4A08 /* NameGUIDPairExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1AD105E26D9ADDD003E4A08 /* NameGUIDPairExtensions.swift */; };
-		E1AD106026D9ADDD003E4A08 /* NameGUIDPairExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1AD105E26D9ADDD003E4A08 /* NameGUIDPairExtensions.swift */; };
 		E1AD106226D9B7CD003E4A08 /* ItemPortraitHeaderOverlayView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1AD106126D9B7CD003E4A08 /* ItemPortraitHeaderOverlayView.swift */; };
-		E1AD106326D9B7CD003E4A08 /* ItemPortraitHeaderOverlayView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1AD106126D9B7CD003E4A08 /* ItemPortraitHeaderOverlayView.swift */; };
 		E1F0204E26CCCA74001C1C3B /* VideoPlayerJumpLength.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1F0204D26CCCA74001C1C3B /* VideoPlayerJumpLength.swift */; };
 		E1F0204F26CCCA74001C1C3B /* VideoPlayerJumpLength.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1F0204D26CCCA74001C1C3B /* VideoPlayerJumpLength.swift */; };
 		E1FCD08826C35A0D007C8DCF /* NetworkError.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1FCD08726C35A0D007C8DCF /* NetworkError.swift */; };
@@ -1434,7 +1431,6 @@
 				62E632F4267D54030063E547 /* ItemViewModel.swift in Sources */,
 				6267B3D826710B9800A7371D /* CollectionExtensions.swift in Sources */,
 				62E632E7267D3F5B0063E547 /* EpisodeItemViewModel.swift in Sources */,
-				E1AD106326D9B7CD003E4A08 /* ItemPortraitHeaderOverlayView.swift in Sources */,
 				E100720726BDABC100CE3E31 /* MediaPlayButtonRowView.swift in Sources */,
 				535870A52669D8AE00D05A09 /* ParallaxHeader.swift in Sources */,
 				53272532268BF09D0035FBF1 /* MediaViewActionButton.swift in Sources */,
@@ -1445,7 +1441,6 @@
 				536D3D81267BDFC60004248C /* PortraitItemElement.swift in Sources */,
 				531690E5267ABD5C005D8AB9 /* MainTabView.swift in Sources */,
 				5310695B2684E7EE00CFFDBA /* AudioView.swift in Sources */,
-				E1AD106026D9ADDD003E4A08 /* NameGUIDPairExtensions.swift in Sources */,
 				5398514726B64E4100101B49 /* SearchBarView.swift in Sources */,
 				091B5A8D268315D400D78B61 /* ServerDiscovery.swift in Sources */,
 				53ABFDE7267974EF00886593 /* ConnectToServerViewModel.swift in Sources */,
@@ -1457,6 +1452,7 @@
 				53649AB2269D019100A2D8B7 /* LogManager.swift in Sources */,
 				535870AA2669D8AE00D05A09 /* BlurHashDecode.swift in Sources */,
 				53ABFDE5267974EF00886593 /* ViewModel.swift in Sources */,
+				C45B29BB26FAC5B600CEF5E0 /* ColorExtension.swift in Sources */,
 				531069582684E7EE00CFFDBA /* MediaInfoView.swift in Sources */,
 				53272537268C1DBB0035FBF1 /* SeasonItemView.swift in Sources */,
 				09389CC526814E4500AE350E /* DeviceProfileBuilder.swift in Sources */,
@@ -1470,8 +1466,6 @@
 				535870632669D21600D05A09 /* JellyfinPlayer_tvOSApp.swift in Sources */,
 				53ABFDE4267974EF00886593 /* LibraryListViewModel.swift in Sources */,
 				5364F456266CA0DC0026ECBA /* BaseItemPersonExtensions.swift in Sources */,
-				E1AD105D26D9ABDD003E4A08 /* PillHStackView.swift in Sources */,
-				E188460526DEF04800B0C5B7 /* CardVStackView.swift in Sources */,
 				531690FA267AD6EC005D8AB9 /* PlainNavigationLinkButton.swift in Sources */,
 				E131691826C583BC0074BFEE /* LogConstructor.swift in Sources */,
 				E1AD105726D981CE003E4A08 /* PortraitHStackView.swift in Sources */,

--- a/Shared/Extensions/ColorExtension.swift
+++ b/Shared/Extensions/ColorExtension.swift
@@ -13,4 +13,13 @@ extension Color {
 
     static let jellyfinPurple = Color(red: 172 / 255, green: 92 / 255, blue: 195 / 255)
 
+    #if os(tvOS) // tvOS doesn't have these
+    public static let systemFill = Color(UIColor.white)
+    public static let secondarySystemFill = Color(UIColor.gray)
+    public static let tertiarySystemFill = Color(UIColor.black)
+    #else
+    public static let systemFill = Color(UIColor.systemFill)
+    public static let secondarySystemFill = Color(UIColor.secondarySystemBackground)
+    public static let tertiarySystemFill = Color(UIColor.tertiarySystemBackground)
+    #endif
 }

--- a/Shared/Views/ImageView.swift
+++ b/Shared/Views/ImageView.swift
@@ -30,7 +30,7 @@ struct ImageView: View {
         .failure {
             ZStack {
                 Rectangle()
-                    .foregroundColor(Color(UIColor.systemFill))
+                   .foregroundColor(Color.systemFill)
                 
                 Text(failureInitials)
                     .font(.largeTitle)


### PR DESCRIPTION
This PR addresses some issues that were preventing a successful build for tvOS. 

- Fixed usage of getEpisodeLocator() which is optional
- Removed usage of some functions on SeriesItemViewModel that are now private
- Removed some items from tvOS target that appear to be created for iOS usage
- Added some fill colors to ColorExtension that are not present on tvOS

While I was in there making some adjustments, I also addressed [Issue #164](https://github.com/jellyfin/Swiftfin/issues/164)
 - Corrected the Home tab's tag from duplicate `.allMedia` to `.home`

With these adjustments, the app will successfully build on tvOS. 