### PR TITLE
Refresh homeview automatically

### DIFF
--- a/Swiftfin/Objects/RefreshHelper.swift
+++ b/Swiftfin/Objects/RefreshHelper.swift
@@ -11,13 +11,30 @@ import UIKit
 
 // A more general derivative of
 // https://stackoverflow.com/questions/65812080/introspect-library-uirefreshcontrol-with-swiftui-not-working
-class RefreshHelper {
+final class RefreshHelper {
     var refreshControl: UIRefreshControl?
     var refreshAction: (() -> Void)?
+    private var lastAutomaticRefresh = Date()
 
     @objc func didRefresh() {
         guard let refreshControl = refreshControl else { return }
         refreshAction?()
         refreshControl.endRefreshing()
+    }
+}
+
+// MARK: - automatic refreshing
+
+extension RefreshHelper {
+    private static let timeUntilStale = TimeInterval(60)
+
+    func refreshStaleData() {
+        guard isStale else { return }
+        lastAutomaticRefresh = .now
+        refreshAction?()
+    }
+
+    private var isStale: Bool {
+        lastAutomaticRefresh.addingTimeInterval(Self.timeUntilStale) < .now
     }
 }

--- a/Swiftfin/Views/HomeView.swift
+++ b/Swiftfin/Views/HomeView.swift
@@ -119,5 +119,8 @@ struct HomeView: View {
                     }
                 }
             }
+            .onAppear {
+                refreshHelper.refreshStaleData()
+            }
     }
 }


### PR DESCRIPTION
I noticed the refresh control sometimes doesn't trigger when pulling down. I haven't been able to reproduce it on the simulator yet, but I figured it's always nicer when the app refreshes automatically.

Small expansion to RefreshHelper so it will refresh the homeview on appear, if it's been at least a minute since last refresh. 