### PR TITLE
Modify External Subtitle URL Logic

### DIFF
--- a/Shared/Extensions/JellyfinAPIExtensions/MediaStreamExtension.swift
+++ b/Shared/Extensions/JellyfinAPIExtensions/MediaStreamExtension.swift
@@ -11,6 +11,10 @@ import JellyfinAPI
 
 extension MediaStream {
 	func externalURL(base: String) -> URL? {
+		var base = base
+		while base.last == Character("/") {
+			base.removeLast()
+		}
 		guard let deliveryURL = deliveryUrl else { return nil }
 		return URL(string: base + deliveryURL)
 	}

--- a/Shared/Extensions/JellyfinAPIExtensions/MediaStreamExtension.swift
+++ b/Shared/Extensions/JellyfinAPIExtensions/MediaStreamExtension.swift
@@ -10,12 +10,8 @@ import Foundation
 import JellyfinAPI
 
 extension MediaStream {
-
 	func externalURL(base: String) -> URL? {
 		guard let deliveryURL = deliveryUrl else { return nil }
-		var baseComponents = URLComponents(string: base)
-		baseComponents?.path += deliveryURL
-
-		return baseComponents?.url
+		return URL(string: base + deliveryURL)
 	}
 }


### PR DESCRIPTION
Modify with reference to https://github.com/jellyfin/Swiftfin/issues/417#issuecomment-1173009298
Checked work normally in 10.7.7 and 10.8.1 (ass, srt)

