### PR TITLE
Add login background to tvOS

### DIFF
--- a/Shared/ViewModels/UserSignInViewModel.swift
+++ b/Shared/ViewModels/UserSignInViewModel.swift
@@ -25,6 +25,7 @@ final class UserSignInViewModel: ViewModel {
 
 	init(server: SwiftfinStore.State.Server) {
 		self.server = server
+		JellyfinAPIAPI.basePath = server.currentURI
 	}
 
 	var alertTitle: String {
@@ -58,7 +59,6 @@ final class UserSignInViewModel: ViewModel {
 
 	func loadUsers() {
 		self.isLoadingUsers = true
-		JellyfinAPIAPI.basePath = server.currentURI
 		UserAPI.getPublicUsers()
 			.sink(receiveCompletion: { completion in
 				self.handleAPIRequestError(displayMessage: L10n.unableToConnectServer, completion: completion)
@@ -74,6 +74,11 @@ final class UserSignInViewModel: ViewModel {
 		                                                        imageType: .primary,
 		                                                        width: 200,
 		                                                        quality: 90).URLString
+		return URL(string: urlString)
+	}
+
+	func getSplashscreenUrl() -> URL? {
+		let urlString = ImageAPI.getSplashscreenWithRequestBuilder().URLString
 		return URL(string: urlString)
 	}
 }

--- a/Swiftfin tvOS/Views/UserSignInView.swift
+++ b/Swiftfin tvOS/Views/UserSignInView.swift
@@ -19,39 +19,44 @@ struct UserSignInView: View {
 	private var password: String = ""
 
 	var body: some View {
-		Form {
+		ZStack {
+			ImageView(viewModel.getSplashscreenUrl())
+				.ignoresSafeArea()
+			Color.black.opacity(0.9)
+				.ignoresSafeArea()
+			Form {
+				Section {
+					TextField(L10n.username, text: $username)
+						.disableAutocorrection(true)
+						.autocapitalization(.none)
 
-			Section {
-				TextField(L10n.username, text: $username)
-					.disableAutocorrection(true)
-					.autocapitalization(.none)
+					SecureField(L10n.password, text: $password)
+						.disableAutocorrection(true)
+						.autocapitalization(.none)
 
-				SecureField(L10n.password, text: $password)
-					.disableAutocorrection(true)
-					.autocapitalization(.none)
-
-				Button {
-					viewModel.login(username: username, password: password)
-				} label: {
-					HStack {
-						L10n.connect.text
-						Spacer()
-						if viewModel.isLoading {
-							ProgressView()
+					Button {
+						viewModel.login(username: username, password: password)
+					} label: {
+						HStack {
+							L10n.connect.text
+							Spacer()
+							if viewModel.isLoading {
+								ProgressView()
+							}
 						}
 					}
-				}
-				.disabled(viewModel.isLoading || username.isEmpty)
+					.disabled(viewModel.isLoading || username.isEmpty)
 
-			} header: {
-				L10n.signInToServer(viewModel.server.name).text
+				} header: {
+					L10n.signInToServer(viewModel.server.name).text
+				}
 			}
+			.alert(item: $viewModel.errorMessage) { _ in
+				Alert(title: Text(viewModel.alertTitle),
+				      message: Text(viewModel.errorMessage?.message ?? L10n.unknownError),
+				      dismissButton: .cancel())
+			}
+			.navigationTitle(L10n.signIn)
 		}
-		.alert(item: $viewModel.errorMessage) { _ in
-			Alert(title: Text(viewModel.alertTitle),
-			      message: Text(viewModel.errorMessage?.message ?? L10n.unknownError),
-			      dismissButton: .cancel())
-		}
-		.navigationTitle(L10n.signIn)
 	}
 }

--- a/Swiftfin tvOS/Views/UserSignInView.swift
+++ b/Swiftfin tvOS/Views/UserSignInView.swift
@@ -22,8 +22,11 @@ struct UserSignInView: View {
 		ZStack {
 			ImageView(viewModel.getSplashscreenUrl())
 				.ignoresSafeArea()
-			Color.black.opacity(0.9)
+
+			Color.black
+				.opacity(0.9)
 				.ignoresSafeArea()
+
 			Form {
 				Section {
 					TextField(L10n.username, text: $username)


### PR DESCRIPTION
Add new Splashscreen from 10.8 as login background like for Android TV jellyfin/jellyfin-androidtv#1709 

I'm not quite sure about the contrast with the navigation header
![Simulator Screen Shot - Apple TV 4K (at 1080p) (2nd generation) - 2022-07-12 at 10 35 11](https://user-images.githubusercontent.com/16425113/178447761-f3cbdbbf-9edc-48f8-8a04-384d2a07ac9b.png)

