### PR TITLE
Fix series item clipping

### DIFF
--- a/Swiftfin tvOS/Views/ItemView/CompactItemView/SeriesItemView.swift
+++ b/Swiftfin tvOS/Views/ItemView/CompactItemView/SeriesItemView.swift
@@ -164,7 +164,7 @@ struct SeriesItemView: View {
                                 Spacer().frame(width: 45)
                             }
                         }.padding(EdgeInsets(top: -30, leading: -90, bottom: 0, trailing: -90))
-                            .frame(height: 360)
+                            .frame(height: 450)
                     }
 
                     if !viewModel.similarItems.isEmpty {
@@ -182,7 +182,7 @@ struct SeriesItemView: View {
                                 Spacer().frame(width: 45)
                             }
                         }.padding(EdgeInsets(top: -30, leading: -90, bottom: 0, trailing: -90))
-                            .frame(height: 360)
+                            .frame(height: 450)
                     }
                 }.padding(EdgeInsets(top: 90, leading: 90, bottom: 45, trailing: 90))
             }.focusScope(namespace)


### PR DESCRIPTION
Closes: #489 

Increases frame heights to allow for the scale effect.

**Note:** any less height than this and the shadow gets clipped resulting in a line artifact at the top edge of the horizontal scroll view.

| Before | After |
| --- | --- |
| ![clipped](https://user-images.githubusercontent.com/5327203/179736851-b893b0bc-b79f-4551-a021-abe26129641b.png) | ![clipped-fix](https://user-images.githubusercontent.com/5327203/179736898-42c9e172-a499-4c27-8d9d-fee97165fbb3.png) |

The same fix has been applied to 'More Like This' such that the design now looks like:
![Simulator Screen Shot - Apple TV 4K (at 1080p) (2nd generation) - 2022-07-19 at 21 14 41](https://user-images.githubusercontent.com/5327203/179737324-7daa1e61-cdcb-4865-8208-7eaa0d1441af.png)

