### PR TITLE
Update JellyfinAPI

### DIFF
--- a/Shared/Coordinators/HomeCoordinator.swift
+++ b/Shared/Coordinators/HomeCoordinator.swift
@@ -7,7 +7,7 @@
 //
 
 import Foundation
-import JellyfinAPI
+import JellyfinAPILegacy
 import Stinsen
 import SwiftUI
 

--- a/Shared/Coordinators/ItemCoordinator.swift
+++ b/Shared/Coordinators/ItemCoordinator.swift
@@ -7,7 +7,7 @@
 //
 
 import Foundation
-import JellyfinAPI
+import JellyfinAPILegacy
 import Stinsen
 import SwiftUI
 

--- a/Shared/Coordinators/ItemOverviewCoordinator.swift
+++ b/Shared/Coordinators/ItemOverviewCoordinator.swift
@@ -6,7 +6,7 @@
 // Copyright (c) 2022 Jellyfin & Jellyfin Contributors
 //
 
-import JellyfinAPI
+import JellyfinAPILegacy
 import Stinsen
 import SwiftUI
 

--- a/Shared/Coordinators/LibraryCoordinator.swift
+++ b/Shared/Coordinators/LibraryCoordinator.swift
@@ -7,7 +7,7 @@
 //
 
 import Foundation
-import JellyfinAPI
+import JellyfinAPILegacy
 import Stinsen
 import SwiftUI
 

--- a/Shared/Coordinators/LiveTVChannelsCoordinator.swift
+++ b/Shared/Coordinators/LiveTVChannelsCoordinator.swift
@@ -7,7 +7,7 @@
 //
 
 import Foundation
-import JellyfinAPI
+import JellyfinAPILegacy
 import Stinsen
 import SwiftUI
 

--- a/Shared/Coordinators/LiveTVCoordinator.swift
+++ b/Shared/Coordinators/LiveTVCoordinator.swift
@@ -7,7 +7,7 @@
 //
 
 import Foundation
-import JellyfinAPI
+import JellyfinAPILegacy
 import Stinsen
 import SwiftUI
 

--- a/Shared/Coordinators/LiveTVProgramsCoordinator.swift
+++ b/Shared/Coordinators/LiveTVProgramsCoordinator.swift
@@ -7,7 +7,7 @@
 //
 
 import Foundation
-import JellyfinAPI
+import JellyfinAPILegacy
 import Stinsen
 import SwiftUI
 

--- a/Shared/Coordinators/MoviesLibrariesCoordinator.swift
+++ b/Shared/Coordinators/MoviesLibrariesCoordinator.swift
@@ -7,7 +7,7 @@
 //
 
 import Foundation
-import JellyfinAPI
+import JellyfinAPILegacy
 import Stinsen
 import SwiftUI
 

--- a/Shared/Coordinators/SearchCoordinator.swift
+++ b/Shared/Coordinators/SearchCoordinator.swift
@@ -7,7 +7,7 @@
 //
 
 import Foundation
-import JellyfinAPI
+import JellyfinAPILegacy
 import Stinsen
 import SwiftUI
 

--- a/Shared/Coordinators/TVLibrariesCoordinator.swift
+++ b/Shared/Coordinators/TVLibrariesCoordinator.swift
@@ -7,7 +7,7 @@
 //
 
 import Foundation
-import JellyfinAPI
+import JellyfinAPILegacy
 import Stinsen
 import SwiftUI
 

--- a/Shared/Coordinators/VideoPlayerCoordinator/iOSLiveTVVideoPlayerCoordinator.swift
+++ b/Shared/Coordinators/VideoPlayerCoordinator/iOSLiveTVVideoPlayerCoordinator.swift
@@ -8,7 +8,7 @@
 
 import Defaults
 import Foundation
-import JellyfinAPI
+import JellyfinAPILegacy
 import Stinsen
 import SwiftUI
 

--- a/Shared/Coordinators/VideoPlayerCoordinator/iOSVideoPlayerCoordinator.swift
+++ b/Shared/Coordinators/VideoPlayerCoordinator/iOSVideoPlayerCoordinator.swift
@@ -8,7 +8,7 @@
 
 import Defaults
 import Foundation
-import JellyfinAPI
+import JellyfinAPILegacy
 import Stinsen
 import SwiftUI
 

--- a/Shared/Coordinators/VideoPlayerCoordinator/tvOSLiveTVVideoPlayerCoordinator.swift
+++ b/Shared/Coordinators/VideoPlayerCoordinator/tvOSLiveTVVideoPlayerCoordinator.swift
@@ -8,7 +8,7 @@
 
 import Defaults
 import Foundation
-import JellyfinAPI
+import JellyfinAPILegacy
 import Stinsen
 import SwiftUI
 

--- a/Shared/Coordinators/VideoPlayerCoordinator/tvOSVideoPlayerCoordinator.swift
+++ b/Shared/Coordinators/VideoPlayerCoordinator/tvOSVideoPlayerCoordinator.swift
@@ -8,7 +8,7 @@
 
 import Defaults
 import Foundation
-import JellyfinAPI
+import JellyfinAPILegacy
 import Stinsen
 import SwiftUI
 

--- a/Shared/Errors/ErrorMessage.swift
+++ b/Shared/Errors/ErrorMessage.swift
@@ -7,7 +7,7 @@
 //
 
 import Foundation
