### PR TITLE
Modify External Subtitle Processing Logic

### DIFF
--- a/Shared/Extensions/JellyfinAPIExtensions/MediaStreamExtension.swift
+++ b/Shared/Extensions/JellyfinAPIExtensions/MediaStreamExtension.swift
@@ -10,12 +10,12 @@ import Foundation
 import JellyfinAPI
 
 extension MediaStream {
-
-	func externalURL(base: String) -> URL? {
-		guard let deliveryURL = deliveryUrl else { return nil }
-		var baseComponents = URLComponents(string: base)
-		baseComponents?.path += deliveryURL
-
-		return baseComponents?.url
+	func externalSubtitleURL(base: String, item: BaseItemDto) -> URL? {
+		guard let id = item.id,
+		      let index = index,
+		      let format = codec else { return nil }
+		let startPositionTicks = item.userData?.playbackPositionTicks ?? 0
+		let mediaSourceID = id
+		return URL(string: "\(base)/Videos/\(id)/\(mediaSourceID)/Subtitles/\(index)/\(startPositionTicks)/Stream.\(format)")
 	}
 }

--- a/Swiftfin tvOS/Views/VideoPlayer/LiveTVPlayerViewController.swift
+++ b/Swiftfin tvOS/Views/VideoPlayer/LiveTVPlayerViewController.swift
@@ -479,7 +479,9 @@ extension LiveTVPlayerViewController {
 
 		// Setup external subtitles
 		for externalSubtitle in viewModel.subtitleStreams.filter({ $0.deliveryMethod == .external }) {
-			if let deliveryURL = externalSubtitle.externalURL(base: SessionManager.main.currentLogin.server.currentURI) {
+			if let deliveryURL = externalSubtitle.externalSubtitleURL(base: SessionManager.main.currentLogin.server.currentURI,
+			                                                          item: viewModel.item)
+			{
 				vlcMediaPlayer.addPlaybackSlave(deliveryURL, type: .subtitle, enforce: false)
 			}
 		}

--- a/Swiftfin tvOS/Views/VideoPlayer/VLCPlayerViewController.swift
+++ b/Swiftfin tvOS/Views/VideoPlayer/VLCPlayerViewController.swift
@@ -479,7 +479,9 @@ extension VLCPlayerViewController {
 
 		// Setup external subtitles
 		for externalSubtitle in viewModel.subtitleStreams.filter({ $0.deliveryMethod == .external }) {
-			if let deliveryURL = externalSubtitle.externalURL(base: SessionManager.main.currentLogin.server.currentURI) {
+			if let deliveryURL = externalSubtitle.externalSubtitleURL(base: SessionManager.main.currentLogin.server.currentURI,
+			                                                          item: viewModel.item)
+			{
 				vlcMediaPlayer.addPlaybackSlave(deliveryURL, type: .subtitle, enforce: false)
 			}
 		}

--- a/Swiftfin/Views/VideoPlayer/VLCPlayerViewController.swift
+++ b/Swiftfin/Views/VideoPlayer/VLCPlayerViewController.swift
@@ -609,8 +609,10 @@ extension VLCPlayerViewController {
 
 		// Setup external subtitles
 		for externalSubtitle in viewModel.subtitleStreams.filter({ $0.deliveryMethod == .external }) {
-			if let deliveryURL = externalSubtitle.externalURL(base: SessionManager.main.currentLogin.server.currentURI) {
-				vlcMediaPlayer.addPlaybackSlave(deliveryURL, type: .subtitle, enforce: false)
+			if let deliveryURL = externalSubtitle.externalSubtitleURL(base: SessionManager.main.currentLogin.server.currentURI,
+			                                                          item: viewModel.item)
+			{
+				vlcMediaPlayer.addPlaybackSlave(deliveryURL, type: .subtitle, enforce: true)
 			}
 		}
 


### PR DESCRIPTION
The `deliveryUrl` of the external subtitles provided by Jellyfin 10.8 did not work properly, so I changed the logic by referring to the source.

Source: https://github.com/jellyfin/jellyfin-androidtv/blob/8c01a3d0ebd98355c4f068767f6ed4920a664767/app/src/main/java/org/jellyfin/androidtv/data/compat/StreamInfo.java

fix #417 