### PR TITLE
LiveTV respect Force Direct Play and Native Player settings

### DIFF
--- a/Shared/Coordinators/VideoPlayerCoordinator/tvOSLiveTVVideoPlayerCoordinator.swift
+++ b/Shared/Coordinators/VideoPlayerCoordinator/tvOSLiveTVVideoPlayerCoordinator.swift
@@ -27,8 +27,14 @@ final class LiveTVVideoPlayerCoordinator: NavigationCoordinatable {
 
 	@ViewBuilder
 	func makeStart() -> some View {
-		LiveTVVideoPlayerView(viewModel: viewModel)
-			.navigationBarHidden(true)
-			.ignoresSafeArea()
+        if Defaults[.Experimental.nativePlayer] {
+            LiveTVNativeVideoPlayerView(viewModel: viewModel)
+                .navigationBarHidden(true)
+                .ignoresSafeArea()
+        } else {
+            LiveTVVideoPlayerView(viewModel: viewModel)
+                .navigationBarHidden(true)
+                .ignoresSafeArea()
+        }
 	}
 }

--- a/Shared/Coordinators/VideoPlayerCoordinator/tvOSLiveTVVideoPlayerCoordinator.swift
+++ b/Shared/Coordinators/VideoPlayerCoordinator/tvOSLiveTVVideoPlayerCoordinator.swift
@@ -27,14 +27,14 @@ final class LiveTVVideoPlayerCoordinator: NavigationCoordinatable {
 
 	@ViewBuilder
 	func makeStart() -> some View {
-        if Defaults[.Experimental.nativePlayer] {
-            LiveTVNativeVideoPlayerView(viewModel: viewModel)
-                .navigationBarHidden(true)
-                .ignoresSafeArea()
-        } else {
-            LiveTVVideoPlayerView(viewModel: viewModel)
-                .navigationBarHidden(true)
-                .ignoresSafeArea()
-        }
+		if Defaults[.Experimental.liveTVNativePlayer] {
+			LiveTVNativeVideoPlayerView(viewModel: viewModel)
+				.navigationBarHidden(true)
+				.ignoresSafeArea()
+		} else {
+			LiveTVVideoPlayerView(viewModel: viewModel)
+				.navigationBarHidden(true)
+				.ignoresSafeArea()
+		}
 	}
 }

--- a/Shared/Extensions/JellyfinAPIExtensions/BaseItemDto+VideoPlayerViewModel.swift
+++ b/Shared/Extensions/JellyfinAPIExtensions/BaseItemDto+VideoPlayerViewModel.swift
@@ -226,14 +226,14 @@ extension BaseItemDto {
 					                                                                     mediaSourceId: mediaSourceID)
 					directStreamURL = URL(string: directStreamBuilder.URLString)!
 
