### PR TITLE
Make the cursor not interact with the User field in tvOS settings

### DIFF
--- a/JellyfinPlayer tvOS/Views/SettingsView/SettingsView.swift
+++ b/JellyfinPlayer tvOS/Views/SettingsView/SettingsView.swift
@@ -42,7 +42,6 @@ struct SettingsView: View {
                             Text(viewModel.user.username)
                                 .foregroundColor(.jellyfinPurple)
                         }
-                        .focusable()
 
                         Button {
                             settingsRouter.route(to: \.serverDetail)


### PR DESCRIPTION
Attempt to fix my own issue #263.

Removing the ability to focus on the 'User' entry in the tvOS settings page, will make the cursor skip over it.