-import JellyfinAPI
+import JellyfinAPILegacy
 
 struct ErrorMessage: Identifiable {
 

--- a/Shared/Errors/NetworkError.swift
+++ b/Shared/Errors/NetworkError.swift
@@ -7,7 +7,7 @@
 //
 
 import Foundation
-import JellyfinAPI
+import JellyfinAPILegacy
 
 enum NetworkError: Error {
 

--- a/Shared/Extensions/JellyfinAPIExtensions/BaseItemDto+Images.swift
+++ b/Shared/Extensions/JellyfinAPIExtensions/BaseItemDto+Images.swift
@@ -7,7 +7,7 @@
 //
 
 import Foundation
-import JellyfinAPI
+import JellyfinAPILegacy
 import UIKit
 
 extension BaseItemDto {

--- a/Shared/Extensions/JellyfinAPIExtensions/BaseItemDto+Poster.swift
+++ b/Shared/Extensions/JellyfinAPIExtensions/BaseItemDto+Poster.swift
@@ -8,7 +8,7 @@
 
 import Defaults
 import Foundation
-import JellyfinAPI
+import JellyfinAPILegacy
 import UIKit
 
 // MARK: PortraitPoster

--- a/Shared/Extensions/JellyfinAPIExtensions/BaseItemDto+VideoPlayerViewModel.swift
+++ b/Shared/Extensions/JellyfinAPIExtensions/BaseItemDto+VideoPlayerViewModel.swift
@@ -8,7 +8,7 @@
 
 import Combine
 import Defaults
-import JellyfinAPI
+import JellyfinAPILegacy
 import UIKit
 
 extension BaseItemDto {

--- a/Shared/Extensions/JellyfinAPIExtensions/BaseItemDtoExtensions.swift
+++ b/Shared/Extensions/JellyfinAPIExtensions/BaseItemDtoExtensions.swift
@@ -7,7 +7,7 @@
 //
 
 import Foundation
-import JellyfinAPI
+import JellyfinAPILegacy
 import UIKit
 
 extension BaseItemDto: Identifiable {}

--- a/Shared/Extensions/JellyfinAPIExtensions/BaseItemPerson+Poster.swift
+++ b/Shared/Extensions/JellyfinAPIExtensions/BaseItemPerson+Poster.swift
@@ -7,7 +7,7 @@
 //
 
 import Foundation
-import JellyfinAPI
+import JellyfinAPILegacy
 import UIKit
 
 // MARK: PortraitImageStackable

--- a/Shared/Extensions/JellyfinAPIExtensions/BaseItemPersonExtensions.swift
+++ b/Shared/Extensions/JellyfinAPIExtensions/BaseItemPersonExtensions.swift
@@ -7,7 +7,7 @@
 //
 
 import Foundation
-import JellyfinAPI
+import JellyfinAPILegacy
 import UIKit
 
 extension BaseItemPerson {

--- a/Shared/Extensions/JellyfinAPIExtensions/ChapterInfoExtensions.swift
+++ b/Shared/Extensions/JellyfinAPIExtensions/ChapterInfoExtensions.swift
@@ -7,7 +7,7 @@
 //
 
 import Foundation
-import JellyfinAPI
+import JellyfinAPILegacy
 
 extension ChapterInfo {
 

--- a/Shared/Extensions/JellyfinAPIExtensions/MediaStreamExtension.swift
+++ b/Shared/Extensions/JellyfinAPIExtensions/MediaStreamExtension.swift
@@ -7,7 +7,7 @@
 //
 
 import Foundation
-import JellyfinAPI
+import JellyfinAPILegacy
 
 extension MediaStream {
     func externalURL(base: String) -> URL? {

--- a/Shared/Extensions/JellyfinAPIExtensions/NameGUIDPairExtensions.swift
+++ b/Shared/Extensions/JellyfinAPIExtensions/NameGUIDPairExtensions.swift
@@ -7,7 +7,7 @@
 //
 
 import Foundation
-import JellyfinAPI
+import JellyfinAPILegacy
 
 extension NameGuidPair: PillStackable {
     var title: String {

--- a/Shared/Extensions/JellyfinAPIExtensions/RequestBuilderExtensions.swift
+++ b/Shared/Extensions/JellyfinAPIExtensions/RequestBuilderExtensions.swift
@@ -7,7 +7,7 @@
 //
 
 import Foundation
-import JellyfinAPI
+import JellyfinAPILegacy
 
 extension RequestBuilder where T == URL {
     var url: URL {

--- a/Shared/Extensions/JellyfinAPIExtensions/UserDtoExtensions.swift
+++ b/Shared/Extensions/JellyfinAPIExtensions/UserDtoExtensions.swift
@@ -7,7 +7,7 @@
 //
 
 import Foundation
-import JellyfinAPI
+import JellyfinAPILegacy
 import UIKit
 
 extension UserDto {

--- a/Shared/Objects/DeviceProfileBuilder.swift
+++ b/Shared/Objects/DeviceProfileBuilder.swift
@@ -9,7 +9,7 @@
 // lol can someone buy me a coffee this took forever :|
 
 import Foundation
-import JellyfinAPI
+import JellyfinAPILegacy
 
 enum CPUModel {
     case A4

--- a/Shared/Objects/Typings.swift
+++ b/Shared/Objects/Typings.swift
@@ -8,7 +8,7 @@
 
 import Combine
 import Foundation
-import JellyfinAPI
+import JellyfinAPILegacy
 
 struct LibraryFilters: Codable, Hashable {
     var filters: [ItemFilter] = []

--- a/Shared/Singleton/SessionManager.swift
+++ b/Shared/Singleton/SessionManager.swift
@@ -11,7 +11,7 @@ import CoreData
 import CoreStore
 import Defaults
 import Foundation
-import JellyfinAPI
+import JellyfinAPILegacy
 import UIKit
 
 typealias CurrentLogin = (server: SwiftfinStore.State.Server, user: SwiftfinStore.State.User)

--- a/Shared/Strings/Strings.swift
+++ b/Shared/Strings/Strings.swift
@@ -11,457 +11,457 @@ import Foundation
 // swiftlint:disable nesting type_body_length type_name vertical_whitespace_opening_braces
 internal enum L10n {
   /// About
-  internal static let about = L10n.tr("Localizable", "about", fallback: #"About"#)
+  internal static let about = L10n.tr("Localizable", "about", fallback: "About")
   /// Accessibility
-  internal static let accessibility = L10n.tr("Localizable", "accessibility", fallback: #"Accessibility"#)
+  internal static let accessibility = L10n.tr("Localizable", "accessibility", fallback: "Accessibility")
   /// Add URL
-  internal static let addURL = L10n.tr("Localizable", "addURL", fallback: #"Add URL"#)
+  internal static let addURL = L10n.tr("Localizable", "addURL", fallback: "Add URL")
   /// Airs %s
   internal static func airWithDate(_ p1: UnsafePointer<CChar>) -> String {
-    return L10n.tr("Localizable", "airWithDate", p1, fallback: #"Airs %s"#)
+    return L10n.tr("Localizable", "airWithDate", p1, fallback: "Airs %s")
   }
   /// All Genres
-  internal static let allGenres = L10n.tr("Localizable", "allGenres", fallback: #"All Genres"#)
+  internal static let allGenres = L10n.tr("Localizable", "allGenres", fallback: "All Genres")
   /// All Media
-  internal static let allMedia = L10n.tr("Localizable", "allMedia", fallback: #"All Media"#)
+  internal static let allMedia = L10n.tr("Localizable", "allMedia", fallback: "All Media")
   /// Appearance
-  internal static let appearance = L10n.tr("Localizable", "appearance", fallback: #"Appearance"#)
+  internal static let appearance = L10n.tr("Localizable", "appearance", fallback: "Appearance")
   /// Apply
-  internal static let apply = L10n.tr("Localizable", "apply", fallback: #"Apply"#)
+  internal static let apply = L10n.tr("Localizable", "apply", fallback: "Apply")
   /// Audio
-  internal static let audio = L10n.tr("Localizable", "audio", fallback: #"Audio"#)
+  internal static let audio = L10n.tr("Localizable", "audio", fallback: "Audio")
   /// Audio & Captions
-  internal static let audioAndCaptions = L10n.tr("Localizable", "audioAndCaptions", fallback: #"Audio & Captions"#)
+  internal static let audioAndCaptions = L10n.tr("Localizable", "audioAndCaptions", fallback: "Audio & Captions")
   /// Audio Track
-  internal static let audioTrack = L10n.tr("Localizable", "audioTrack", fallback: #"Audio Track"#)
+  internal static let audioTrack = L10n.tr("Localizable", "audioTrack", fallback: "Audio Track")
   /// Authorize
-  internal static let authorize = L10n.tr("Localizable", "authorize", fallback: #"Authorize"#)
+  internal static let authorize = L10n.tr("Localizable", "authorize", fallback: "Authorize")
   /// Auto Play
-  internal static let autoPlay = L10n.tr("Localizable", "autoPlay", fallback: #"Auto Play"#)
+  internal static let autoPlay = L10n.tr("Localizable", "autoPlay", fallback: "Auto Play")
   /// Back
-  internal static let back = L10n.tr("Localizable", "back", fallback: #"Back"#)
+  internal static let back = L10n.tr("Localizable", "back", fallback: "Back")
   /// Cancel
-  internal static let cancel = L10n.tr("Localizable", "cancel", fallback: #"Cancel"#)
+  internal static let cancel = L10n.tr("Localizable", "cancel", fallback: "Cancel")
   /// Cannot connect to host
-  internal static let cannotConnectToHost = L10n.tr("Localizable", "cannotConnectToHost", fallback: #"Cannot connect to host"#)
+  internal static let cannotConnectToHost = L10n.tr("Localizable", "cannotConnectToHost", fallback: "Cannot connect to host")
   /// CAST
-  internal static let cast = L10n.tr("Localizable", "cast", fallback: #"CAST"#)
+  internal static let cast = L10n.tr("Localizable", "cast", fallback: "CAST")
   /// Cast & Crew
-  internal static let castAndCrew = L10n.tr("Localizable", "castAndCrew", fallback: #"Cast & Crew"#)
+  internal static let castAndCrew = L10n.tr("Localizable", "castAndCrew", fallback: "Cast & Crew")
   /// Change Server
-  internal static let changeServer = L10n.tr("Localizable", "changeServer", fallback: #"Change Server"#)
+  internal static let changeServer = L10n.tr("Localizable", "changeServer", fallback: "Change Server")
   /// Channels
-  internal static let channels = L10n.tr("Localizable", "channels", fallback: #"Channels"#)
+  internal static let channels = L10n.tr("Localizable", "channels", fallback: "Channels")
   /// Chapters
-  internal static let chapters = L10n.tr("Localizable", "chapters", fallback: #"Chapters"#)
+  internal static let chapters = L10n.tr("Localizable", "chapters", fallback: "Chapters")
   /// Cinematic
-  internal static let cinematic = L10n.tr("Localizable", "cinematic", fallback: #"Cinematic"#)
+  internal static let cinematic = L10n.tr("Localizable", "cinematic", fallback: "Cinematic")
   /// Cinematic Views
-  internal static let cinematicViews = L10n.tr("Localizable", "cinematicViews", fallback: #"Cinematic Views"#)
+  internal static let cinematicViews = L10n.tr("Localizable", "cinematicViews", fallback: "Cinematic Views")
   /// Close
-  internal static let close = L10n.tr("Localizable", "close", fallback: #"Close"#)
+  internal static let close = L10n.tr("Localizable", "close", fallback: "Close")
   /// Closed Captions
-  internal static let closedCaptions = L10n.tr("Localizable", "closedCaptions", fallback: #"Closed Captions"#)
+  internal static let closedCaptions = L10n.tr("Localizable", "closedCaptions", fallback: "Closed Captions")
   /// Compact
-  internal static let compact = L10n.tr("Localizable", "compact", fallback: #"Compact"#)
+  internal static let compact = L10n.tr("Localizable", "compact", fallback: "Compact")
   /// Compact Logo
-  internal static let compactLogo = L10n.tr("Localizable", "compactLogo", fallback: #"Compact Logo"#)
+  internal static let compactLogo = L10n.tr("Localizable", "compactLogo", fallback: "Compact Logo")
   /// Compact Poster
-  internal static let compactPoster = L10n.tr("Localizable", "compactPoster", fallback: #"Compact Poster"#)
+  internal static let compactPoster = L10n.tr("Localizable", "compactPoster", fallback: "Compact Poster")
   /// Confirm Close
-  internal static let confirmClose = L10n.tr("Localizable", "confirmClose", fallback: #"Confirm Close"#)
+  internal static let confirmClose = L10n.tr("Localizable", "confirmClose", fallback: "Confirm Close")
   /// Connect
-  internal static let connect = L10n.tr("Localizable", "connect", fallback: #"Connect"#)
+  internal static let connect = L10n.tr("Localizable", "connect", fallback: "Connect")
   /// Connect Manually
-  internal static let connectManually = L10n.tr("Localizable", "connectManually", fallback: #"Connect Manually"#)
+  internal static let connectManually = L10n.tr("Localizable", "connectManually", fallback: "Connect Manually")
   /// Connect to Jellyfin
-  internal static let connectToJellyfin = L10n.tr("Localizable", "connectToJellyfin", fallback: #"Connect to Jellyfin"#)
+  internal static let connectToJellyfin = L10n.tr("Localizable", "connectToJellyfin", fallback: "Connect to Jellyfin")
   /// Connect to a Jellyfin server
-  internal static let connectToJellyfinServer = L10n.tr("Localizable", "connectToJellyfinServer", fallback: #"Connect to a Jellyfin server"#)
+  internal static let connectToJellyfinServer = L10n.tr("Localizable", "connectToJellyfinServer", fallback: "Connect to a Jellyfin server")
   /// Connect to a Jellyfin server to get started
-  internal static let connectToJellyfinServerStart = L10n.tr("Localizable", "connectToJellyfinServerStart", fallback: #"Connect to a Jellyfin server to get started"#)
+  internal static let connectToJellyfinServerStart = L10n.tr("Localizable", "connectToJellyfinServerStart", fallback: "Connect to a Jellyfin server to get started")
   /// Connect to Server
-  internal static let connectToServer = L10n.tr("Localizable", "connectToServer", fallback: #"Connect to Server"#)
+  internal static let connectToServer = L10n.tr("Localizable", "connectToServer", fallback: "Connect to Server")
   /// Containers
-  internal static let containers = L10n.tr("Localizable", "containers", fallback: #"Containers"#)
+  internal static let containers = L10n.tr("Localizable", "containers", fallback: "Containers")
   /// Continue
-  internal static let `continue` = L10n.tr("Localizable", "continue", fallback: #"Continue"#)
+  internal static let `continue` = L10n.tr("Localizable", "continue", fallback: "Continue")
   /// Continue Watching
-  internal static let continueWatching = L10n.tr("Localizable", "continueWatching", fallback: #"Continue Watching"#)
+  internal static let continueWatching = L10n.tr("Localizable", "continueWatching", fallback: "Continue Watching")
   /// Current Position
-  internal static let currentPosition = L10n.tr("Localizable", "currentPosition", fallback: #"Current Position"#)
+  internal static let currentPosition = L10n.tr("Localizable", "currentPosition", fallback: "Current Position")
   /// Customize
-  internal static let customize = L10n.tr("Localizable", "customize", fallback: #"Customize"#)
+  internal static let customize = L10n.tr("Localizable", "customize", fallback: "Customize")
   /// Dark
-  internal static let dark = L10n.tr("Localizable", "dark", fallback: #"Dark"#)
+  internal static let dark = L10n.tr("Localizable", "dark", fallback: "Dark")
   /// Default Scheme
-  internal static let defaultScheme = L10n.tr("Localizable", "defaultScheme", fallback: #"Default Scheme"#)
+  internal static let defaultScheme = L10n.tr("Localizable", "defaultScheme", fallback: "Default Scheme")
   /// DIRECTOR
-  internal static let director = L10n.tr("Localizable", "director", fallback: #"DIRECTOR"#)
+  internal static let director = L10n.tr("Localizable", "director", fallback: "DIRECTOR")
   /// Discovered Servers
-  internal static let discoveredServers = L10n.tr("Localizable", "discoveredServers", fallback: #"Discovered Servers"#)
+  internal static let discoveredServers = L10n.tr("Localizable", "discoveredServers", fallback: "Discovered Servers")
   /// Display order
-  internal static let displayOrder = L10n.tr("Localizable", "displayOrder", fallback: #"Display order"#)
+  internal static let displayOrder = L10n.tr("Localizable", "displayOrder", fallback: "Display order")
   /// Edit Jump Lengths
-  internal static let editJumpLengths = L10n.tr("Localizable", "editJumpLengths", fallback: #"Edit Jump Lengths"#)
+  internal static let editJumpLengths = L10n.tr("Localizable", "editJumpLengths", fallback: "Edit Jump Lengths")
   /// Empty Next Up
-  internal static let emptyNextUp = L10n.tr("Localizable", "emptyNextUp", fallback: #"Empty Next Up"#)
+  internal static let emptyNextUp = L10n.tr("Localizable", "emptyNextUp", fallback: "Empty Next Up")
   /// Episode %2$@
   internal static func episodeNumber(_ p1: Any) -> String {
-    return L10n.tr("Localizable", "episodeNumber", String(describing: p1), fallback: #"Episode %2$@"#)
+    return L10n.tr("Localizable", "episodeNumber", String(describing: p1), fallback: "Episode %2$@")
   }
   /// Episodes
-  internal static let episodes = L10n.tr("Localizable", "episodes", fallback: #"Episodes"#)
+  internal static let episodes = L10n.tr("Localizable", "episodes", fallback: "Episodes")
   /// Error
-  internal static let error = L10n.tr("Localizable", "error", fallback: #"Error"#)
+  internal static let error = L10n.tr("Localizable", "error", fallback: "Error")
   /// Existing Server
-  internal static let existingServer = L10n.tr("Localizable", "existingServer", fallback: #"Existing Server"#)
+  internal static let existingServer = L10n.tr("Localizable", "existingServer", fallback: "Existing Server")
   /// Existing User
-  internal static let existingUser = L10n.tr("Localizable", "existingUser", fallback: #"Existing User"#)
+  internal static let existingUser = L10n.tr("Localizable", "existingUser", fallback: "Existing User")
   /// Experimental
-  internal static let experimental = L10n.tr("Localizable", "experimental", fallback: #"Experimental"#)
+  internal static let experimental = L10n.tr("Localizable", "experimental", fallback: "Experimental")
   /// Favorites
-  internal static let favorites = L10n.tr("Localizable", "favorites", fallback: #"Favorites"#)
+  internal static let favorites = L10n.tr("Localizable", "favorites", fallback: "Favorites")
   /// File
-  internal static let file = L10n.tr("Localizable", "file", fallback: #"File"#)
+  internal static let file = L10n.tr("Localizable", "file", fallback: "File")
   /// Filter Results
-  internal static let filterResults = L10n.tr("Localizable", "filterResults", fallback: #"Filter Results"#)
+  internal static let filterResults = L10n.tr("Localizable", "filterResults", fallback: "Filter Results")
   /// Filters
-  internal static let filters = L10n.tr("Localizable", "filters", fallback: #"Filters"#)
+  internal static let filters = L10n.tr("Localizable", "filters", fallback: "Filters")
   /// Genres
-  internal static let genres = L10n.tr("Localizable", "genres", fallback: #"Genres"#)
+  internal static let genres = L10n.tr("Localizable", "genres", fallback: "Genres")
   /// Home
-  internal static let home = L10n.tr("Localizable", "home", fallback: #"Home"#)
+  internal static let home = L10n.tr("Localizable", "home", fallback: "Home")
   /// Information
-  internal static let information = L10n.tr("Localizable", "information", fallback: #"Information"#)
+  internal static let information = L10n.tr("Localizable", "information", fallback: "Information")
   /// Items
-  internal static let items = L10n.tr("Localizable", "items", fallback: #"Items"#)
+  internal static let items = L10n.tr("Localizable", "items", fallback: "Items")
   /// Jump Backward
-  internal static let jumpBackward = L10n.tr("Localizable", "jumpBackward", fallback: #"Jump Backward"#)
+  internal static let jumpBackward = L10n.tr("Localizable", "jumpBackward", fallback: "Jump Backward")
   /// Jump Backward Length
-  internal static let jumpBackwardLength = L10n.tr("Localizable", "jumpBackwardLength", fallback: #"Jump Backward Length"#)
+  internal static let jumpBackwardLength = L10n.tr("Localizable", "jumpBackwardLength", fallback: "Jump Backward Length")
   /// Jump Forward
-  internal static let jumpForward = L10n.tr("Localizable", "jumpForward", fallback: #"Jump Forward"#)
+  internal static let jumpForward = L10n.tr("Localizable", "jumpForward", fallback: "Jump Forward")
   /// Jump Forward Length
-  internal static let jumpForwardLength = L10n.tr("Localizable", "jumpForwardLength", fallback: #"Jump Forward Length"#)
+  internal static let jumpForwardLength = L10n.tr("Localizable", "jumpForwardLength", fallback: "Jump Forward Length")
   /// Jump Gestures Enabled
-  internal static let jumpGesturesEnabled = L10n.tr("Localizable", "jumpGesturesEnabled", fallback: #"Jump Gestures Enabled"#)
+  internal static let jumpGesturesEnabled = L10n.tr("Localizable", "jumpGesturesEnabled", fallback: "Jump Gestures Enabled")
   /// %s seconds
   internal static func jumpLengthSeconds(_ p1: UnsafePointer<CChar>) -> String {
-    return L10n.tr("Localizable", "jumpLengthSeconds", p1, fallback: #"%s seconds"#)
+    return L10n.tr("Localizable", "jumpLengthSeconds", p1, fallback: "%s seconds")
   }
   /// Larger
-  internal static let larger = L10n.tr("Localizable", "larger", fallback: #"Larger"#)
+  internal static let larger = L10n.tr("Localizable", "larger", fallback: "Larger")
   /// Largest
-  internal static let largest = L10n.tr("Localizable", "largest", fallback: #"Largest"#)
+  internal static let largest = L10n.tr("Localizable", "largest", fallback: "Largest")
   /// Latest %@
   internal static func latestWithString(_ p1: Any) -> String {
-    return L10n.tr("Localizable", "latestWithString", String(describing: p1), fallback: #"Latest %@"#)
+    return L10n.tr("Localizable", "latestWithString", String(describing: p1), fallback: "Latest %@")
   }
   /// Library
-  internal static let library = L10n.tr("Localizable", "library", fallback: #"Library"#)
+  internal static let library = L10n.tr("Localizable", "library", fallback: "Library")
   /// Light
-  internal static let light = L10n.tr("Localizable", "light", fallback: #"Light"#)
+  internal static let light = L10n.tr("Localizable", "light", fallback: "Light")
   /// Loading
-  internal static let loading = L10n.tr("Localizable", "loading", fallback: #"Loading"#)
+  internal static let loading = L10n.tr("Localizable", "loading", fallback: "Loading")
   /// Local Servers
-  internal static let localServers = L10n.tr("Localizable", "localServers", fallback: #"Local Servers"#)
+  internal static let localServers = L10n.tr("Localizable", "localServers", fallback: "Local Servers")
   /// Login
-  internal static let login = L10n.tr("Localizable", "login", fallback: #"Login"#)
+  internal static let login = L10n.tr("Localizable", "login", fallback: "Login")
   /// Login to %@
   internal static func loginToWithString(_ p1: Any) -> String {
-    return L10n.tr("Localizable", "loginToWithString", String(describing: p1), fallback: #"Login to %@"#)
+    return L10n.tr("Localizable", "loginToWithString", String(describing: p1), fallback: "Login to %@")
   }
   /// Media
-  internal static let media = L10n.tr("Localizable", "media", fallback: #"Media"#)
+  internal static let media = L10n.tr("Localizable", "media", fallback: "Media")
   /// Missing
-  internal static let missing = L10n.tr("Localizable", "missing", fallback: #"Missing"#)
+  internal static let missing = L10n.tr("Localizable", "missing", fallback: "Missing")
   /// Missing Items
-  internal static let missingItems = L10n.tr("Localizable", "missingItems", fallback: #"Missing Items"#)
+  internal static let missingItems = L10n.tr("Localizable", "missingItems", fallback: "Missing Items")
   /// More Like This
-  internal static let moreLikeThis = L10n.tr("Localizable", "moreLikeThis", fallback: #"More Like This"#)
+  internal static let moreLikeThis = L10n.tr("Localizable", "moreLikeThis", fallback: "More Like This")
   /// Movies
-  internal static let movies = L10n.tr("Localizable", "movies", fallback: #"Movies"#)
+  internal static let movies = L10n.tr("Localizable", "movies", fallback: "Movies")
   /// %d users
   internal static func multipleUsers(_ p1: Int) -> String {
-    return L10n.tr("Localizable", "multipleUsers", p1, fallback: #"%d users"#)
+    return L10n.tr("Localizable", "multipleUsers", p1, fallback: "%d users")
   }
   /// Name
-  internal static let name = L10n.tr("Localizable", "name", fallback: #"Name"#)
+  internal static let name = L10n.tr("Localizable", "name", fallback: "Name")
   /// Networking
-  internal static let networking = L10n.tr("Localizable", "networking", fallback: #"Networking"#)
+  internal static let networking = L10n.tr("Localizable", "networking", fallback: "Networking")
   /// Network timed out
-  internal static let networkTimedOut = L10n.tr("Localizable", "networkTimedOut", fallback: #"Network timed out"#)
+  internal static let networkTimedOut = L10n.tr("Localizable", "networkTimedOut", fallback: "Network timed out")
   /// Next
-  internal static let next = L10n.tr("Localizable", "next", fallback: #"Next"#)
+  internal static let next = L10n.tr("Localizable", "next", fallback: "Next")
   /// Next Item
-  internal static let nextItem = L10n.tr("Localizable", "nextItem", fallback: #"Next Item"#)
+  internal static let nextItem = L10n.tr("Localizable", "nextItem", fallback: "Next Item")
   /// Next Up
-  internal static let nextUp = L10n.tr("Localizable", "nextUp", fallback: #"Next Up"#)
+  internal static let nextUp = L10n.tr("Localizable", "nextUp", fallback: "Next Up")
   /// No Cast devices found..
-  internal static let noCastdevicesfound = L10n.tr("Localizable", "noCastdevicesfound", fallback: #"No Cast devices found.."#)
+  internal static let noCastdevicesfound = L10n.tr("Localizable", "noCastdevicesfound", fallback: "No Cast devices found..")
   /// No Codec
-  internal static let noCodec = L10n.tr("Localizable", "noCodec", fallback: #"No Codec"#)
+  internal static let noCodec = L10n.tr("Localizable", "noCodec", fallback: "No Codec")
   /// No episodes available
-  internal static let noEpisodesAvailable = L10n.tr("Localizable", "noEpisodesAvailable", fallback: #"No episodes available"#)
+  internal static let noEpisodesAvailable = L10n.tr("Localizable", "noEpisodesAvailable", fallback: "No episodes available")
   /// No local servers found
-  internal static let noLocalServersFound = L10n.tr("Localizable", "noLocalServersFound", fallback: #"No local servers found"#)
+  internal static let noLocalServersFound = L10n.tr("Localizable", "noLocalServersFound", fallback: "No local servers found")
   /// None
-  internal static let `none` = L10n.tr("Localizable", "none", fallback: #"None"#)
+  internal static let `none` = L10n.tr("Localizable", "none", fallback: "None")
   /// No overview available
-  internal static let noOverviewAvailable = L10n.tr("Localizable", "noOverviewAvailable", fallback: #"No overview available"#)
+  internal static let noOverviewAvailable = L10n.tr("Localizable", "noOverviewAvailable", fallback: "No overview available")
   /// No public Users
-  internal static let noPublicUsers = L10n.tr("Localizable", "noPublicUsers", fallback: #"No public Users"#)
+  internal static let noPublicUsers = L10n.tr("Localizable", "noPublicUsers", fallback: "No public Users")
   /// No results.
-  internal static let noResults = L10n.tr("Localizable", "noResults", fallback: #"No results."#)
+  internal static let noResults = L10n.tr("Localizable", "noResults", fallback: "No results.")
   /// Normal
-  internal static let normal = L10n.tr("Localizable", "normal", fallback: #"Normal"#)
+  internal static let normal = L10n.tr("Localizable", "normal", fallback: "Normal")
   /// N/A
-  internal static let notAvailableSlash = L10n.tr("Localizable", "notAvailableSlash", fallback: #"N/A"#)
+  internal static let notAvailableSlash = L10n.tr("Localizable", "notAvailableSlash", fallback: "N/A")
   /// Type: %@ not implemented yet :(
   internal static func notImplementedYetWithType(_ p1: Any) -> String {
-    return L10n.tr("Localizable", "notImplementedYetWithType", String(describing: p1), fallback: #"Type: %@ not implemented yet :("#)
+    return L10n.tr("Localizable", "notImplementedYetWithType", String(describing: p1), fallback: "Type: %@ not implemented yet :(")
   }
   /// No title
-  internal static let noTitle = L10n.tr("Localizable", "noTitle", fallback: #"No title"#)
+  internal static let noTitle = L10n.tr("Localizable", "noTitle", fallback: "No title")
   /// Ok
-  internal static let ok = L10n.tr("Localizable", "ok", fallback: #"Ok"#)
+  internal static let ok = L10n.tr("Localizable", "ok", fallback: "Ok")
   /// 1 user
-  internal static let oneUser = L10n.tr("Localizable", "oneUser", fallback: #"1 user"#)
+  internal static let oneUser = L10n.tr("Localizable", "oneUser", fallback: "1 user")
   /// Operating System
-  internal static let operatingSystem = L10n.tr("Localizable", "operatingSystem", fallback: #"Operating System"#)
+  internal static let operatingSystem = L10n.tr("Localizable", "operatingSystem", fallback: "Operating System")
   /// Other
-  internal static let other = L10n.tr("Localizable", "other", fallback: #"Other"#)
+  internal static let other = L10n.tr("Localizable", "other", fallback: "Other")
   /// Other User
-  internal static let otherUser = L10n.tr("Localizable", "otherUser", fallback: #"Other User"#)
+  internal static let otherUser = L10n.tr("Localizable", "otherUser", fallback: "Other User")
   /// Overlay
-  internal static let overlay = L10n.tr("Localizable", "overlay", fallback: #"Overlay"#)
+  internal static let overlay = L10n.tr("Localizable", "overlay", fallback: "Overlay")
   /// Overlay Type
-  internal static let overlayType = L10n.tr("Localizable", "overlayType", fallback: #"Overlay Type"#)
+  internal static let overlayType = L10n.tr("Localizable", "overlayType", fallback: "Overlay Type")
   /// Overview
-  internal static let overview = L10n.tr("Localizable", "overview", fallback: #"Overview"#)
+  internal static let overview = L10n.tr("Localizable", "overview", fallback: "Overview")
   /// Page %1$@ of %2$@
   internal static func pageOfWithNumbers(_ p1: Any, _ p2: Any) -> String {
-    return L10n.tr("Localizable", "pageOfWithNumbers", String(describing: p1), String(describing: p2), fallback: #"Page %1$@ of %2$@"#)
+    return L10n.tr("Localizable", "pageOfWithNumbers", String(describing: p1), String(describing: p2), fallback: "Page %1$@ of %2$@")
   }
   /// Password
-  internal static let password = L10n.tr("Localizable", "password", fallback: #"Password"#)
+  internal static let password = L10n.tr("Localizable", "password", fallback: "Password")
   /// Play
-  internal static let play = L10n.tr("Localizable", "play", fallback: #"Play"#)
+  internal static let play = L10n.tr("Localizable", "play", fallback: "Play")
   /// Play / Pause
-  internal static let playAndPause = L10n.tr("Localizable", "playAndPause", fallback: #"Play / Pause"#)
+  internal static let playAndPause = L10n.tr("Localizable", "playAndPause", fallback: "Play / Pause")
   /// Playback settings
-  internal static let playbackSettings = L10n.tr("Localizable", "playbackSettings", fallback: #"Playback settings"#)
+  internal static let playbackSettings = L10n.tr("Localizable", "playbackSettings", fallback: "Playback settings")
   /// Playback Speed
-  internal static let playbackSpeed = L10n.tr("Localizable", "playbackSpeed", fallback: #"Playback Speed"#)
+  internal static let playbackSpeed = L10n.tr("Localizable", "playbackSpeed", fallback: "Playback Speed")
   /// Player Gestures Lock Gesture Enabled
-  internal static let playerGesturesLockGestureEnabled = L10n.tr("Localizable", "playerGesturesLockGestureEnabled", fallback: #"Player Gestures Lock Gesture Enabled"#)
+  internal static let playerGesturesLockGestureEnabled = L10n.tr("Localizable", "playerGesturesLockGestureEnabled", fallback: "Player Gestures Lock Gesture Enabled")
   /// Play From Beginning
-  internal static let playFromBeginning = L10n.tr("Localizable", "playFromBeginning", fallback: #"Play From Beginning"#)
+  internal static let playFromBeginning = L10n.tr("Localizable", "playFromBeginning", fallback: "Play From Beginning")
   /// Play Next
-  internal static let playNext = L10n.tr("Localizable", "playNext", fallback: #"Play Next"#)
+  internal static let playNext = L10n.tr("Localizable", "playNext", fallback: "Play Next")
   /// Play Next Item
-  internal static let playNextItem = L10n.tr("Localizable", "playNextItem", fallback: #"Play Next Item"#)
+  internal static let playNextItem = L10n.tr("Localizable", "playNextItem", fallback: "Play Next Item")
   /// Play Previous Item
-  internal static let playPreviousItem = L10n.tr("Localizable", "playPreviousItem", fallback: #"Play Previous Item"#)
+  internal static let playPreviousItem = L10n.tr("Localizable", "playPreviousItem", fallback: "Play Previous Item")
   /// Present
-  internal static let present = L10n.tr("Localizable", "present", fallback: #"Present"#)
+  internal static let present = L10n.tr("Localizable", "present", fallback: "Present")
   /// Press Down for Menu
-  internal static let pressDownForMenu = L10n.tr("Localizable", "pressDownForMenu", fallback: #"Press Down for Menu"#)
+  internal static let pressDownForMenu = L10n.tr("Localizable", "pressDownForMenu", fallback: "Press Down for Menu")
   /// Previous Item
-  internal static let previousItem = L10n.tr("Localizable", "previousItem", fallback: #"Previous Item"#)
+  internal static let previousItem = L10n.tr("Localizable", "previousItem", fallback: "Previous Item")
   /// Programs
-  internal static let programs = L10n.tr("Localizable", "programs", fallback: #"Programs"#)
+  internal static let programs = L10n.tr("Localizable", "programs", fallback: "Programs")
   /// Public Users
-  internal static let publicUsers = L10n.tr("Localizable", "publicUsers", fallback: #"Public Users"#)
+  internal static let publicUsers = L10n.tr("Localizable", "publicUsers", fallback: "Public Users")
   /// Quick Connect
-  internal static let quickConnect = L10n.tr("Localizable", "quickConnect", fallback: #"Quick Connect"#)
+  internal static let quickConnect = L10n.tr("Localizable", "quickConnect", fallback: "Quick Connect")
   /// Quick Connect code
-  internal static let quickConnectCode = L10n.tr("Localizable", "quickConnectCode", fallback: #"Quick Connect code"#)
+  internal static let quickConnectCode = L10n.tr("Localizable", "quickConnectCode", fallback: "Quick Connect code")
   /// Invalid Quick Connect code
-  internal static let quickConnectInvalidError = L10n.tr("Localizable", "quickConnectInvalidError", fallback: #"Invalid Quick Connect code"#)
+  internal static let quickConnectInvalidError = L10n.tr("Localizable", "quickConnectInvalidError", fallback: "Invalid Quick Connect code")
   /// Note: Quick Connect not enabled
-  internal static let quickConnectNotEnabled = L10n.tr("Localizable", "quickConnectNotEnabled", fallback: #"Note: Quick Connect not enabled"#)
+  internal static let quickConnectNotEnabled = L10n.tr("Localizable", "quickConnectNotEnabled", fallback: "Note: Quick Connect not enabled")
   /// 1. Open the Jellyfin app on your phone or web browser and sign in with your account
-  internal static let quickConnectStep1 = L10n.tr("Localizable", "quickConnectStep1", fallback: #"1. Open the Jellyfin app on your phone or web browser and sign in with your account"#)
+  internal static let quickConnectStep1 = L10n.tr("Localizable", "quickConnectStep1", fallback: "1. Open the Jellyfin app on your phone or web browser and sign in with your account")
   /// 2. Open the user menu and go to the Quick Connect page
-  internal static let quickConnectStep2 = L10n.tr("Localizable", "quickConnectStep2", fallback: #"2. Open the user menu and go to the Quick Connect page"#)
+  internal static let quickConnectStep2 = L10n.tr("Localizable", "quickConnectStep2", fallback: "2. Open the user menu and go to the Quick Connect page")
   /// 3. Enter the following code:
-  internal static let quickConnectStep3 = L10n.tr("Localizable", "quickConnectStep3", fallback: #"3. Enter the following code:"#)
+  internal static let quickConnectStep3 = L10n.tr("Localizable", "quickConnectStep3", fallback: "3. Enter the following code:")
   /// Authorizing Quick Connect successful. Please continue on your other device.
-  internal static let quickConnectSuccessMessage = L10n.tr("Localizable", "quickConnectSuccessMessage", fallback: #"Authorizing Quick Connect successful. Please continue on your other device."#)
+  internal static let quickConnectSuccessMessage = L10n.tr("Localizable", "quickConnectSuccessMessage", fallback: "Authorizing Quick Connect successful. Please continue on your other device.")
   /// Rated
-  internal static let rated = L10n.tr("Localizable", "rated", fallback: #"Rated"#)
+  internal static let rated = L10n.tr("Localizable", "rated", fallback: "Rated")
   /// Recently Added
-  internal static let recentlyAdded = L10n.tr("Localizable", "recentlyAdded", fallback: #"Recently Added"#)
+  internal static let recentlyAdded = L10n.tr("Localizable", "recentlyAdded", fallback: "Recently Added")
   /// Recommended
-  internal static let recommended = L10n.tr("Localizable", "recommended", fallback: #"Recommended"#)
+  internal static let recommended = L10n.tr("Localizable", "recommended", fallback: "Recommended")
   /// Refresh
-  internal static let refresh = L10n.tr("Localizable", "refresh", fallback: #"Refresh"#)
+  internal static let refresh = L10n.tr("Localizable", "refresh", fallback: "Refresh")
   /// Regular
-  internal static let regular = L10n.tr("Localizable", "regular", fallback: #"Regular"#)
+  internal static let regular = L10n.tr("Localizable", "regular", fallback: "Regular")
   /// Released
-  internal static let released = L10n.tr("Localizable", "released", fallback: #"Released"#)
+  internal static let released = L10n.tr("Localizable", "released", fallback: "Released")
   /// Remaining Time
-  internal static let remainingTime = L10n.tr("Localizable", "remainingTime", fallback: #"Remaining Time"#)
+  internal static let remainingTime = L10n.tr("Localizable", "remainingTime", fallback: "Remaining Time")
   /// Remove
-  internal static let remove = L10n.tr("Localizable", "remove", fallback: #"Remove"#)
+  internal static let remove = L10n.tr("Localizable", "remove", fallback: "Remove")
   /// Remove All Users
-  internal static let removeAllUsers = L10n.tr("Localizable", "removeAllUsers", fallback: #"Remove All Users"#)
+  internal static let removeAllUsers = L10n.tr("Localizable", "removeAllUsers", fallback: "Remove All Users")
   /// Remove From Resume
-  internal static let removeFromResume = L10n.tr("Localizable", "removeFromResume", fallback: #"Remove From Resume"#)
+  internal static let removeFromResume = L10n.tr("Localizable", "removeFromResume", fallback: "Remove From Resume")
   /// Report an Issue
-  internal static let reportIssue = L10n.tr("Localizable", "reportIssue", fallback: #"Report an Issue"#)
+  internal static let reportIssue = L10n.tr("Localizable", "reportIssue", fallback: "Report an Issue")
   /// Request a Feature
-  internal static let requestFeature = L10n.tr("Localizable", "requestFeature", fallback: #"Request a Feature"#)
+  internal static let requestFeature = L10n.tr("Localizable", "requestFeature", fallback: "Request a Feature")
   /// Reset
-  internal static let reset = L10n.tr("Localizable", "reset", fallback: #"Reset"#)
+  internal static let reset = L10n.tr("Localizable", "reset", fallback: "Reset")
   /// Reset App Settings
-  internal static let resetAppSettings = L10n.tr("Localizable", "resetAppSettings", fallback: #"Reset App Settings"#)
+  internal static let resetAppSettings = L10n.tr("Localizable", "resetAppSettings", fallback: "Reset App Settings")
   /// Reset User Settings
-  internal static let resetUserSettings = L10n.tr("Localizable", "resetUserSettings", fallback: #"Reset User Settings"#)
+  internal static let resetUserSettings = L10n.tr("Localizable", "resetUserSettings", fallback: "Reset User Settings")
   /// Resume 5 Second Offset
-  internal static let resume5SecondOffset = L10n.tr("Localizable", "resume5SecondOffset", fallback: #"Resume 5 Second Offset"#)
+  internal static let resume5SecondOffset = L10n.tr("Localizable", "resume5SecondOffset", fallback: "Resume 5 Second Offset")
   /// Retry
-  internal static let retry = L10n.tr("Localizable", "retry", fallback: #"Retry"#)
+  internal static let retry = L10n.tr("Localizable", "retry", fallback: "Retry")
   /// Runtime
-  internal static let runtime = L10n.tr("Localizable", "runtime", fallback: #"Runtime"#)
+  internal static let runtime = L10n.tr("Localizable", "runtime", fallback: "Runtime")
   /// Search
-  internal static let search = L10n.tr("Localizable", "search", fallback: #"Search"#)
+  internal static let search = L10n.tr("Localizable", "search", fallback: "Search")
   /// Search…
-  internal static let searchDots = L10n.tr("Localizable", "searchDots", fallback: #"Search…"#)
+  internal static let searchDots = L10n.tr("Localizable", "searchDots", fallback: "Search…")
   /// Searching…
-  internal static let searchingDots = L10n.tr("Localizable", "searchingDots", fallback: #"Searching…"#)
+  internal static let searchingDots = L10n.tr("Localizable", "searchingDots", fallback: "Searching…")
   /// Season
-  internal static let season = L10n.tr("Localizable", "season", fallback: #"Season"#)
+  internal static let season = L10n.tr("Localizable", "season", fallback: "Season")
   /// S%1$@:E%2$@
   internal static func seasonAndEpisode(_ p1: Any, _ p2: Any) -> String {
-    return L10n.tr("Localizable", "seasonAndEpisode", String(describing: p1), String(describing: p2), fallback: #"S%1$@:E%2$@"#)
+    return L10n.tr("Localizable", "seasonAndEpisode", String(describing: p1), String(describing: p2), fallback: "S%1$@:E%2$@")
   }
   /// Seasons
-  internal static let seasons = L10n.tr("Localizable", "seasons", fallback: #"Seasons"#)
+  internal static let seasons = L10n.tr("Localizable", "seasons", fallback: "Seasons")
   /// See All
-  internal static let seeAll = L10n.tr("Localizable", "seeAll", fallback: #"See All"#)
+  internal static let seeAll = L10n.tr("Localizable", "seeAll", fallback: "See All")
   /// Seek Slide Gesture Enabled
-  internal static let seekSlideGestureEnabled = L10n.tr("Localizable", "seekSlideGestureEnabled", fallback: #"Seek Slide Gesture Enabled"#)
+  internal static let seekSlideGestureEnabled = L10n.tr("Localizable", "seekSlideGestureEnabled", fallback: "Seek Slide Gesture Enabled")
   /// See More
-  internal static let seeMore = L10n.tr("Localizable", "seeMore", fallback: #"See More"#)
+  internal static let seeMore = L10n.tr("Localizable", "seeMore", fallback: "See More")
   /// Select Cast Destination
-  internal static let selectCastDestination = L10n.tr("Localizable", "selectCastDestination", fallback: #"Select Cast Destination"#)
+  internal static let selectCastDestination = L10n.tr("Localizable", "selectCastDestination", fallback: "Select Cast Destination")
   /// Series
-  internal static let series = L10n.tr("Localizable", "series", fallback: #"Series"#)
+  internal static let series = L10n.tr("Localizable", "series", fallback: "Series")
   /// Server
-  internal static let server = L10n.tr("Localizable", "server", fallback: #"Server"#)
+  internal static let server = L10n.tr("Localizable", "server", fallback: "Server")
   /// Server %s is already connected
   internal static func serverAlreadyConnected(_ p1: UnsafePointer<CChar>) -> String {
-    return L10n.tr("Localizable", "serverAlreadyConnected", p1, fallback: #"Server %s is already connected"#)
+    return L10n.tr("Localizable", "serverAlreadyConnected", p1, fallback: "Server %s is already connected")
   }
   /// Server %s already exists. Add new URL?
   internal static func serverAlreadyExistsPrompt(_ p1: UnsafePointer<CChar>) -> String {
-    return L10n.tr("Localizable", "serverAlreadyExistsPrompt", p1, fallback: #"Server %s already exists. Add new URL?"#)
+    return L10n.tr("Localizable", "serverAlreadyExistsPrompt", p1, fallback: "Server %s already exists. Add new URL?")
   }
   /// Server Details
-  internal static let serverDetails = L10n.tr("Localizable", "serverDetails", fallback: #"Server Details"#)
+  internal static let serverDetails = L10n.tr("Localizable", "serverDetails", fallback: "Server Details")
   /// Server Information
-  internal static let serverInformation = L10n.tr("Localizable", "serverInformation", fallback: #"Server Information"#)
+  internal static let serverInformation = L10n.tr("Localizable", "serverInformation", fallback: "Server Information")
   /// Servers
-  internal static let servers = L10n.tr("Localizable", "servers", fallback: #"Servers"#)
+  internal static let servers = L10n.tr("Localizable", "servers", fallback: "Servers")
   /// Server URL
-  internal static let serverURL = L10n.tr("Localizable", "serverURL", fallback: #"Server URL"#)
+  internal static let serverURL = L10n.tr("Localizable", "serverURL", fallback: "Server URL")
   /// Settings
-  internal static let settings = L10n.tr("Localizable", "settings", fallback: #"Settings"#)
+  internal static let settings = L10n.tr("Localizable", "settings", fallback: "Settings")
   /// Show Cast & Crew
-  internal static let showCastAndCrew = L10n.tr("Localizable", "showCastAndCrew", fallback: #"Show Cast & Crew"#)
+  internal static let showCastAndCrew = L10n.tr("Localizable", "showCastAndCrew", fallback: "Show Cast & Crew")
   /// Show Chapters Info In Bottom Overlay
-  internal static let showChaptersInfoInBottomOverlay = L10n.tr("Localizable", "showChaptersInfoInBottomOverlay", fallback: #"Show Chapters Info In Bottom Overlay"#)
+  internal static let showChaptersInfoInBottomOverlay = L10n.tr("Localizable", "showChaptersInfoInBottomOverlay", fallback: "Show Chapters Info In Bottom Overlay")
   /// Flatten Library Items
-  internal static let showFlattenView = L10n.tr("Localizable", "showFlattenView", fallback: #"Flatten Library Items"#)
+  internal static let showFlattenView = L10n.tr("Localizable", "showFlattenView", fallback: "Flatten Library Items")
   /// Show Missing Episodes
-  internal static let showMissingEpisodes = L10n.tr("Localizable", "showMissingEpisodes", fallback: #"Show Missing Episodes"#)
+  internal static let showMissingEpisodes = L10n.tr("Localizable", "showMissingEpisodes", fallback: "Show Missing Episodes")
   /// Show Missing Seasons
-  internal static let showMissingSeasons = L10n.tr("Localizable", "showMissingSeasons", fallback: #"Show Missing Seasons"#)
+  internal static let showMissingSeasons = L10n.tr("Localizable", "showMissingSeasons", fallback: "Show Missing Seasons")
   /// Show Poster Labels
-  internal static let showPosterLabels = L10n.tr("Localizable", "showPosterLabels", fallback: #"Show Poster Labels"#)
+  internal static let showPosterLabels = L10n.tr("Localizable", "showPosterLabels", fallback: "Show Poster Labels")
   /// Signed in as %@
   internal static func signedInAsWithString(_ p1: Any) -> String {
-    return L10n.tr("Localizable", "signedInAsWithString", String(describing: p1), fallback: #"Signed in as %@"#)
+    return L10n.tr("Localizable", "signedInAsWithString", String(describing: p1), fallback: "Signed in as %@")
   }
   /// Sign In
-  internal static let signIn = L10n.tr("Localizable", "signIn", fallback: #"Sign In"#)
+  internal static let signIn = L10n.tr("Localizable", "signIn", fallback: "Sign In")
   /// Sign in to get started
-  internal static let signInGetStarted = L10n.tr("Localizable", "signInGetStarted", fallback: #"Sign in to get started"#)
+  internal static let signInGetStarted = L10n.tr("Localizable", "signInGetStarted", fallback: "Sign in to get started")
   /// Sign In to %s
   internal static func signInToServer(_ p1: UnsafePointer<CChar>) -> String {
-    return L10n.tr("Localizable", "signInToServer", p1, fallback: #"Sign In to %s"#)
+    return L10n.tr("Localizable", "signInToServer", p1, fallback: "Sign In to %s")
   }
   /// Smaller
-  internal static let smaller = L10n.tr("Localizable", "smaller", fallback: #"Smaller"#)
+  internal static let smaller = L10n.tr("Localizable", "smaller", fallback: "Smaller")
   /// Smallest
-  internal static let smallest = L10n.tr("Localizable", "smallest", fallback: #"Smallest"#)
+  internal static let smallest = L10n.tr("Localizable", "smallest", fallback: "Smallest")
   /// Sort by
-  internal static let sortBy = L10n.tr("Localizable", "sortBy", fallback: #"Sort by"#)
+  internal static let sortBy = L10n.tr("Localizable", "sortBy", fallback: "Sort by")
   /// Source Code
-  internal static let sourceCode = L10n.tr("Localizable", "sourceCode", fallback: #"Source Code"#)
+  internal static let sourceCode = L10n.tr("Localizable", "sourceCode", fallback: "Source Code")
   /// STUDIO
-  internal static let studio = L10n.tr("Localizable", "studio", fallback: #"STUDIO"#)
+  internal static let studio = L10n.tr("Localizable", "studio", fallback: "STUDIO")
   /// Studios
-  internal static let studios = L10n.tr("Localizable", "studios", fallback: #"Studios"#)
+  internal static let studios = L10n.tr("Localizable", "studios", fallback: "Studios")
   /// Subtitle Font
-  internal static let subtitleFont = L10n.tr("Localizable", "subtitleFont", fallback: #"Subtitle Font"#)
+  internal static let subtitleFont = L10n.tr("Localizable", "subtitleFont", fallback: "Subtitle Font")
   /// Subtitles
-  internal static let subtitles = L10n.tr("Localizable", "subtitles", fallback: #"Subtitles"#)
+  internal static let subtitles = L10n.tr("Localizable", "subtitles", fallback: "Subtitles")
   /// Subtitle Size
-  internal static let subtitleSize = L10n.tr("Localizable", "subtitleSize", fallback: #"Subtitle Size"#)
+  internal static let subtitleSize = L10n.tr("Localizable", "subtitleSize", fallback: "Subtitle Size")
   /// Suggestions
-  internal static let suggestions = L10n.tr("Localizable", "suggestions", fallback: #"Suggestions"#)
+  internal static let suggestions = L10n.tr("Localizable", "suggestions", fallback: "Suggestions")
   /// Switch User
-  internal static let switchUser = L10n.tr("Localizable", "switchUser", fallback: #"Switch User"#)
+  internal static let switchUser = L10n.tr("Localizable", "switchUser", fallback: "Switch User")
   /// System
-  internal static let system = L10n.tr("Localizable", "system", fallback: #"System"#)
+  internal static let system = L10n.tr("Localizable", "system", fallback: "System")
   /// System Control Gestures Enabled
-  internal static let systemControlGesturesEnabled = L10n.tr("Localizable", "systemControlGesturesEnabled", fallback: #"System Control Gestures Enabled"#)
+  internal static let systemControlGesturesEnabled = L10n.tr("Localizable", "systemControlGesturesEnabled", fallback: "System Control Gestures Enabled")
   /// Tags
-  internal static let tags = L10n.tr("Localizable", "tags", fallback: #"Tags"#)
+  internal static let tags = L10n.tr("Localizable", "tags", fallback: "Tags")
   /// Too Many Redirects
-  internal static let tooManyRedirects = L10n.tr("Localizable", "tooManyRedirects", fallback: #"Too Many Redirects"#)
+  internal static let tooManyRedirects = L10n.tr("Localizable", "tooManyRedirects", fallback: "Too Many Redirects")
   /// Try again
-  internal static let tryAgain = L10n.tr("Localizable", "tryAgain", fallback: #"Try again"#)
+  internal static let tryAgain = L10n.tr("Localizable", "tryAgain", fallback: "Try again")
   /// TV Shows
-  internal static let tvShows = L10n.tr("Localizable", "tvShows", fallback: #"TV Shows"#)
+  internal static let tvShows = L10n.tr("Localizable", "tvShows", fallback: "TV Shows")
   /// Unable to connect to server
-  internal static let unableToConnectServer = L10n.tr("Localizable", "unableToConnectServer", fallback: #"Unable to connect to server"#)
+  internal static let unableToConnectServer = L10n.tr("Localizable", "unableToConnectServer", fallback: "Unable to connect to server")
   /// Unable to find host
-  internal static let unableToFindHost = L10n.tr("Localizable", "unableToFindHost", fallback: #"Unable to find host"#)
+  internal static let unableToFindHost = L10n.tr("Localizable", "unableToFindHost", fallback: "Unable to find host")
   /// Unaired
-  internal static let unaired = L10n.tr("Localizable", "unaired", fallback: #"Unaired"#)
+  internal static let unaired = L10n.tr("Localizable", "unaired", fallback: "Unaired")
   /// Unauthorized
-  internal static let unauthorized = L10n.tr("Localizable", "unauthorized", fallback: #"Unauthorized"#)
+  internal static let unauthorized = L10n.tr("Localizable", "unauthorized", fallback: "Unauthorized")
   /// Unauthorized user
-  internal static let unauthorizedUser = L10n.tr("Localizable", "unauthorizedUser", fallback: #"Unauthorized user"#)
+  internal static let unauthorizedUser = L10n.tr("Localizable", "unauthorizedUser", fallback: "Unauthorized user")
   /// Unknown
-  internal static let unknown = L10n.tr("Localizable", "unknown", fallback: #"Unknown"#)
+  internal static let unknown = L10n.tr("Localizable", "unknown", fallback: "Unknown")
   /// Unknown Error
-  internal static let unknownError = L10n.tr("Localizable", "unknownError", fallback: #"Unknown Error"#)
+  internal static let unknownError = L10n.tr("Localizable", "unknownError", fallback: "Unknown Error")
   /// URL
-  internal static let url = L10n.tr("Localizable", "url", fallback: #"URL"#)
+  internal static let url = L10n.tr("Localizable", "url", fallback: "URL")
   /// User
-  internal static let user = L10n.tr("Localizable", "user", fallback: #"User"#)
+  internal static let user = L10n.tr("Localizable", "user", fallback: "User")
   /// User %s is already signed in
   internal static func userAlreadySignedIn(_ p1: UnsafePointer<CChar>) -> String {
-    return L10n.tr("Localizable", "userAlreadySignedIn", p1, fallback: #"User %s is already signed in"#)
+    return L10n.tr("Localizable", "userAlreadySignedIn", p1, fallback: "User %s is already signed in")
   }
   /// Username
-  internal static let username = L10n.tr("Localizable", "username", fallback: #"Username"#)
+  internal static let username = L10n.tr("Localizable", "username", fallback: "Username")
   /// Version
-  internal static let version = L10n.tr("Localizable", "version", fallback: #"Version"#)
+  internal static let version = L10n.tr("Localizable", "version", fallback: "Version")
   /// Video Player
-  internal static let videoPlayer = L10n.tr("Localizable", "videoPlayer", fallback: #"Video Player"#)
+  internal static let videoPlayer = L10n.tr("Localizable", "videoPlayer", fallback: "Video Player")
   /// Who's watching?
-  internal static let whosWatching = L10n.tr("Localizable", "WhosWatching", fallback: #"Who's watching?"#)
+  internal static let whosWatching = L10n.tr("Localizable", "WhosWatching", fallback: "Who's watching?")
   /// WIP
-  internal static let wip = L10n.tr("Localizable", "wip", fallback: #"WIP"#)
+  internal static let wip = L10n.tr("Localizable", "wip", fallback: "WIP")
   /// Your Favorites
-  internal static let yourFavorites = L10n.tr("Localizable", "yourFavorites", fallback: #"Your Favorites"#)
+  internal static let yourFavorites = L10n.tr("Localizable", "yourFavorites", fallback: "Your Favorites")
 }
 // swiftlint:enable explicit_type_interface function_parameter_count identifier_name line_length
 // swiftlint:enable nesting type_body_length type_name vertical_whitespace_opening_braces

--- a/Shared/ViewModels/ConnectToServerViewModel.swift
+++ b/Shared/ViewModels/ConnectToServerViewModel.swift
@@ -8,7 +8,7 @@
 
 import Combine
 import Foundation
-import JellyfinAPI
+import JellyfinAPILegacy
 import Stinsen
 
 struct AddServerURIPayload: Identifiable {

--- a/Shared/ViewModels/EpisodesRowManager.swift
+++ b/Shared/ViewModels/EpisodesRowManager.swift
@@ -7,7 +7,7 @@
 //
 
 import Defaults
-import JellyfinAPI
+import JellyfinAPILegacy
 import SwiftUI
 
 protocol EpisodesRowManager: ViewModel {

--- a/Shared/ViewModels/HomeViewModel.swift
+++ b/Shared/ViewModels/HomeViewModel.swift
@@ -9,7 +9,7 @@
 import ActivityIndicator
 import Combine
 import Foundation
-import JellyfinAPI
+import JellyfinAPILegacy
 
 final class HomeViewModel: ViewModel {
 

--- a/Shared/ViewModels/ItemViewModel/CollectionItemViewModel.swift
+++ b/Shared/ViewModels/ItemViewModel/CollectionItemViewModel.swift
@@ -8,7 +8,7 @@
 
 import Combine
 import Foundation
-import JellyfinAPI
+import JellyfinAPILegacy
 
 final class CollectionItemViewModel: ItemViewModel {
 

--- a/Shared/ViewModels/ItemViewModel/EpisodeItemViewModel.swift
+++ b/Shared/ViewModels/ItemViewModel/EpisodeItemViewModel.swift
@@ -8,7 +8,7 @@
 
 import Combine
 import Foundation
-import JellyfinAPI
+import JellyfinAPILegacy
 import Stinsen
 
 final class EpisodeItemViewModel: ItemViewModel {

--- a/Shared/ViewModels/ItemViewModel/ItemViewModel.swift
+++ b/Shared/ViewModels/ItemViewModel/ItemViewModel.swift
@@ -8,7 +8,7 @@
 
 import Combine
 import Foundation
-import JellyfinAPI
+import JellyfinAPILegacy
 import UIKit
 
 class ItemViewModel: ViewModel {

--- a/Shared/ViewModels/ItemViewModel/MovieItemViewModel.swift
+++ b/Shared/ViewModels/ItemViewModel/MovieItemViewModel.swift
@@ -8,7 +8,7 @@
 
 import Combine
 import Foundation
-import JellyfinAPI
+import JellyfinAPILegacy
 
 final class MovieItemViewModel: ItemViewModel {
 

--- a/Shared/ViewModels/ItemViewModel/SeasonItemViewModel.swift
+++ b/Shared/ViewModels/ItemViewModel/SeasonItemViewModel.swift
@@ -8,7 +8,7 @@
 
 import Combine
 import Foundation
-import JellyfinAPI
+import JellyfinAPILegacy
 import Stinsen
 
 final class SeasonItemViewModel: ItemViewModel, EpisodesRowManager {

--- a/Shared/ViewModels/ItemViewModel/SeriesItemViewModel.swift
+++ b/Shared/ViewModels/ItemViewModel/SeriesItemViewModel.swift
@@ -9,7 +9,7 @@
 import Combine
 import Defaults
 import Foundation
-import JellyfinAPI
+import JellyfinAPILegacy
 
 final class SeriesItemViewModel: ItemViewModel, EpisodesRowManager {
 

--- a/Shared/ViewModels/LatestMediaViewModel.swift
+++ b/Shared/ViewModels/LatestMediaViewModel.swift
@@ -8,7 +8,7 @@
 
 import Combine
 import Foundation
-import JellyfinAPI
+import JellyfinAPILegacy
 
 final class LatestMediaViewModel: ViewModel {
 

--- a/Shared/ViewModels/LibraryFilterViewModel.swift
+++ b/Shared/ViewModels/LibraryFilterViewModel.swift
@@ -8,7 +8,7 @@
 
 import Combine
 import Foundation
-import JellyfinAPI
+import JellyfinAPILegacy
 
 enum FilterType {
     case tag

--- a/Shared/ViewModels/LibraryListViewModel.swift
+++ b/Shared/ViewModels/LibraryListViewModel.swift
@@ -8,7 +8,7 @@
 
 import Defaults
 import Foundation
-import JellyfinAPI
+import JellyfinAPILegacy
 
 final class LibraryListViewModel: ViewModel {
 

--- a/Shared/ViewModels/LibrarySearchViewModel.swift
+++ b/Shared/ViewModels/LibrarySearchViewModel.swift
@@ -9,7 +9,7 @@
 import Combine
 import CombineExt
 import Foundation
-import JellyfinAPI
+import JellyfinAPILegacy
 import SwiftUI
 
 final class LibrarySearchViewModel: ViewModel {

--- a/Shared/ViewModels/LibraryViewModel.swift
+++ b/Shared/ViewModels/LibraryViewModel.swift
@@ -9,7 +9,7 @@
 import Combine
 import Defaults
 import Foundation
-import JellyfinAPI
+import JellyfinAPILegacy
 import SwiftUICollection
 import UIKit
 

--- a/Shared/ViewModels/LiveTVChannelsViewModel.swift
+++ b/Shared/ViewModels/LiveTVChannelsViewModel.swift
@@ -7,7 +7,7 @@
 //
 
 import Foundation
-import JellyfinAPI
+import JellyfinAPILegacy
 import SwiftUICollection
 
 typealias LiveTVChannelRow = CollectionRow<Int, LiveTVChannelRowCell>

--- a/Shared/ViewModels/LiveTVProgramsViewModel.swift
+++ b/Shared/ViewModels/LiveTVProgramsViewModel.swift
@@ -7,7 +7,7 @@
 //
 
 import Foundation
-import JellyfinAPI
+import JellyfinAPILegacy
 
 final class LiveTVProgramsViewModel: ViewModel {
 

--- a/Shared/ViewModels/MovieLibrariesViewModel.swift
+++ b/Shared/ViewModels/MovieLibrariesViewModel.swift
@@ -8,7 +8,7 @@
 
 import Combine
 import Foundation
-import JellyfinAPI
+import JellyfinAPILegacy
 import Stinsen
 import SwiftUICollection
 

--- a/Shared/ViewModels/QuickConnectSettingsViewModel.swift
+++ b/Shared/ViewModels/QuickConnectSettingsViewModel.swift
@@ -7,7 +7,7 @@
 //
 
 import Foundation
-import JellyfinAPI
+import JellyfinAPILegacy
 
 final class QuickConnectSettingsViewModel: ViewModel {
 

--- a/Shared/ViewModels/ServerDetailViewModel.swift
+++ b/Shared/ViewModels/ServerDetailViewModel.swift
@@ -7,7 +7,7 @@
 //
 
 import Foundation
-import JellyfinAPI
+import JellyfinAPILegacy
 
 class ServerDetailViewModel: ViewModel {
 

--- a/Shared/ViewModels/SettingsViewModel.swift
+++ b/Shared/ViewModels/SettingsViewModel.swift
@@ -8,7 +8,7 @@
 
 import Defaults
 import Foundation
-import JellyfinAPI
+import JellyfinAPILegacy
 import Stinsen
 import SwiftUI
 

--- a/Shared/ViewModels/TVLibrariesViewModel.swift
+++ b/Shared/ViewModels/TVLibrariesViewModel.swift
@@ -8,7 +8,7 @@
 
 import Combine
 import Foundation
-import JellyfinAPI
+import JellyfinAPILegacy
 import Stinsen
 import SwiftUICollection
 

--- a/Shared/ViewModels/UserSignInViewModel.swift
+++ b/Shared/ViewModels/UserSignInViewModel.swift
@@ -8,7 +8,7 @@
 
 import CoreStore
 import Foundation
-import JellyfinAPI
+import JellyfinAPILegacy
 import Stinsen
 
 final class UserSignInViewModel: ViewModel {

--- a/Shared/ViewModels/VideoPlayerModel.swift
+++ b/Shared/ViewModels/VideoPlayerModel.swift
@@ -6,7 +6,7 @@
 // Copyright (c) 2022 Jellyfin & Jellyfin Contributors
 //
 
-import JellyfinAPI
+import JellyfinAPILegacy
 import SwiftUI
 
 struct Subtitle {

--- a/Shared/ViewModels/VideoPlayerViewModel/VideoPlayerViewModel.swift
+++ b/Shared/ViewModels/VideoPlayerViewModel/VideoPlayerViewModel.swift
@@ -10,7 +10,7 @@ import Algorithms
 import Combine
 import Defaults
 import Foundation
-import JellyfinAPI
+import JellyfinAPILegacy
 import UIKit
 
 #if os(tvOS)

--- a/Shared/ViewModels/ViewModel.swift
+++ b/Shared/ViewModels/ViewModel.swift
@@ -9,7 +9,7 @@
 import ActivityIndicator
 import Combine
 import Foundation
-import JellyfinAPI
+import JellyfinAPILegacy
 
 class ViewModel: ObservableObject {
 

--- a/Swiftfin tvOS/Components/HomeCinematicView/CinematicBackgroundView.swift
+++ b/Swiftfin tvOS/Components/HomeCinematicView/CinematicBackgroundView.swift
@@ -6,7 +6,7 @@
 // Copyright (c) 2022 Jellyfin & Jellyfin Contributors
 //
 
-import JellyfinAPI
+import JellyfinAPILegacy
 import Nuke
 import NukeExtensions
 import SwiftUI

--- a/Swiftfin tvOS/Components/HomeCinematicView/CinematicNextUpCardView.swift
+++ b/Swiftfin tvOS/Components/HomeCinematicView/CinematicNextUpCardView.swift
@@ -6,7 +6,7 @@
 // Copyright (c) 2022 Jellyfin & Jellyfin Contributors
 //
 
-import JellyfinAPI
+import JellyfinAPILegacy
 import SwiftUI
 
 struct CinematicNextUpCardView: View {

--- a/Swiftfin tvOS/Components/HomeCinematicView/CinematicResumeCardView.swift
+++ b/Swiftfin tvOS/Components/HomeCinematicView/CinematicResumeCardView.swift
@@ -6,7 +6,7 @@
 // Copyright (c) 2022 Jellyfin & Jellyfin Contributors
 //
 
-import JellyfinAPI
+import JellyfinAPILegacy
 import SwiftUI
 
 struct CinematicResumeCardView: View {

--- a/Swiftfin tvOS/Components/HomeCinematicView/HomeCinematicView.swift
+++ b/Swiftfin tvOS/Components/HomeCinematicView/HomeCinematicView.swift
@@ -6,7 +6,7 @@
 // Copyright (c) 2022 Jellyfin & Jellyfin Contributors
 //
 
-import JellyfinAPI
+import JellyfinAPILegacy
 import SwiftUI
 import UIKit
 

--- a/Swiftfin tvOS/Components/LandscapeItemElement.swift
+++ b/Swiftfin tvOS/Components/LandscapeItemElement.swift
@@ -6,7 +6,7 @@
 // Copyright (c) 2022 Jellyfin & Jellyfin Contributors
 //
 
-import JellyfinAPI
+import JellyfinAPILegacy
 import SwiftUI
 
 struct CutOffShadow: Shape {

--- a/Swiftfin tvOS/Components/PortraitItemElement.swift
+++ b/Swiftfin tvOS/Components/PortraitItemElement.swift
@@ -6,7 +6,7 @@
 // Copyright (c) 2022 Jellyfin & Jellyfin Contributors
 //
 
-import JellyfinAPI
+import JellyfinAPILegacy
 import SwiftUI
 
 // TODO: Transition to `PortraitButton`

--- a/Swiftfin tvOS/Views/ContinueWatchingView/ContinueWatchingCard.swift
+++ b/Swiftfin tvOS/Views/ContinueWatchingView/ContinueWatchingCard.swift
@@ -6,7 +6,7 @@
 // Copyright (c) 2022 Jellyfin & Jellyfin Contributors
 //
 
-import JellyfinAPI
+import JellyfinAPILegacy
 import SwiftUI
 
 struct ContinueWatchingCard: View {

--- a/Swiftfin tvOS/Views/ContinueWatchingView/ContinueWatchingView.swift
+++ b/Swiftfin tvOS/Views/ContinueWatchingView/ContinueWatchingView.swift
@@ -7,7 +7,7 @@
 //
 
 import Combine
-import JellyfinAPI
+import JellyfinAPILegacy
 import Stinsen
 import SwiftUI
 

--- a/Swiftfin tvOS/Views/HomeView.swift
+++ b/Swiftfin tvOS/Views/HomeView.swift
@@ -9,7 +9,7 @@
 import Defaults
 import Foundation
 import Introspect
-import JellyfinAPI
+import JellyfinAPILegacy
 import SwiftUI
 
 struct HomeView: View {

--- a/Swiftfin tvOS/Views/ItemView/ItemView.swift
+++ b/Swiftfin tvOS/Views/ItemView/ItemView.swift
@@ -8,7 +8,7 @@
 
 import Defaults
 import Introspect
-import JellyfinAPI
+import JellyfinAPILegacy
 import SwiftUI
 
 struct ItemView: View {

--- a/Swiftfin tvOS/Views/ItemView/SeriesItemView/Components/EpisodeCard.swift
+++ b/Swiftfin tvOS/Views/ItemView/SeriesItemView/Components/EpisodeCard.swift
@@ -7,7 +7,7 @@
 //
 
 import Combine
-import JellyfinAPI
+import JellyfinAPILegacy
 import SwiftUI
 
 struct EpisodeCard: View {

--- a/Swiftfin tvOS/Views/ItemView/SeriesItemView/Components/SeriesEpisodesView.swift
+++ b/Swiftfin tvOS/Views/ItemView/SeriesItemView/Components/SeriesEpisodesView.swift
@@ -7,7 +7,7 @@
 //
 
 import Introspect
-import JellyfinAPI
+import JellyfinAPILegacy
 import SwiftUI
 
 struct SeriesEpisodesView: View {

--- a/Swiftfin tvOS/Views/LatestInLibraryView.swift
+++ b/Swiftfin tvOS/Views/LatestInLibraryView.swift
@@ -6,7 +6,7 @@
 // Copyright (c) 2022 Jellyfin & Jellyfin Contributors
 //
 
-import JellyfinAPI
+import JellyfinAPILegacy
 import SwiftUI
 
 struct LatestInLibraryView: View {

--- a/Swiftfin tvOS/Views/LibraryFilterView.swift
+++ b/Swiftfin tvOS/Views/LibraryFilterView.swift
@@ -6,7 +6,7 @@
 // Copyright (c) 2022 Jellyfin & Jellyfin Contributors
 //
 
-import JellyfinAPI
+import JellyfinAPILegacy
 import Stinsen
 import SwiftUI
 

--- a/Swiftfin tvOS/Views/LibraryListView.swift
+++ b/Swiftfin tvOS/Views/LibraryListView.swift
@@ -7,7 +7,7 @@
 //
 
 import Foundation
-import JellyfinAPI
+import JellyfinAPILegacy
 import Stinsen
 import SwiftUI
 

--- a/Swiftfin tvOS/Views/LibrarySearchView.swift
+++ b/Swiftfin tvOS/Views/LibrarySearchView.swift
@@ -7,7 +7,7 @@
 //
 
 import Combine
-import JellyfinAPI
+import JellyfinAPILegacy
 import SwiftUI
 
 struct LibrarySearchView: View {

--- a/Swiftfin tvOS/Views/LibraryView.swift
+++ b/Swiftfin tvOS/Views/LibraryView.swift
@@ -6,7 +6,7 @@
 // Copyright (c) 2022 Jellyfin & Jellyfin Contributors
 //
 
-import JellyfinAPI
+import JellyfinAPILegacy
 import SwiftUI
 import SwiftUICollection
 

--- a/Swiftfin tvOS/Views/LiveTVChannelItemElement.swift
+++ b/Swiftfin tvOS/Views/LiveTVChannelItemElement.swift
@@ -6,7 +6,7 @@
 // Copyright (c) 2022 Jellyfin & Jellyfin Contributors
 //
 
-import JellyfinAPI
+import JellyfinAPILegacy
 import SwiftUI
 
 struct LiveTVChannelItemElement: View {

--- a/Swiftfin tvOS/Views/LiveTVChannelsView.swift
+++ b/Swiftfin tvOS/Views/LiveTVChannelsView.swift
@@ -7,7 +7,7 @@
 //
 
 import Foundation
-import JellyfinAPI
+import JellyfinAPILegacy
 import SwiftUI
 import SwiftUICollection
 

--- a/Swiftfin tvOS/Views/MovieLibrariesView.swift
+++ b/Swiftfin tvOS/Views/MovieLibrariesView.swift
@@ -6,7 +6,7 @@
 // Copyright (c) 2022 Jellyfin & Jellyfin Contributors
 //
 
-import JellyfinAPI
+import JellyfinAPILegacy
 import SwiftUI
 import SwiftUICollection
 

--- a/Swiftfin tvOS/Views/SettingsView/SettingsView.swift
+++ b/Swiftfin tvOS/Views/SettingsView/SettingsView.swift
@@ -8,7 +8,7 @@
 
 import CoreData
 import Defaults
-import JellyfinAPI
+import JellyfinAPILegacy
 import SwiftUI
 
 struct SettingsView: View {

--- a/Swiftfin tvOS/Views/TVLibrariesView.swift
+++ b/Swiftfin tvOS/Views/TVLibrariesView.swift
@@ -6,7 +6,7 @@
 // Copyright (c) 2022 Jellyfin & Jellyfin Contributors
 //
 
-import JellyfinAPI
+import JellyfinAPILegacy
 import SwiftUI
 import SwiftUICollection
 

--- a/Swiftfin tvOS/Views/UserSignInView.swift
+++ b/Swiftfin tvOS/Views/UserSignInView.swift
@@ -6,7 +6,7 @@
 // Copyright (c) 2022 Jellyfin & Jellyfin Contributors
 //
 
-import JellyfinAPI
+import JellyfinAPILegacy
 import Stinsen
 import SwiftUI
 

--- a/Swiftfin tvOS/Views/VideoPlayer/LiveTVPlayerViewController.swift
+++ b/Swiftfin tvOS/Views/VideoPlayer/LiveTVPlayerViewController.swift
@@ -10,7 +10,7 @@ import AVFoundation
 import AVKit
 import Combine
 import Defaults
-import JellyfinAPI
+import JellyfinAPILegacy
 import MediaPlayer
 import SwiftUI
 import TVVLCKit

--- a/Swiftfin tvOS/Views/VideoPlayer/NativePlayerViewController.swift
+++ b/Swiftfin tvOS/Views/VideoPlayer/NativePlayerViewController.swift
@@ -8,7 +8,7 @@
 
 import AVKit
 import Combine
-import JellyfinAPI
+import JellyfinAPILegacy
 import UIKit
 
 class NativePlayerViewController: AVPlayerViewController {

--- a/Swiftfin tvOS/Views/VideoPlayer/Overlays/SmallMenuOverlay.swift
+++ b/Swiftfin tvOS/Views/VideoPlayer/Overlays/SmallMenuOverlay.swift
@@ -6,7 +6,7 @@
 // Copyright (c) 2022 Jellyfin & Jellyfin Contributors
 //
 
-import JellyfinAPI
+import JellyfinAPILegacy
 import SwiftUI
 
 // TODO: Needs replacement/reworking

--- a/Swiftfin tvOS/Views/VideoPlayer/Overlays/tvOSLiveTVOverlay.swift
+++ b/Swiftfin tvOS/Views/VideoPlayer/Overlays/tvOSLiveTVOverlay.swift
@@ -7,7 +7,7 @@
 //
 
 import Defaults
-import JellyfinAPI
+import JellyfinAPILegacy
 import SwiftUI
 
 struct tvOSLiveTVOverlay: View {

--- a/Swiftfin tvOS/Views/VideoPlayer/Overlays/tvOSVLCOverlay.swift
+++ b/Swiftfin tvOS/Views/VideoPlayer/Overlays/tvOSVLCOverlay.swift
@@ -7,7 +7,7 @@
 //
 
 import Defaults
-import JellyfinAPI
+import JellyfinAPILegacy
 import SwiftUI
 
 struct tvOSVLCOverlay: View {

--- a/Swiftfin tvOS/Views/VideoPlayer/PlayerOverlayDelegate.swift
+++ b/Swiftfin tvOS/Views/VideoPlayer/PlayerOverlayDelegate.swift
@@ -7,7 +7,7 @@
 //
 
 import Foundation
-import JellyfinAPI
+import JellyfinAPILegacy
 
 protocol PlayerOverlayDelegate {
 

--- a/Swiftfin tvOS/Views/VideoPlayer/VLCPlayerViewController.swift
+++ b/Swiftfin tvOS/Views/VideoPlayer/VLCPlayerViewController.swift
@@ -10,7 +10,7 @@ import AVFoundation
 import AVKit
 import Combine
 import Defaults
-import JellyfinAPI
+import JellyfinAPILegacy
 import MediaPlayer
 import SwiftUI
 import TVVLCKit

--- a/Swiftfin.xcodeproj/project.pbxproj
+++ b/Swiftfin.xcodeproj/project.pbxproj
@@ -3245,8 +3245,8 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/jellyfin/jellyfin-sdk-swift";
 			requirement = {
-				branch = main;
-				kind = branch;
+				kind = upToNextMajorVersion;
+				minimumVersion = 0.2.0;
 			};
 		};
 		E10EAA4B277BB716000269ED /* XCRemoteSwiftPackageReference "swiftui-sliders" */ = {

--- a/Swiftfin.xcodeproj/project.pbxproj
+++ b/Swiftfin.xcodeproj/project.pbxproj
@@ -243,7 +243,6 @@
 		E10D87DC2784EC5200BD264C /* SeriesEpisodesView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E10D87DB2784EC5200BD264C /* SeriesEpisodesView.swift */; };
 		E10D87E227852FD000BD264C /* EpisodesRowManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = E10D87E127852FD000BD264C /* EpisodesRowManager.swift */; };
 		E10D87E327852FD000BD264C /* EpisodesRowManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = E10D87E127852FD000BD264C /* EpisodesRowManager.swift */; };
-		E10EAA45277BB646000269ED /* JellyfinAPI in Frameworks */ = {isa = PBXBuildFile; productRef = E10EAA44277BB646000269ED /* JellyfinAPI */; };
 		E10EAA4D277BB716000269ED /* Sliders in Frameworks */ = {isa = PBXBuildFile; productRef = E10EAA4C277BB716000269ED /* Sliders */; };
 		E10EAA4F277BBCC4000269ED /* CGSizeExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = E10EAA4E277BBCC4000269ED /* CGSizeExtensions.swift */; };
 		E10EAA50277BBCC4000269ED /* CGSizeExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = E10EAA4E277BBCC4000269ED /* CGSizeExtensions.swift */; };
@@ -251,6 +250,7 @@
 		E10EAA54277BBD17000269ED /* BaseItemDto+VideoPlayerViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = E10EAA52277BBD17000269ED /* BaseItemDto+VideoPlayerViewModel.swift */; };
 		E1101177281B1E8A006A3584 /* Puppy in Frameworks */ = {isa = PBXBuildFile; productRef = E1101176281B1E8A006A3584 /* Puppy */; };
 		E111DE222790BB46008118A3 /* DetectBottomScrollView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E111DE212790BB46008118A3 /* DetectBottomScrollView.swift */; };
+		E113F92028AEAF54006326C0 /* JellyfinAPILegacy in Frameworks */ = {isa = PBXBuildFile; productRef = E113F91F28AEAF54006326C0 /* JellyfinAPILegacy */; };
 		E1171A1928A2212600FA1AF5 /* QuickConnectView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1171A1828A2212600FA1AF5 /* QuickConnectView.swift */; };
 		E118959D289312020042947B /* BaseItemPerson+Poster.swift in Sources */ = {isa = PBXBuildFile; fileRef = E118959C289312020042947B /* BaseItemPerson+Poster.swift */; };
 		E118959E289312020042947B /* BaseItemPerson+Poster.swift in Sources */ = {isa = PBXBuildFile; fileRef = E118959C289312020042947B /* BaseItemPerson+Poster.swift */; };
@@ -325,7 +325,6 @@
 		E173DA5226D04AAF00CC4EB7 /* ColorExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = E173DA5126D04AAF00CC4EB7 /* ColorExtension.swift */; };
 		E173DA5426D050F500CC4EB7 /* ServerDetailViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = E173DA5326D050F500CC4EB7 /* ServerDetailViewModel.swift */; };
 		E176DE6D278E30D2001EFD8D /* EpisodeCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = E176DE6C278E30D2001EFD8D /* EpisodeCard.swift */; };
-		E178857D278037FD0094FBCF /* JellyfinAPI in Frameworks */ = {isa = PBXBuildFile; productRef = E178857C278037FD0094FBCF /* JellyfinAPI */; };
 		E178859B2780F1F40094FBCF /* tvOSSlider.swift in Sources */ = {isa = PBXBuildFile; fileRef = E178859A2780F1F40094FBCF /* tvOSSlider.swift */; };
 		E178859E2780F53B0094FBCF /* SliderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E178859D2780F53B0094FBCF /* SliderView.swift */; };
 		E17885A02780F55C0094FBCF /* tvOSVLCOverlay.swift in Sources */ = {isa = PBXBuildFile; fileRef = E178859F2780F55C0094FBCF /* tvOSVLCOverlay.swift */; };
@@ -742,6 +741,7 @@
 		E10EAA4E277BBCC4000269ED /* CGSizeExtensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CGSizeExtensions.swift; sourceTree = "<group>"; };
 		E10EAA52277BBD17000269ED /* BaseItemDto+VideoPlayerViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "BaseItemDto+VideoPlayerViewModel.swift"; sourceTree = "<group>"; };
 		E111DE212790BB46008118A3 /* DetectBottomScrollView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DetectBottomScrollView.swift; sourceTree = "<group>"; };
+		E113F91E28AEAF19006326C0 /* jellyfin-sdk-swift */ = {isa = PBXFileReference; lastKnownFileType = wrapper; name = "jellyfin-sdk-swift"; path = "../jellyfin-sdk-swift"; sourceTree = "<group>"; };
 		E1171A1828A2212600FA1AF5 /* QuickConnectView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QuickConnectView.swift; sourceTree = "<group>"; };
 		E118959C289312020042947B /* BaseItemPerson+Poster.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "BaseItemPerson+Poster.swift"; sourceTree = "<group>"; };
 		E11895A8289383BC0042947B /* ScrollViewOffsetModifier.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScrollViewOffsetModifier.swift; sourceTree = "<group>"; };
@@ -950,7 +950,6 @@
 				E13AF3BC28A0C59E009093AB /* BlurHashKit in Frameworks */,
 				62666E1327E501C300EC0ECD /* AudioToolbox.framework in Frameworks */,
 				E13AF3B628A0C598009093AB /* Nuke in Frameworks */,
-				E178857D278037FD0094FBCF /* JellyfinAPI in Frameworks */,
 				E12186DE2718F1C50010884C /* Defaults in Frameworks */,
 				E1347DB6279E3CA500BC6161 /* Puppy in Frameworks */,
 				53ABFDED26799D7700886593 /* ActivityIndicator in Frameworks */,
@@ -967,6 +966,7 @@
 				E13DD3D327168E65009D4DAF /* Defaults in Frameworks */,
 				E1101177281B1E8A006A3584 /* Puppy in Frameworks */,
 				E1002B682793CFBA00E47059 /* Algorithms in Frameworks */,
+				E113F92028AEAF54006326C0 /* JellyfinAPILegacy in Frameworks */,
 				62666E1127E501B900EC0ECD /* UIKit.framework in Frameworks */,
 				62666DF727E5012C00EC0ECD /* MobileVLCKit.xcframework in Frameworks */,
 				62666E0327E5017100EC0ECD /* CoreMedia.framework in Frameworks */,
@@ -997,7 +997,6 @@
 				62666E3927E502CE00EC0ECD /* SwizzleSwift in Frameworks */,
 				E1B6DCE8271A23780015B715 /* CombineExt in Frameworks */,
 				E1347DB2279E3C6200BC6161 /* Puppy in Frameworks */,
-				E10EAA45277BB646000269ED /* JellyfinAPI in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1187,6 +1186,7 @@
 		5377CBE8263B596A003A4E83 = {
 			isa = PBXGroup;
 			children = (
+				E113F91D28AEAF19006326C0 /* Packages */,
 				534D4FE126A7D7CC000A7A48 /* Translations */,
 				53D5E3DB264B47EE00BADDC8 /* Frameworks */,
 				5377CBF3263B596A003A4E83 /* Swiftfin */,
@@ -1550,6 +1550,14 @@
 				62E632EB267D410B0063E547 /* SeriesItemViewModel.swift */,
 			);
 			path = ItemViewModel;
+			sourceTree = "<group>";
+		};
+		E113F91D28AEAF19006326C0 /* Packages */ = {
+			isa = PBXGroup;
+			children = (
+				E113F91E28AEAF19006326C0 /* jellyfin-sdk-swift */,
+			);
+			name = Packages;
 			sourceTree = "<group>";
 		};
 		E1171A1A28A2215800FA1AF5 /* UserSignInView */ = {
@@ -2147,7 +2155,6 @@
 				E13DD3CC27164CA7009D4DAF /* CoreStore */,
 				E12186DD2718F1C50010884C /* Defaults */,
 				E1218C9D271A2CD600EA0737 /* CombineExt */,
-				E178857C278037FD0094FBCF /* JellyfinAPI */,
 				E1002B6A2793E36600E47059 /* Algorithms */,
 				E1347DB5279E3CA500BC6161 /* Puppy */,
 				C409CE9B284EA6EA00CABC12 /* SwiftUICollection */,
@@ -2185,7 +2192,6 @@
 				E13DD3D227168E65009D4DAF /* Defaults */,
 				E1B6DCE7271A23780015B715 /* CombineExt */,
 				E1B6DCE9271A23880015B715 /* SwiftyJSON */,
-				E10EAA44277BB646000269ED /* JellyfinAPI */,
 				E10EAA4C277BB716000269ED /* Sliders */,
 				E1002B672793CFBA00E47059 /* Algorithms */,
 				62666E3827E502CE00EC0ECD /* SwizzleSwift */,
@@ -2195,6 +2201,7 @@
 				E19E6E0428A0B958005C10C8 /* Nuke */,
 				E19E6E0628A0B958005C10C8 /* NukeUI */,
 				E19E6E0928A0BEFF005C10C8 /* BlurHashKit */,
+				E113F91F28AEAF54006326C0 /* JellyfinAPILegacy */,
 			);
 			productName = JellyfinPlayer;
 			productReference = 5377CBF1263B596A003A4E83 /* Swiftfin iOS.app */;
@@ -2252,7 +2259,6 @@
 				E13DD3D127168E65009D4DAF /* XCRemoteSwiftPackageReference "Defaults" */,
 				E1267D42271A212C003C492E /* XCRemoteSwiftPackageReference "CombineExt" */,
 				E1C16B89271A2180009A5D25 /* XCRemoteSwiftPackageReference "SwiftyJSON" */,
-				E10EAA43277BB646000269ED /* XCRemoteSwiftPackageReference "jellyfin-sdk-swift" */,
 				E10EAA4B277BB716000269ED /* XCRemoteSwiftPackageReference "swiftui-sliders" */,
 				E1002B662793CFBA00E47059 /* XCRemoteSwiftPackageReference "swift-algorithms" */,
 				62666E3727E502CE00EC0ECD /* XCRemoteSwiftPackageReference "SwizzleSwift" */,
@@ -3241,14 +3247,6 @@
 				minimumVersion = 1.0.0;
 			};
 		};
-		E10EAA43277BB646000269ED /* XCRemoteSwiftPackageReference "jellyfin-sdk-swift" */ = {
-			isa = XCRemoteSwiftPackageReference;
-			repositoryURL = "https://github.com/jellyfin/jellyfin-sdk-swift";
-			requirement = {
-				kind = upToNextMajorVersion;
-				minimumVersion = 0.2.0;
-			};
-		};
 		E10EAA4B277BB716000269ED /* XCRemoteSwiftPackageReference "swiftui-sliders" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/spacenation/swiftui-sliders";
@@ -3384,11 +3382,6 @@
 			package = E1002B662793CFBA00E47059 /* XCRemoteSwiftPackageReference "swift-algorithms" */;
 			productName = Algorithms;
 		};
-		E10EAA44277BB646000269ED /* JellyfinAPI */ = {
-			isa = XCSwiftPackageProductDependency;
-			package = E10EAA43277BB646000269ED /* XCRemoteSwiftPackageReference "jellyfin-sdk-swift" */;
-			productName = JellyfinAPI;
-		};
 		E10EAA4C277BB716000269ED /* Sliders */ = {
 			isa = XCSwiftPackageProductDependency;
 			package = E10EAA4B277BB716000269ED /* XCRemoteSwiftPackageReference "swiftui-sliders" */;
@@ -3398,6 +3391,10 @@
 			isa = XCSwiftPackageProductDependency;
 			package = E1101175281B1E8A006A3584 /* XCRemoteSwiftPackageReference "Puppy" */;
 			productName = Puppy;
+		};
+		E113F91F28AEAF54006326C0 /* JellyfinAPILegacy */ = {
+			isa = XCSwiftPackageProductDependency;
+			productName = JellyfinAPILegacy;
 		};
 		E12186DD2718F1C50010884C /* Defaults */ = {
 			isa = XCSwiftPackageProductDependency;
@@ -3453,11 +3450,6 @@
 			isa = XCSwiftPackageProductDependency;
 			package = E13DD3D127168E65009D4DAF /* XCRemoteSwiftPackageReference "Defaults" */;
 			productName = Defaults;
-		};
-		E178857C278037FD0094FBCF /* JellyfinAPI */ = {
-			isa = XCSwiftPackageProductDependency;
-			package = E10EAA43277BB646000269ED /* XCRemoteSwiftPackageReference "jellyfin-sdk-swift" */;
-			productName = JellyfinAPI;
 		};
 		E19E6E0428A0B958005C10C8 /* Nuke */ = {
 			isa = XCSwiftPackageProductDependency;

--- a/Swiftfin.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Swiftfin.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -10,15 +10,6 @@
       }
     },
     {
-      "identity" : "anycodable",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/Flight-School/AnyCodable",
-      "state" : {
-        "revision" : "f9fda69a7b704d46fb5123005f2f7e43dbb8a0fa",
-        "version" : "0.6.5"
-      }
-    },
-    {
       "identity" : "ascollectionview",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apptekstudios/ASCollectionView",
@@ -73,12 +64,21 @@
       }
     },
     {
+      "identity" : "get",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/kean/Get",
+      "state" : {
+        "revision" : "db5248ce985c703c5ea0030b7c4d3f908db304c9",
+        "version" : "1.0.2"
+      }
+    },
+    {
       "identity" : "jellyfin-sdk-swift",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/jellyfin/jellyfin-sdk-swift",
       "state" : {
-        "branch" : "main",
-        "revision" : "9d6e46b94d2178116ee3546b03dfb67e19e3a93a"
+        "revision" : "848cd01551880a7772367559e1212a8cf330a43d",
+        "version" : "0.2.0"
       }
     },
     {
@@ -178,6 +178,15 @@
       "state" : {
         "revision" : "337dd5f158182620b2bb53c6847f8874a0117b2f",
         "version" : "1.0.0"
+      }
+    },
+    {
+      "identity" : "urlqueryencoder",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/CreateAPI/URLQueryEncoder",
+      "state" : {
+        "revision" : "4cc975d4d075d0e62699a796a08284e217d4ee93",
+        "version" : "0.2.0"
       }
     }
   ],

--- a/Swiftfin.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Swiftfin.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,194 +1,178 @@
 {
-  "pins" : [
-    {
-      "identity" : "activityindicator",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/duyquang91/ActivityIndicator",
-      "state" : {
-        "revision" : "0101a02196f6a67cf26f6434b007d3db6bd07fee",
-        "version" : "1.1.0"
+  "object": {
+    "pins": [
+      {
+        "package": "ActivityIndicator",
+        "repositoryURL": "https://github.com/duyquang91/ActivityIndicator",
+        "state": {
+          "branch": null,
+          "revision": "0101a02196f6a67cf26f6434b007d3db6bd07fee",
+          "version": "1.1.0"
+        }
+      },
+      {
+        "package": "AnyCodable",
+        "repositoryURL": "https://github.com/Flight-School/AnyCodable",
+        "state": {
+          "branch": null,
+          "revision": "f9fda69a7b704d46fb5123005f2f7e43dbb8a0fa",
+          "version": "0.6.5"
+        }
+      },
+      {
+        "package": "ASCollectionView",
+        "repositoryURL": "https://github.com/apptekstudios/ASCollectionView",
+        "state": {
+          "branch": null,
+          "revision": "4288744ba484c1062c109c0f28d72b629d321d55",
+          "version": "2.1.1"
+        }
+      },
+      {
+        "package": "BlurHashKit",
+        "repositoryURL": "https://github.com/LePips/BlurHashKit",
+        "state": {
+          "branch": null,
+          "revision": "3c23237f1f2b62741bce70bd2e4ef2aa7799ea85",
+          "version": "1.1.0"
+        }
+      },
+      {
+        "package": "CombineExt",
+        "repositoryURL": "https://github.com/CombineCommunity/CombineExt",
+        "state": {
+          "branch": null,
+          "revision": "581849239060948b626d1173eb0e5926818e7f8c",
+          "version": "1.7.0"
+        }
+      },
+      {
+        "package": "CoreStore",
+        "repositoryURL": "https://github.com/JohnEstropia/CoreStore.git",
+        "state": {
+          "branch": null,
+          "revision": "496145761ab30e8cf1c44220c0882b95e6b41077",
+          "version": "8.1.0"
+        }
+      },
+      {
+        "package": "Defaults",
+        "repositoryURL": "https://github.com/sindresorhus/Defaults",
+        "state": {
+          "branch": null,
+          "revision": "981ccb0a01c54abbe3c12ccb8226108527bbf115",
+          "version": "6.3.0"
+        }
+      },
+      {
+        "package": "DifferenceKit",
+        "repositoryURL": "https://github.com/ra1028/DifferenceKit",
+        "state": {
+          "branch": null,
+          "revision": "073b9671ce2b9b5b96398611427a1f929927e428",
+          "version": "1.3.0"
+        }
+      },
+      {
+        "package": "Nuke",
+        "repositoryURL": "https://github.com/kean/Nuke",
+        "state": {
+          "branch": null,
+          "revision": "8ea514737c2011ff7d7544aa065ad44905bdae0b",
+          "version": "11.1.0"
+        }
+      },
+      {
+        "package": "Puppy",
+        "repositoryURL": "https://github.com/sushichop/Puppy",
+        "state": {
+          "branch": null,
+          "revision": "7cfae42becac2d8916cb1a866dd12d9843199df9",
+          "version": "0.5.0"
+        }
+      },
+      {
+        "package": "Stinsen",
+        "repositoryURL": "https://github.com/rundfunk47/stinsen",
+        "state": {
+          "branch": "master",
+          "revision": "17afde3c4763e014c7505da15258a5d44821c91a",
+          "version": null
+        }
+      },
+      {
+        "package": "swift-algorithms",
+        "repositoryURL": "https://github.com/apple/swift-algorithms.git",
+        "state": {
+          "branch": null,
+          "revision": "b14b7f4c528c942f121c8b860b9410b2bf57825e",
+          "version": "1.0.0"
+        }
+      },
+      {
+        "package": "swift-log",
+        "repositoryURL": "https://github.com/apple/swift-log.git",
+        "state": {
+          "branch": null,
+          "revision": "5d66f7ba25daf4f94100e7022febf3c75e37a6c7",
+          "version": "1.4.2"
+        }
+      },
+      {
+        "package": "swift-numerics",
+        "repositoryURL": "https://github.com/apple/swift-numerics",
+        "state": {
+          "branch": null,
+          "revision": "0a5bc04095a675662cf24757cc0640aa2204253b",
+          "version": "1.0.2"
+        }
+      },
+      {
+        "package": "Introspect",
+        "repositoryURL": "https://github.com/siteline/SwiftUI-Introspect",
+        "state": {
+          "branch": null,
+          "revision": "f2616860a41f9d9932da412a8978fec79c06fe24",
+          "version": "0.1.4"
+        }
+      },
+      {
+        "package": "Sliders",
+        "repositoryURL": "https://github.com/spacenation/swiftui-sliders",
+        "state": {
+          "branch": "master",
+          "revision": "5ba8614462a7ed4bd47a93fbca6c281599f74337",
+          "version": null
+        }
+      },
+      {
+        "package": "SwiftUICollection",
+        "repositoryURL": "https://github.com/defagos/SwiftUICollection",
+        "state": {
+          "branch": "master",
+          "revision": "5b9f14eb3ec5d48cec8b3e4462dcc554d4bff2a8",
+          "version": null
+        }
+      },
+      {
+        "package": "SwiftyJSON",
+        "repositoryURL": "https://github.com/SwiftyJSON/SwiftyJSON",
+        "state": {
+          "branch": null,
+          "revision": "b3dcd7dbd0d488e1a7077cb33b00f2083e382f07",
+          "version": "5.0.1"
+        }
+      },
+      {
+        "package": "SwizzleSwift",
+        "repositoryURL": "https://github.com/MarioIannotta/SwizzleSwift",
+        "state": {
+          "branch": null,
+          "revision": "337dd5f158182620b2bb53c6847f8874a0117b2f",
+          "version": "1.0.0"
+        }
       }
-    },
-    {
-      "identity" : "ascollectionview",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/apptekstudios/ASCollectionView",
-      "state" : {
-        "revision" : "4288744ba484c1062c109c0f28d72b629d321d55",
-        "version" : "2.1.1"
-      }
-    },
-    {
-      "identity" : "blurhashkit",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/LePips/BlurHashKit",
-      "state" : {
-        "revision" : "3c23237f1f2b62741bce70bd2e4ef2aa7799ea85",
-        "version" : "1.1.0"
-      }
-    },
-    {
-      "identity" : "combineext",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/CombineCommunity/CombineExt",
-      "state" : {
-        "revision" : "581849239060948b626d1173eb0e5926818e7f8c",
-        "version" : "1.7.0"
-      }
-    },
-    {
-      "identity" : "corestore",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/JohnEstropia/CoreStore.git",
-      "state" : {
-        "revision" : "496145761ab30e8cf1c44220c0882b95e6b41077",
-        "version" : "8.1.0"
-      }
-    },
-    {
-      "identity" : "defaults",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/sindresorhus/Defaults",
-      "state" : {
-        "revision" : "981ccb0a01c54abbe3c12ccb8226108527bbf115",
-        "version" : "6.3.0"
-      }
-    },
-    {
-      "identity" : "differencekit",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/ra1028/DifferenceKit",
-      "state" : {
-        "revision" : "073b9671ce2b9b5b96398611427a1f929927e428",
-        "version" : "1.3.0"
-      }
-    },
-    {
-      "identity" : "get",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/kean/Get",
-      "state" : {
-        "revision" : "db5248ce985c703c5ea0030b7c4d3f908db304c9",
-        "version" : "1.0.2"
-      }
-    },
-    {
-      "identity" : "jellyfin-sdk-swift",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/jellyfin/jellyfin-sdk-swift",
-      "state" : {
-        "revision" : "848cd01551880a7772367559e1212a8cf330a43d",
-        "version" : "0.2.0"
-      }
-    },
-    {
-      "identity" : "nuke",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/kean/Nuke",
-      "state" : {
-        "revision" : "8ea514737c2011ff7d7544aa065ad44905bdae0b",
-        "version" : "11.1.0"
-      }
-    },
-    {
-      "identity" : "puppy",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/sushichop/Puppy",
-      "state" : {
-        "revision" : "7cfae42becac2d8916cb1a866dd12d9843199df9",
-        "version" : "0.5.0"
-      }
-    },
-    {
-      "identity" : "stinsen",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/rundfunk47/stinsen",
-      "state" : {
-        "branch" : "master",
-        "revision" : "17afde3c4763e014c7505da15258a5d44821c91a"
-      }
-    },
-    {
-      "identity" : "swift-algorithms",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/apple/swift-algorithms.git",
-      "state" : {
-        "revision" : "b14b7f4c528c942f121c8b860b9410b2bf57825e",
-        "version" : "1.0.0"
-      }
-    },
-    {
-      "identity" : "swift-log",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/apple/swift-log.git",
-      "state" : {
-        "revision" : "5d66f7ba25daf4f94100e7022febf3c75e37a6c7",
-        "version" : "1.4.2"
-      }
-    },
-    {
-      "identity" : "swift-numerics",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/apple/swift-numerics",
-      "state" : {
-        "revision" : "0a5bc04095a675662cf24757cc0640aa2204253b",
-        "version" : "1.0.2"
-      }
-    },
-    {
-      "identity" : "swiftui-introspect",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/siteline/SwiftUI-Introspect",
-      "state" : {
-        "revision" : "f2616860a41f9d9932da412a8978fec79c06fe24",
-        "version" : "0.1.4"
-      }
-    },
-    {
-      "identity" : "swiftui-sliders",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/spacenation/swiftui-sliders",
-      "state" : {
-        "branch" : "master",
-        "revision" : "5ba8614462a7ed4bd47a93fbca6c281599f74337"
-      }
-    },
-    {
-      "identity" : "swiftuicollection",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/defagos/SwiftUICollection",
-      "state" : {
-        "branch" : "master",
-        "revision" : "5b9f14eb3ec5d48cec8b3e4462dcc554d4bff2a8"
-      }
-    },
-    {
-      "identity" : "swiftyjson",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/SwiftyJSON/SwiftyJSON",
-      "state" : {
-        "revision" : "b3dcd7dbd0d488e1a7077cb33b00f2083e382f07",
-        "version" : "5.0.1"
-      }
-    },
-    {
-      "identity" : "swizzleswift",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/MarioIannotta/SwizzleSwift",
-      "state" : {
-        "revision" : "337dd5f158182620b2bb53c6847f8874a0117b2f",
-        "version" : "1.0.0"
-      }
-    },
-    {
-      "identity" : "urlqueryencoder",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/CreateAPI/URLQueryEncoder",
-      "state" : {
-        "revision" : "4cc975d4d075d0e62699a796a08284e217d4ee93",
-        "version" : "0.2.0"
-      }
-    }
-  ],
-  "version" : 2
+    ]
+  },
+  "version": 1
 }

--- a/Swiftfin/AppURLHandler/AppURLHandler.swift
+++ b/Swiftfin/AppURLHandler/AppURLHandler.swift
@@ -8,7 +8,7 @@
 
 import Combine
 import Foundation
-import JellyfinAPI
+import JellyfinAPILegacy
 import Stinsen
 
 final class AppURLHandler {

--- a/Swiftfin/AppURLHandler/DeepLink.swift
+++ b/Swiftfin/AppURLHandler/DeepLink.swift
@@ -7,7 +7,7 @@
 //
 
 import Foundation
-import JellyfinAPI
+import JellyfinAPILegacy
 
 enum DeepLink {
     case item(BaseItemDto)

--- a/Swiftfin/Views/HomeView/Components/ContinueWatchingView.swift
+++ b/Swiftfin/Views/HomeView/Components/ContinueWatchingView.swift
@@ -6,7 +6,7 @@
 // Copyright (c) 2022 Jellyfin & Jellyfin Contributors
 //
 
-import JellyfinAPI
+import JellyfinAPILegacy
 import SwiftUI
 
 struct ContinueWatchingView: View {

--- a/Swiftfin/Views/HomeView/Components/LatestInLibraryView.swift
+++ b/Swiftfin/Views/HomeView/Components/LatestInLibraryView.swift
@@ -7,7 +7,7 @@
 //
 
 import Defaults
-import JellyfinAPI
+import JellyfinAPILegacy
 import SwiftUI
 
 struct LatestInLibraryView: View {

--- a/Swiftfin/Views/ItemOverviewView.swift
+++ b/Swiftfin/Views/ItemOverviewView.swift
@@ -6,7 +6,7 @@
 // Copyright (c) 2022 Jellyfin & Jellyfin Contributors
 //
 
-import JellyfinAPI
+import JellyfinAPILegacy
 import SwiftUI
 
 struct ItemOverviewView: View {

--- a/Swiftfin/Views/ItemView/Components/AboutView.swift
+++ b/Swiftfin/Views/ItemView/Components/AboutView.swift
@@ -6,7 +6,7 @@
 // Copyright (c) 2022 Jellyfin & Jellyfin Contributors
 //
 
-import JellyfinAPI
+import JellyfinAPILegacy
 import SwiftUI
 
 extension ItemView {

--- a/Swiftfin/Views/ItemView/Components/EpisodesRowView/EpisodeCard.swift
+++ b/Swiftfin/Views/ItemView/Components/EpisodesRowView/EpisodeCard.swift
@@ -6,7 +6,7 @@
 // Copyright (c) 2022 Jellyfin & Jellyfin Contributors
 //
 
-import JellyfinAPI
+import JellyfinAPILegacy
 import SwiftUI
 
 struct EpisodeCard: View {

--- a/Swiftfin/Views/ItemView/Components/EpisodesRowView/SeriesEpisodesView.swift
+++ b/Swiftfin/Views/ItemView/Components/EpisodesRowView/SeriesEpisodesView.swift
@@ -6,7 +6,7 @@
 // Copyright (c) 2022 Jellyfin & Jellyfin Contributors
 //
 
-import JellyfinAPI
+import JellyfinAPILegacy
 import SwiftUI
 
 struct SeriesEpisodesView<RowManager: EpisodesRowManager>: View {

--- a/Swiftfin/Views/ItemView/Components/ListDetailsView.swift
+++ b/Swiftfin/Views/ItemView/Components/ListDetailsView.swift
@@ -6,7 +6,7 @@
 // Copyright (c) 2022 Jellyfin & Jellyfin Contributors
 //
 
-import JellyfinAPI
+import JellyfinAPILegacy
 import SwiftUI
 
 struct ListDetailsView: View {

--- a/Swiftfin/Views/ItemView/ItemView.swift
+++ b/Swiftfin/Views/ItemView/ItemView.swift
@@ -7,7 +7,7 @@
 //
 
 import Introspect
-import JellyfinAPI
+import JellyfinAPILegacy
 import SwiftUI
 import WidgetKit
 

--- a/Swiftfin/Views/ItemView/iOS/EpisodeItemView/EpisodeItemContentView.swift
+++ b/Swiftfin/Views/ItemView/iOS/EpisodeItemView/EpisodeItemContentView.swift
@@ -6,7 +6,7 @@
 // Copyright (c) 2022 Jellyfin & Jellyfin Contributors
 //
 
-import JellyfinAPI
+import JellyfinAPILegacy
 import SwiftUI
 
 extension EpisodeItemView {

--- a/Swiftfin/Views/ItemView/iOS/EpisodeItemView/EpisodeItemView.swift
+++ b/Swiftfin/Views/ItemView/iOS/EpisodeItemView/EpisodeItemView.swift
@@ -6,7 +6,7 @@
 // Copyright (c) 2022 Jellyfin & Jellyfin Contributors
 //
 
-import JellyfinAPI
+import JellyfinAPILegacy
 import SwiftUI
 
 struct EpisodeItemView: View {

--- a/Swiftfin/Views/ItemView/iOS/MovieItemView/MovieItemContentView.swift
+++ b/Swiftfin/Views/ItemView/iOS/MovieItemView/MovieItemContentView.swift
@@ -7,7 +7,7 @@
 //
 
 import Defaults
-import JellyfinAPI
+import JellyfinAPILegacy
 import SwiftUI
 
 extension MovieItemView {

--- a/Swiftfin/Views/ItemView/iOS/MovieItemView/MovieItemView.swift
+++ b/Swiftfin/Views/ItemView/iOS/MovieItemView/MovieItemView.swift
@@ -7,7 +7,7 @@
 //
 
 import Defaults
-import JellyfinAPI
+import JellyfinAPILegacy
 import SwiftUI
 
 struct MovieItemView: View {

--- a/Swiftfin/Views/ItemView/iOS/SeriesItemView/SeriesItemContentView.swift
+++ b/Swiftfin/Views/ItemView/iOS/SeriesItemView/SeriesItemContentView.swift
@@ -7,7 +7,7 @@
 //
 
 import Defaults
-import JellyfinAPI
+import JellyfinAPILegacy
 import SwiftUI
 
 extension SeriesItemView {

--- a/Swiftfin/Views/ItemView/iOS/SeriesItemView/SeriesItemView.swift
+++ b/Swiftfin/Views/ItemView/iOS/SeriesItemView/SeriesItemView.swift
@@ -7,7 +7,7 @@
 //
 
 import Defaults
-import JellyfinAPI
+import JellyfinAPILegacy
 import SwiftUI
 
 struct SeriesItemView: View {

--- a/Swiftfin/Views/ItemView/iPadOS/EpisodeItemView/iPadOSEpisodeContentView.swift
+++ b/Swiftfin/Views/ItemView/iPadOS/EpisodeItemView/iPadOSEpisodeContentView.swift
@@ -6,7 +6,7 @@
 // Copyright (c) 2022 Jellyfin & Jellyfin Contributors
 //
 
-import JellyfinAPI
+import JellyfinAPILegacy
 import SwiftUI
 
 extension iPadOSEpisodeItemView {

--- a/Swiftfin/Views/ItemView/iPadOS/EpisodeItemView/iPadOSEpisodeItemView.swift
+++ b/Swiftfin/Views/ItemView/iPadOS/EpisodeItemView/iPadOSEpisodeItemView.swift
@@ -6,7 +6,7 @@
 // Copyright (c) 2022 Jellyfin & Jellyfin Contributors
 //
 
-import JellyfinAPI
+import JellyfinAPILegacy
 import SwiftUI
 
 struct iPadOSEpisodeItemView: View {

--- a/Swiftfin/Views/ItemView/iPadOS/MovieItemView/iPadOSMovieItemContentView.swift
+++ b/Swiftfin/Views/ItemView/iPadOS/MovieItemView/iPadOSMovieItemContentView.swift
@@ -6,7 +6,7 @@
 // Copyright (c) 2022 Jellyfin & Jellyfin Contributors
 //
 
-import JellyfinAPI
+import JellyfinAPILegacy
 import SwiftUI
 
 extension iPadOSMovieItemView {

--- a/Swiftfin/Views/ItemView/iPadOS/MovieItemView/iPadOSMovieItemView.swift
+++ b/Swiftfin/Views/ItemView/iPadOS/MovieItemView/iPadOSMovieItemView.swift
@@ -6,7 +6,7 @@
 // Copyright (c) 2022 Jellyfin & Jellyfin Contributors
 //
 
-import JellyfinAPI
+import JellyfinAPILegacy
 import SwiftUI
 
 struct iPadOSMovieItemView: View {

--- a/Swiftfin/Views/ItemView/iPadOS/SeriesItemView/iPadOSSeriesItemContentView.swift
+++ b/Swiftfin/Views/ItemView/iPadOS/SeriesItemView/iPadOSSeriesItemContentView.swift
@@ -6,7 +6,7 @@
 // Copyright (c) 2022 Jellyfin & Jellyfin Contributors
 //
 
-import JellyfinAPI
+import JellyfinAPILegacy
 import SwiftUI
 
 extension iPadOSSeriesItemView {

--- a/Swiftfin/Views/ItemView/iPadOS/SeriesItemView/iPadOSSeriesItemView.swift
+++ b/Swiftfin/Views/ItemView/iPadOS/SeriesItemView/iPadOSSeriesItemView.swift
@@ -6,7 +6,7 @@
 // Copyright (c) 2022 Jellyfin & Jellyfin Contributors
 //
 
-import JellyfinAPI
+import JellyfinAPILegacy
 import SwiftUI
 
 struct iPadOSSeriesItemView: View {

--- a/Swiftfin/Views/LibraryFilterView.swift
+++ b/Swiftfin/Views/LibraryFilterView.swift
@@ -6,7 +6,7 @@
 // Copyright (c) 2022 Jellyfin & Jellyfin Contributors
 //
 
-import JellyfinAPI
+import JellyfinAPILegacy
 import Stinsen
 import SwiftUI
 

--- a/Swiftfin/Views/LibraryListView.swift
+++ b/Swiftfin/Views/LibraryListView.swift
@@ -7,7 +7,7 @@
 //
 
 import Foundation
-import JellyfinAPI
+import JellyfinAPILegacy
 import Stinsen
 import SwiftUI
 

--- a/Swiftfin/Views/LibrarySearchView.swift
+++ b/Swiftfin/Views/LibrarySearchView.swift
@@ -7,7 +7,7 @@
 //
 
 import Combine
-import JellyfinAPI
+import JellyfinAPILegacy
 import Stinsen
 import SwiftUI
 

--- a/Swiftfin/Views/LiveTVChannelItemElement.swift
+++ b/Swiftfin/Views/LiveTVChannelItemElement.swift
@@ -6,7 +6,7 @@
 // Copyright (c) 2022 Jellyfin & Jellyfin Contributors
 //
 
-import JellyfinAPI
+import JellyfinAPILegacy
 import SwiftUI
 
 struct LiveTVChannelItemElement: View {

--- a/Swiftfin/Views/LiveTVChannelItemWideElement.swift
+++ b/Swiftfin/Views/LiveTVChannelItemWideElement.swift
@@ -6,7 +6,7 @@
 // Copyright (c) 2022 Jellyfin & Jellyfin Contributors
 //
 
-import JellyfinAPI
+import JellyfinAPILegacy
 import SwiftUI
 
 struct LiveTVChannelItemWideElement: View {

--- a/Swiftfin/Views/LiveTVChannelsView.swift
+++ b/Swiftfin/Views/LiveTVChannelsView.swift
@@ -8,7 +8,7 @@
 
 import ASCollectionView
 import Foundation
-import JellyfinAPI
+import JellyfinAPILegacy
 import SwiftUI
 import SwiftUICollection
 

--- a/Swiftfin/Views/UserSignInView/Components/PublicUserSignInView.swift
+++ b/Swiftfin/Views/UserSignInView/Components/PublicUserSignInView.swift
@@ -6,7 +6,7 @@
 // Copyright (c) 2022 Jellyfin & Jellyfin Contributors
 //
 
-import JellyfinAPI
+import JellyfinAPILegacy
 import SwiftUI
 
 extension UserSignInView {

--- a/Swiftfin/Views/VideoPlayer/LiveTVNativePlayerViewController.swift
+++ b/Swiftfin/Views/VideoPlayer/LiveTVNativePlayerViewController.swift
@@ -8,7 +8,7 @@
 
 import AVKit
 import Combine
-import JellyfinAPI
+import JellyfinAPILegacy
 import UIKit
 
 class LiveTVNativePlayerViewController: AVPlayerViewController {

--- a/Swiftfin/Views/VideoPlayer/LiveTVPlayerViewController.swift
+++ b/Swiftfin/Views/VideoPlayer/LiveTVPlayerViewController.swift
@@ -10,7 +10,7 @@ import AVFoundation
 import AVKit
 import Combine
 import Defaults
-import JellyfinAPI
+import JellyfinAPILegacy
 import MediaPlayer
 import MobileVLCKit
 import SwiftUI

--- a/Swiftfin/Views/VideoPlayer/NativePlayerViewController.swift
+++ b/Swiftfin/Views/VideoPlayer/NativePlayerViewController.swift
@@ -8,7 +8,7 @@
 
 import AVKit
 import Combine
-import JellyfinAPI
+import JellyfinAPILegacy
 import UIKit
 
 class NativePlayerViewController: AVPlayerViewController {

--- a/Swiftfin/Views/VideoPlayer/Overlays/VLCPlayerChapterOverlayView.swift
+++ b/Swiftfin/Views/VideoPlayer/Overlays/VLCPlayerChapterOverlayView.swift
@@ -6,7 +6,7 @@
 // Copyright (c) 2022 Jellyfin & Jellyfin Contributors
 //
 
-import JellyfinAPI
+import JellyfinAPILegacy
 import SwiftUI
 
 struct VLCPlayerChapterOverlayView: View {

--- a/Swiftfin/Views/VideoPlayer/Overlays/VLCPlayerOverlayView.swift
+++ b/Swiftfin/Views/VideoPlayer/Overlays/VLCPlayerOverlayView.swift
@@ -8,7 +8,7 @@
 
 import Combine
 import Defaults
-import JellyfinAPI
+import JellyfinAPILegacy
 import MobileVLCKit
 import Sliders
 import SwiftUI

--- a/Swiftfin/Views/VideoPlayer/PlayerOverlayDelegate.swift
+++ b/Swiftfin/Views/VideoPlayer/PlayerOverlayDelegate.swift
@@ -7,7 +7,7 @@
 //
 
 import Foundation
-import JellyfinAPI
+import JellyfinAPILegacy
 import UIKit
 
 protocol PlayerOverlayDelegate {

--- a/Swiftfin/Views/VideoPlayer/VLCPlayerViewController.swift
+++ b/Swiftfin/Views/VideoPlayer/VLCPlayerViewController.swift
@@ -10,7 +10,7 @@ import AVFoundation
 import AVKit
 import Combine
 import Defaults
-import JellyfinAPI
+import JellyfinAPILegacy
 import MediaPlayer
 import MobileVLCKit
 import SwiftUI


### PR DESCRIPTION
This PR servers as the (long) transition to the new async/await provided in the new JellyfinAPI.

I am developing this transition with the following steps:
1. remove jellyfin-sdk-swift
2. have a local copy of jellyfin-sdk-swift at version 0.1.0, rename _folder_ to `jellyfin-sdk-swift-legacy`
3. rename the target to `JellyfinAPILegacy`
4. import as local package and update imports to `JellyfinAPILegacy`
5. add jellyfin-sdk-swift at version 0.2.0

This allows incremental updates instead of having to replace all of the calls at once before a successful build.

- [ ] make async/await wrappers
- [ ] inject some sort of session object into environment
    - this helps with resetting the app view on logout
- [ ] ActivityIndicator replacement
- [ ] refactor view models error handling
- [ ] replace calls...
    - might require slight adjustments to other views/callsites that require a full URL, like `ImageView`