-                    if let transcodeURL = currentMediaSource.transcodingUrl, !Defaults[.Experimental.forceDirectPlay] {
+					if let transcodeURL = currentMediaSource.transcodingUrl, !Defaults[.Experimental.liveTVForceDirectPlay] {
 						streamType = .transcode
 						transcodedStreamURL = URLComponents(string: SessionManager.main.currentLogin.server.currentURI
 							.appending(transcodeURL))!
 					} else {
 						streamType = .direct
 						transcodedStreamURL = nil
-                    }
+					}
 
 					let hlsStreamBuilder = DynamicHlsAPI.getMasterHlsVideoPlaylistWithRequestBuilder(itemId: id ?? "",
 					                                                                                 mediaSourceId: id ?? "",

--- a/Shared/Extensions/JellyfinAPIExtensions/BaseItemDto+VideoPlayerViewModel.swift
+++ b/Shared/Extensions/JellyfinAPIExtensions/BaseItemDto+VideoPlayerViewModel.swift
@@ -226,14 +226,14 @@ extension BaseItemDto {
 					                                                                     mediaSourceId: mediaSourceID)
 					directStreamURL = URL(string: directStreamBuilder.URLString)!
 
-					if let transcodeURL = currentMediaSource.transcodingUrl {
+                    if let transcodeURL = currentMediaSource.transcodingUrl, !Defaults[.Experimental.forceDirectPlay] {
 						streamType = .transcode
 						transcodedStreamURL = URLComponents(string: SessionManager.main.currentLogin.server.currentURI
 							.appending(transcodeURL))!
 					} else {
 						streamType = .direct
 						transcodedStreamURL = nil
-					}
+                    }
 
 					let hlsStreamBuilder = DynamicHlsAPI.getMasterHlsVideoPlaylistWithRequestBuilder(itemId: id ?? "",
 					                                                                                 mediaSourceId: id ?? "",

--- a/Shared/SwiftfinStore/SwiftfinStoreDefaults.swift
+++ b/Shared/SwiftfinStore/SwiftfinStoreDefaults.swift
@@ -74,8 +74,10 @@ extension Defaults.Keys {
 		static let syncSubtitleStateWithAdjacent = Key<Bool>("experimental.syncSubtitleState", default: false,
 		                                                     suite: SwiftfinStore.Defaults.generalSuite)
 		static let forceDirectPlay = Key<Bool>("forceDirectPlay", default: false, suite: SwiftfinStore.Defaults.generalSuite)
-		static let liveTVAlphaEnabled = Key<Bool>("liveTVAlphaEnabled", default: false, suite: SwiftfinStore.Defaults.generalSuite)
 		static let nativePlayer = Key<Bool>("nativePlayer", default: false, suite: SwiftfinStore.Defaults.generalSuite)
+		static let liveTVAlphaEnabled = Key<Bool>("liveTVAlphaEnabled", default: false, suite: SwiftfinStore.Defaults.generalSuite)
+		static let liveTVForceDirectPlay = Key<Bool>("liveTVForceDirectPlay", default: false, suite: SwiftfinStore.Defaults.generalSuite)
+		static let liveTVNativePlayer = Key<Bool>("liveTVNativePlayer", default: false, suite: SwiftfinStore.Defaults.generalSuite)
 	}
 
 	// tvos specific

--- a/Shared/ViewModels/VideoPlayerViewModel/VideoPlayerViewModel.swift
+++ b/Shared/ViewModels/VideoPlayerViewModel/VideoPlayerViewModel.swift
@@ -151,7 +151,8 @@ final class VideoPlayerViewModel: ViewModel {
 	}
 
 	func setSeconds(_ seconds: Int64) {
-		let videoDuration = item.runTimeTicks!
+        guard let runTimeTicks = item.runTimeTicks else { return }
+		let videoDuration = runTimeTicks
 		let percentage = Double(seconds * 10_000_000) / Double(videoDuration)
 
 		sliderPercentage = percentage

--- a/Shared/ViewModels/VideoPlayerViewModel/VideoPlayerViewModel.swift
+++ b/Shared/ViewModels/VideoPlayerViewModel/VideoPlayerViewModel.swift
@@ -151,7 +151,7 @@ final class VideoPlayerViewModel: ViewModel {
 	}
 
 	func setSeconds(_ seconds: Int64) {
-        guard let runTimeTicks = item.runTimeTicks else { return }
+		guard let runTimeTicks = item.runTimeTicks else { return }
 		let videoDuration = runTimeTicks
 		let percentage = Double(seconds * 10_000_000) / Double(videoDuration)
 

--- a/Shared/Views/LiveTVChannelItemElement.swift
+++ b/Shared/Views/LiveTVChannelItemElement.swift
@@ -10,71 +10,127 @@ import JellyfinAPI
 import SwiftUI
 
 struct LiveTVChannelItemElement: View {
-	@Environment(\.isFocused)
-	var envFocused: Bool
+	@FocusState
+	private var focused: Bool
 	@State
-	var focused: Bool = false
+	private var loading: Bool = false
+	@State
+	private var isFocused: Bool = false
 
 	var channel: BaseItemDto
 	var program: BaseItemDto?
 	var startString = " "
 	var endString = " "
 	var progressPercent = Double(0)
+	var onSelect: (@escaping (Bool) -> Void) -> Void
+
+	private var detailText: String {
+		guard let program = program else {
+			return ""
+		}
+		var text = ""
+		if let season = program.parentIndexNumber,
+		   let episode = program.indexNumber
+		{
+			text.append("\(season)x\(episode) ")
+		} else if let episode = program.indexNumber {
+			text.append("\(episode) ")
+		}
+		if let title = program.episodeTitle {
+			text.append("\(title) ")
+		}
+		if let year = program.productionYear {
+			text.append("\(year) ")
+		}
+		if let rating = program.officialRating {
+			text.append("\(rating)")
+		}
+		return text
+	}
 
 	var body: some View {
-		VStack {
-			HStack {
-				Spacer()
-				Text(channel.number ?? "")
-					.font(.footnote)
-					.frame(alignment: .trailing)
-			}.frame(alignment: .top)
-			ImageView(channel.getPrimaryImage(maxWidth: 125))
-				.frame(width: 125, alignment: .center)
-				.offset(x: 0, y: -32)
-			Text(channel.name ?? "?")
-				.font(.footnote)
-				.lineLimit(1)
-				.frame(alignment: .center)
-			Text(program?.name ?? L10n.notAvailableSlash)
-				.font(.body)
-				.lineLimit(1)
-				.foregroundColor(.green)
+		ZStack {
 			VStack {
 				HStack {
-					Text(startString)
+					Text(channel.number ?? "")
 						.font(.footnote)
-						.lineLimit(1)
 						.frame(alignment: .leading)
-
+						.padding()
 					Spacer()
+				}.frame(alignment: .top)
+				Spacer()
+			}
+			VStack {
+				ImageView(channel.getPrimaryImage(maxWidth: 128))
+					.aspectRatio(contentMode: .fit)
+					.frame(width: 128, alignment: .center)
+					.padding(.init(top: 8, leading: 0, bottom: 0, trailing: 0))
+				Text(channel.name ?? "?")
+					.font(.footnote)
+					.lineLimit(1)
+					.frame(alignment: .center)
+				Text(program?.name ?? L10n.notAvailableSlash)
+					.font(.body)
+					.lineLimit(1)
+					.foregroundColor(.green)
+				Text(detailText)
+					.font(.body)
+					.lineLimit(1)
+					.foregroundColor(.green)
+				Spacer()
+				HStack(alignment: .bottom) {
+					VStack {
+						Spacer()
+						HStack {
+							Text(startString)
+								.font(.footnote)
+								.lineLimit(1)
+								.frame(alignment: .leading)
 
-					Text(endString)
-						.font(.footnote)
-						.lineLimit(1)
-						.frame(alignment: .trailing)
-				}
-				GeometryReader { gp in
-					ZStack(alignment: .leading) {
-						RoundedRectangle(cornerRadius: 6)
-							.fill(Color.gray)
-							.opacity(0.4)
-							.frame(minWidth: 100, maxWidth: .infinity, minHeight: 12, maxHeight: 12)
-						RoundedRectangle(cornerRadius: 6)
-							.fill(Color.jellyfinPurple)
-							.frame(width: CGFloat(progressPercent * gp.size.width), height: 12)
+							Spacer()
+
+							Text(endString)
+								.font(.footnote)
+								.lineLimit(1)
+								.frame(alignment: .trailing)
+						}
+						GeometryReader { gp in
+							ZStack(alignment: .leading) {
+								RoundedRectangle(cornerRadius: 6)
+									.fill(Color.gray)
+									.opacity(0.4)
+									.frame(minWidth: 100, maxWidth: .infinity, minHeight: 12, maxHeight: 12)
+								RoundedRectangle(cornerRadius: 6)
+									.fill(Color.jellyfinPurple)
+									.frame(width: CGFloat(progressPercent * gp.size.width), height: 12)
+							}
+							.frame(alignment: .bottom)
+						}
 					}
 				}
 			}
-		}
-		.padding()
-		.background(Color.clear)
-		.border(focused ? Color.blue : Color.clear, width: 4)
-		.onChange(of: envFocused) { envFocus in
-			withAnimation(.linear(duration: 0.15)) {
-				self.focused = envFocus
+			.padding()
+			.opacity(loading ? 0.5 : 1.0)
+
+			if loading {
+				ProgressView()
 			}
 		}
-		.scaleEffect(focused ? 1.1 : 1)
+		.overlay(RoundedRectangle(cornerRadius: 20)
+			.stroke(isFocused ? Color.blue : Color.clear, lineWidth: 4))
+		.cornerRadius(20)
+		.scaleEffect(isFocused ? 1.1 : 1)
+		.focusable(true)
+		.focused($focused)
+		.onChange(of: focused) { foc in
+			withAnimation(.linear(duration: 0.15)) {
+				self.isFocused = foc
+			}
+		}
+		.onLongPressGesture(minimumDuration: 0.01, pressing: { _ in }) {
+			onSelect { loadingState in
+				loading = loadingState
+			}
+		}
 	}
 }

--- a/Swiftfin tvOS/Views/LibraryListView.swift
+++ b/Swiftfin tvOS/Views/LibraryListView.swift
@@ -38,6 +38,31 @@ struct LibraryListView: View {
 									self.mainCoordinator.root(\.liveTV)
 								}
 									label: {
+										ZStack {
+											HStack {
+												Spacer()
+												VStack {
+													Text(library.name ?? "")
+														.foregroundColor(.white)
+														.font(.title2)
+														.fontWeight(.semibold)
+												}
+												Spacer()
+											}.padding(32)
+										}
+										.frame(minWidth: 100, maxWidth: .infinity)
+										.frame(height: 100)
+									}
+										.cornerRadius(10)
+										.shadow(radius: 5)
+										.padding(.bottom, 5)
+							}
+						} else {
+							Button {
+								self.libraryListRouter.route(to: \.library,
+								                             (viewModel: LibraryViewModel(parentID: library.id), title: library.name ?? ""))
+							}
+								label: {
 									ZStack {
 										HStack {
 											Spacer()
@@ -56,31 +81,6 @@ struct LibraryListView: View {
 									.cornerRadius(10)
 									.shadow(radius: 5)
 									.padding(.bottom, 5)
-							}
-						} else {
-							Button {
-								self.libraryListRouter.route(to: \.library,
-								                             (viewModel: LibraryViewModel(parentID: library.id), title: library.name ?? ""))
-							}
-								label: {
-								ZStack {
-									HStack {
-										Spacer()
-										VStack {
-											Text(library.name ?? "")
-												.foregroundColor(.white)
-												.font(.title2)
-												.fontWeight(.semibold)
-										}
-										Spacer()
-									}.padding(32)
-								}
-								.frame(minWidth: 100, maxWidth: .infinity)
-								.frame(height: 100)
-							}
-								.cornerRadius(10)
-								.shadow(radius: 5)
-								.padding(.bottom, 5)
 						}
 					}
 				} else {

--- a/Swiftfin tvOS/Views/LiveTVChannelsView.swift
+++ b/Swiftfin tvOS/Views/LiveTVChannelsView.swift
@@ -55,15 +55,21 @@ struct LiveTVChannelsView: View {
 		let channel = item.channel
 		if channel.type != "Folder" {
 			Button {
+                self.viewModel.isLoading = true
 				self.viewModel.fetchVideoPlayerViewModel(item: channel) { playerViewModel in
 					self.router.route(to: \.videoPlayer, playerViewModel)
+                    DispatchQueue.main.asyncAfter(deadline: .now() + 2) {
+                        self.viewModel.isLoading = false
+                    }
 				}
 			} label: {
-				LiveTVChannelItemElement(channel: channel,
+                let progressPercent = item.program?.getLiveProgressPercentage() ?? 0
+                LiveTVChannelItemElement(channel: channel,
 				                         program: item.program,
 				                         startString: item.program?.getLiveStartTimeString(formatter: viewModel.timeFormatter) ?? " ",
 				                         endString: item.program?.getLiveEndTimeString(formatter: viewModel.timeFormatter) ?? " ",
-				                         progressPercent: item.program?.getLiveProgressPercentage() ?? 0)
+                                         progressPercent: progressPercent > 1.0 ? 1.0 : progressPercent
+                )
 			}
 			.buttonStyle(PlainNavigationLinkButtonStyle())
 		}

--- a/Swiftfin tvOS/Views/LiveTVChannelsView.swift
+++ b/Swiftfin tvOS/Views/LiveTVChannelsView.swift
@@ -54,24 +54,21 @@ struct LiveTVChannelsView: View {
 		let item = cell.item
 		let channel = item.channel
 		if channel.type != "Folder" {
-			Button {
-                self.viewModel.isLoading = true
-				self.viewModel.fetchVideoPlayerViewModel(item: channel) { playerViewModel in
-					self.router.route(to: \.videoPlayer, playerViewModel)
-                    DispatchQueue.main.asyncAfter(deadline: .now() + 2) {
-                        self.viewModel.isLoading = false
-                    }
-				}
-			} label: {
-                let progressPercent = item.program?.getLiveProgressPercentage() ?? 0
-                LiveTVChannelItemElement(channel: channel,
-				                         program: item.program,
-				                         startString: item.program?.getLiveStartTimeString(formatter: viewModel.timeFormatter) ?? " ",
-				                         endString: item.program?.getLiveEndTimeString(formatter: viewModel.timeFormatter) ?? " ",
-                                         progressPercent: progressPercent > 1.0 ? 1.0 : progressPercent
-                )
-			}
-			.buttonStyle(PlainNavigationLinkButtonStyle())
+			let progressPercent = item.program?.getLiveProgressPercentage() ?? 0
+			LiveTVChannelItemElement(channel: channel,
+			                         program: item.program,
+			                         startString: item.program?.getLiveStartTimeString(formatter: viewModel.timeFormatter) ?? " ",
+			                         endString: item.program?.getLiveEndTimeString(formatter: viewModel.timeFormatter) ?? " ",
+			                         progressPercent: progressPercent > 1.0 ? 1.0 : progressPercent,
+			                         onSelect: { loadingAction in
+			                         	loadingAction(true)
+			                         	self.viewModel.fetchVideoPlayerViewModel(item: channel) { playerViewModel in
+			                         		self.router.route(to: \.videoPlayer, playerViewModel)
+			                         		DispatchQueue.main.asyncAfter(deadline: .now() + 2) {
+			                         			loadingAction(false)
+			                         		}
+			                         	}
+			                         })
 		}
 	}
 

--- a/Swiftfin tvOS/Views/SettingsView/ExperimentalSettingsView.swift
+++ b/Swiftfin tvOS/Views/SettingsView/ExperimentalSettingsView.swift
@@ -48,7 +48,7 @@ struct ExperimentalSettingsView: View {
 				Toggle("Live TV Native Player", isOn: $liveTVNativePlayer)
 
 			} header: {
-				L10n.experimental.text
+				Text("Live TV")
 			}
 		}
 	}

--- a/Swiftfin tvOS/Views/SettingsView/ExperimentalSettingsView.swift
+++ b/Swiftfin tvOS/Views/SettingsView/ExperimentalSettingsView.swift
@@ -15,10 +15,15 @@ struct ExperimentalSettingsView: View {
 	var forceDirectPlay
 	@Default(.Experimental.syncSubtitleStateWithAdjacent)
 	var syncSubtitleStateWithAdjacent
-	@Default(.Experimental.liveTVAlphaEnabled)
-	var liveTVAlphaEnabled
 	@Default(.Experimental.nativePlayer)
 	var nativePlayer
+
+	@Default(.Experimental.liveTVAlphaEnabled)
+	var liveTVAlphaEnabled
+	@Default(.Experimental.liveTVForceDirectPlay)
+	var liveTVForceDirectPlay
+	@Default(.Experimental.liveTVNativePlayer)
+	var liveTVNativePlayer
 
 	var body: some View {
 		Form {
@@ -28,9 +33,19 @@ struct ExperimentalSettingsView: View {
 
 				Toggle("Sync Subtitles with Adjacent Episodes", isOn: $syncSubtitleStateWithAdjacent)
 
+				Toggle("Native Player", isOn: $nativePlayer)
+
+			} header: {
+				L10n.experimental.text
+			}
+
+			Section {
+
 				Toggle("Live TV (Alpha)", isOn: $liveTVAlphaEnabled)
 
-				Toggle("Native Player", isOn: $nativePlayer)
+				Toggle("Live TV Force Direct Play", isOn: $liveTVForceDirectPlay)
+
+				Toggle("Live TV Native Player", isOn: $liveTVNativePlayer)
 
 			} header: {
 				L10n.experimental.text

--- a/Swiftfin tvOS/Views/VideoPlayer/LiveTVNativeVideoPlayerView.swift
+++ b/Swiftfin tvOS/Views/VideoPlayer/LiveTVNativeVideoPlayerView.swift
@@ -1,0 +1,23 @@
+//
+// Swiftfin is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, you can obtain one at https://mozilla.org/MPL/2.0/.
+//
+// Copyright (c) 2022 Jellyfin & Jellyfin Contributors
+//
+
+import SwiftUI
+import UIKit
+
+struct LiveTVNativeVideoPlayerView: UIViewControllerRepresentable {
+    
+    let viewModel: VideoPlayerViewModel
+    
+    typealias UIViewControllerType = NativePlayerViewController
+    
+    func makeUIViewController(context: Context) -> NativePlayerViewController {
+        NativePlayerViewController(viewModel: viewModel)
+    }
+    
+    func updateUIViewController(_ uiViewController: NativePlayerViewController, context: Context) {}
+}

--- a/Swiftfin tvOS/Views/VideoPlayer/LiveTVNativeVideoPlayerView.swift
+++ b/Swiftfin tvOS/Views/VideoPlayer/LiveTVNativeVideoPlayerView.swift
@@ -10,14 +10,14 @@ import SwiftUI
 import UIKit
 
 struct LiveTVNativeVideoPlayerView: UIViewControllerRepresentable {
-    
-    let viewModel: VideoPlayerViewModel
-    
-    typealias UIViewControllerType = NativePlayerViewController
-    
-    func makeUIViewController(context: Context) -> NativePlayerViewController {
-        NativePlayerViewController(viewModel: viewModel)
-    }
-    
-    func updateUIViewController(_ uiViewController: NativePlayerViewController, context: Context) {}
+
+	let viewModel: VideoPlayerViewModel
+
+	typealias UIViewControllerType = NativePlayerViewController
+
+	func makeUIViewController(context: Context) -> NativePlayerViewController {
+		NativePlayerViewController(viewModel: viewModel)
+	}
+
+	func updateUIViewController(_ uiViewController: NativePlayerViewController, context: Context) {}
 }

--- a/Swiftfin.xcodeproj/project.pbxproj
+++ b/Swiftfin.xcodeproj/project.pbxproj
@@ -263,6 +263,7 @@
 		C4AE2C3027498D2300AE13CF /* LiveTVHomeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C4AE2C2F27498D2300AE13CF /* LiveTVHomeView.swift */; };
 		C4AE2C3227498D6A00AE13CF /* LiveTVProgramsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C4AE2C3127498D6A00AE13CF /* LiveTVProgramsView.swift */; };
 		C4AE2C3327498DBE00AE13CF /* LiveTVChannelItemElement.swift in Sources */ = {isa = PBXBuildFile; fileRef = C4E52304272CE68800654268 /* LiveTVChannelItemElement.swift */; };
+		C4B9B91427E1921B0063535C /* LiveTVNativeVideoPlayerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C4B9B91327E1921B0063535C /* LiveTVNativeVideoPlayerView.swift */; };
 		C4BE0764271FC0BB003F4AD1 /* TVLibrariesCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = C4BE0762271FC0BB003F4AD1 /* TVLibrariesCoordinator.swift */; };
 		C4BE0767271FC109003F4AD1 /* TVLibrariesViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = C4BE0765271FC109003F4AD1 /* TVLibrariesViewModel.swift */; };
 		C4BE076A271FC164003F4AD1 /* TVLibrariesView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C4BE0768271FC164003F4AD1 /* TVLibrariesView.swift */; };
@@ -741,6 +742,7 @@
 		C4534984279A40C50045F1E2 /* LiveTVVideoPlayerView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LiveTVVideoPlayerView.swift; sourceTree = "<group>"; };
 		C4AE2C2F27498D2300AE13CF /* LiveTVHomeView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LiveTVHomeView.swift; sourceTree = "<group>"; };
 		C4AE2C3127498D6A00AE13CF /* LiveTVProgramsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LiveTVProgramsView.swift; sourceTree = "<group>"; };
+		C4B9B91327E1921B0063535C /* LiveTVNativeVideoPlayerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LiveTVNativeVideoPlayerView.swift; sourceTree = "<group>"; };
 		C4BE0762271FC0BB003F4AD1 /* TVLibrariesCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TVLibrariesCoordinator.swift; sourceTree = "<group>"; };
 		C4BE0765271FC109003F4AD1 /* TVLibrariesViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TVLibrariesViewModel.swift; sourceTree = "<group>"; };
 		C4BE0768271FC164003F4AD1 /* TVLibrariesView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TVLibrariesView.swift; sourceTree = "<group>"; };
@@ -999,6 +1001,7 @@
 				E17885A7278130690094FBCF /* Overlays */,
 				E1C812C8277AE40900918266 /* VideoPlayerView.swift */,
 				C4534984279A40C50045F1E2 /* LiveTVVideoPlayerView.swift */,
+				C4B9B91327E1921B0063535C /* LiveTVNativeVideoPlayerView.swift */,
 				C453497E279A2DA50045F1E2 /* LiveTVPlayerViewController.swift */,
 				E1384943278036C70024FB48 /* VLCPlayerViewController.swift */,
 				E13AD72F2798C60F00FDCEE8 /* NativePlayerViewController.swift */,
@@ -2171,6 +2174,7 @@
 				E193D53327193F7D00900D82 /* FilterCoordinator.swift in Sources */,
 				6267B3DC2671139500A7371D /* ImageExtensions.swift in Sources */,
 				E103A6A9278AB6FF00820EC7 /* CinematicNextUpCardView.swift in Sources */,
+				C4B9B91427E1921B0063535C /* LiveTVNativeVideoPlayerView.swift in Sources */,
 				E107BB9427880A8F00354E07 /* CollectionItemViewModel.swift in Sources */,
 				C4534985279A40C60045F1E2 /* LiveTVVideoPlayerView.swift in Sources */,
 				E1A2C15A279A7D76005EC829 /* BundleExtensions.swift in Sources */,


### PR DESCRIPTION
Ensures LiveTV respects those settings. LiveTV / HLS works better in the Native player than in VLCKit. 

However, I wonder if it would make sense to break these out as separate settings specifically for LiveTV? Because it might make sense to use Force Direct Play / Native Player for liveTV, but maybe I wouldn't choose those settings when playing something from my library. 

I've also added usage of the loading indicator right upon selecting an item in the LiveTV Channels view, as there was previously a bit of a delay after selecting and item and the viewModel creation completing. This change makes it feel a little more responsive to selection. However, while the loading overlay is shown, the Tab bar takes focus. This could create some confusion, as you could change tabs while the loading is still in progress. I'd prefer to hide it, but I'm not exactly sure if that can easily be done with a Tab Bar on tvOS.

Lastly, I had to put a short delay on hiding the loading indicator after the view model is built just before player view appears. I don't love it, but without that delay, the loading completes and the channels grid view flashes momentarily before the player view appears, which didn't feel clean. 


Loading example: 

https://user-images.githubusercontent.com/125045/159558737-d90e2c8c-636e-4886-978b-7be0a0eb2ba8.mp4



