### PR TITLE
Fix long name on continue watching and chapters overlay shifting next item

### DIFF
--- a/Swiftfin/Views/ContinueWatchingView.swift
+++ b/Swiftfin/Views/ContinueWatchingView.swift
@@ -95,6 +95,7 @@ struct ContinueWatchingView: View {
                                         .lineLimit(1)
                                 }
                             }
+                            .frame(width: 320, alignment: .leading)
                         }
                     }
                     .contextMenu {

--- a/Swiftfin/Views/VideoPlayer/Overlays/VLCPlayerChapterOverlayView.swift
+++ b/Swiftfin/Views/VideoPlayer/Overlays/VLCPlayerChapterOverlayView.swift
@@ -67,6 +67,7 @@ struct VLCPlayerChapterOverlayView: View {
                                                 .font(.subheadline)
                                                 .fontWeight(.semibold)
                                                 .foregroundColor(.white)
+                                                .lineLimit(1)
 
                                             Text(viewModel.chapters[chapterIndex].timestampLabel)
                                                 .font(.subheadline)
@@ -78,6 +79,7 @@ struct VLCPlayerChapterOverlayView: View {
                                                     Color(UIColor.darkGray).opacity(0.2).cornerRadius(4)
                                                 }
                                         }
+                                        .frame(width: 150, alignment: .leading)
                                     }
                                     .id(viewModel.chapters[chapterIndex])
                                 }


### PR DESCRIPTION
Could only test the continue watching changes since the chapters view crashes the simulator for me

<details>
<summary> Before </summary>

![IMG_3336](https://user-images.githubusercontent.com/16425113/183099967-e5c37ce2-b15b-4493-bb4b-441708f7b2b4.PNG)
</details>


<details>
<summary>After</summary>

![Simulator Screen Shot - iPhone 13 - 2022-08-05 at 16 30 24](https://user-images.githubusercontent.com/16425113/183099821-e40de28c-f75a-4d35-a8d2-8c4428861931.png)
</details>
