### PR TITLE
Re-implement BlurHash

### DIFF
--- a/Shared/Extensions/BlurHashDecode.swift
+++ b/Shared/Extensions/BlurHashDecode.swift
@@ -8,6 +8,8 @@
 
 import UIKit
 
+// https://github.com/woltapp/blurhash/tree/master/Swift
+
 public extension UIImage {
 	convenience init?(blurHash: String, size: CGSize, punch: Float = 1) {
 		guard blurHash.count >= 6 else { return nil }

--- a/Shared/Extensions/JellyfinAPIExtensions/BaseItemDtoExtensions.swift
+++ b/Shared/Extensions/JellyfinAPIExtensions/BaseItemDtoExtensions.swift
@@ -55,11 +55,11 @@ public extension BaseItemDto {
 		}
 
 		if imgURL.queryParameters?[ImageType.backdrop.rawValue] == nil {
-            if itemType == .episode {
-                return imageBlurHashes?.backdrop?.values.first ?? "001fC^"
-            } else {
-                return imageBlurHashes?.backdrop?[imgTag] ?? "001fC^"
-            }
+			if itemType == .episode {
+				return imageBlurHashes?.backdrop?.values.first ?? "001fC^"
+			} else {
+				return imageBlurHashes?.backdrop?[imgTag] ?? "001fC^"
+			}
 		} else {
 			return imageBlurHashes?.primary?[imgTag] ?? "001fC^"
 		}

--- a/Shared/Extensions/JellyfinAPIExtensions/BaseItemDtoExtensions.swift
+++ b/Shared/Extensions/JellyfinAPIExtensions/BaseItemDtoExtensions.swift
@@ -55,7 +55,11 @@ public extension BaseItemDto {
 		}
 
 		if imgURL.queryParameters?[ImageType.backdrop.rawValue] == nil {
-			return imageBlurHashes?.backdrop?[imgTag] ?? "001fC^"
+            if itemType == .episode {
+                return imageBlurHashes?.backdrop?.values.first ?? "001fC^"
+            } else {
+                return imageBlurHashes?.backdrop?[imgTag] ?? "001fC^"
+            }
 		} else {
 			return imageBlurHashes?.primary?[imgTag] ?? "001fC^"
 		}

--- a/Shared/Views/ImageView.swift
+++ b/Shared/Views/ImageView.swift
@@ -36,7 +36,7 @@ struct ImageView: View {
 
 	// TODO: fix placeholder hash view
 	@ViewBuilder
-    private var placeholderView: some View {
+	private var placeholderView: some View {
 		Image(uiImage: UIImage(blurHash: blurhash, size: CGSize(width: 12, height: 12)) ??
 			UIImage(blurHash: "001fC^", size: CGSize(width: 12, height: 12))!)
 			.resizable()

--- a/Shared/Views/ImageView.swift
+++ b/Shared/Views/ImageView.swift
@@ -9,6 +9,8 @@
 import NukeUI
 import SwiftUI
 
+// TODO: update multiple sources so that multiple blurhashes can be taken, clean up
+
 struct ImageView: View {
 
 	@State
@@ -34,24 +36,10 @@ struct ImageView: View {
 
 	// TODO: fix placeholder hash view
 	@ViewBuilder
-	private func placeholderView() -> some View {
-//		Image(uiImage: UIImage(blurHash: blurhash, size: CGSize(width: 8, height: 8)) ??
-//			UIImage(blurHash: "001fC^", size: CGSize(width: 8, height: 8))!)
-//			.resizable()
-
-		#if os(tvOS)
-			ZStack {
-				Color.black.ignoresSafeArea()
-
-				ProgressView()
-			}
-		#else
-			ZStack {
-				Color.gray.ignoresSafeArea()
-
-				ProgressView()
-			}
-		#endif
+    private var placeholderView: some View {
+		Image(uiImage: UIImage(blurHash: blurhash, size: CGSize(width: 12, height: 12)) ??
+			UIImage(blurHash: "001fC^", size: CGSize(width: 12, height: 12))!)
+			.resizable()
 	}
 
 	@ViewBuilder
@@ -73,9 +61,9 @@ struct ImageView: View {
 				if let image = state.image {
 					image
 				} else if state.error != nil {
-					failureImage().onAppear { sources.removeFirst() }
+					placeholderView.onAppear { sources.removeFirst() }
 				} else {
-					placeholderView()
+					placeholderView
 				}
 			}
 			.pipeline(ImagePipeline(configuration: .withDataCache))

--- a/Swiftfin/Views/ContinueWatchingView.swift
+++ b/Swiftfin/Views/ContinueWatchingView.swift
@@ -99,7 +99,7 @@ struct ContinueWatchingView: View {
 						Button(role: .destructive) {
 							viewModel.removeItemFromResume(item)
 						} label: {
-                            Label(L10n.removeFromResume, systemImage: "minus.circle")
+							Label(L10n.removeFromResume, systemImage: "minus.circle")
 						}
 					}
 				}

--- a/Swiftfin/Views/ContinueWatchingView.swift
+++ b/Swiftfin/Views/ContinueWatchingView.swift
@@ -99,7 +99,7 @@ struct ContinueWatchingView: View {
 						Button(role: .destructive) {
 							viewModel.removeItemFromResume(item)
 						} label: {
-							L10n.removeFromResume.text
+                            Label(L10n.removeFromResume, systemImage: "minus.circle")
 						}
 					}
 				}

--- a/Swiftfin/Views/ItemView/Portrait/ItemPortraitHeaderOverlayView.swift
+++ b/Swiftfin/Views/ItemView/Portrait/ItemPortraitHeaderOverlayView.swift
@@ -24,8 +24,8 @@ struct PortraitHeaderOverlayView: View {
 
 				// MARK: Portrait Image
 
-                ImageView(src: viewModel.item.portraitHeaderViewURL(maxWidth: 130),
-                          bh: viewModel.item.getPrimaryImageBlurHash())
+				ImageView(src: viewModel.item.portraitHeaderViewURL(maxWidth: 130),
+				          bh: viewModel.item.getPrimaryImageBlurHash())
 					.portraitPoster(width: 130)
 					.accessibilityIgnoresInvertColors()
 

--- a/Swiftfin/Views/ItemView/Portrait/ItemPortraitHeaderOverlayView.swift
+++ b/Swiftfin/Views/ItemView/Portrait/ItemPortraitHeaderOverlayView.swift
@@ -24,7 +24,8 @@ struct PortraitHeaderOverlayView: View {
 
 				// MARK: Portrait Image
 
-				ImageView(src: viewModel.item.portraitHeaderViewURL(maxWidth: 130))
+                ImageView(src: viewModel.item.portraitHeaderViewURL(maxWidth: 130),
+                          bh: viewModel.item.getPrimaryImageBlurHash())
 					.portraitPoster(width: 130)
 					.accessibilityIgnoresInvertColors()
 


### PR DESCRIPTION
Re-implements BlurHash that I commented out, turns out it just needed a resizing so it wasn't pixelated as much and some blurhash detection needed to be fixed.

Also adds a minus icon with "Remove from Resume".

Something that I noticed is that the blurhashes for episode items aren't found correctly (hence the forced first return). We probably just need to change these things, but I would like to ultimately clean up how all images are created throughout the app. Blurhashes still need to be implemented in some new views that I've created.

I also noticed the episode backdrop image sometimes snaps between transitions instead of a fade on iOS.