### PR TITLE
Proper Library Handling

### DIFF
--- a/Shared/Coordinators/MoviesLibrariesCoordinator.swift
+++ b/Shared/Coordinators/MoviesLibrariesCoordinator.swift
@@ -36,10 +36,10 @@ final class MovieLibrariesCoordinator: NavigationCoordinatable {
     }
 
     func makeLibrary(library: BaseItemDto) -> LibraryCoordinator {
-        LibraryCoordinator(viewModel: LibraryViewModel(parentID: library.id), title: library.title)
+        LibraryCoordinator(viewModel: LibraryViewModel(library: library), title: library.title)
     }
 
     func makeRootLibrary(library: BaseItemDto) -> LibraryCoordinator {
-        LibraryCoordinator(viewModel: LibraryViewModel(parentID: library.id), title: library.title)
+        LibraryCoordinator(viewModel: LibraryViewModel(library: library), title: library.title)
     }
 }

--- a/Shared/Coordinators/TVLibrariesCoordinator.swift
+++ b/Shared/Coordinators/TVLibrariesCoordinator.swift
@@ -36,10 +36,10 @@ final class TVLibrariesCoordinator: NavigationCoordinatable {
     }
 
     func makeLibrary(library: BaseItemDto) -> LibraryCoordinator {
-        LibraryCoordinator(viewModel: LibraryViewModel(parentID: library.id), title: library.title)
+        LibraryCoordinator(viewModel: LibraryViewModel(library: library), title: library.title)
     }
 
     func makeRootLibrary(library: BaseItemDto) -> LibraryCoordinator {
-        LibraryCoordinator(viewModel: LibraryViewModel(parentID: library.id), title: library.title)
+        LibraryCoordinator(viewModel: LibraryViewModel(library: library), title: library.title)
     }
 }

--- a/Shared/Extensions/JellyfinAPIExtensions/BaseItemDto+Poster.swift
+++ b/Shared/Extensions/JellyfinAPIExtensions/BaseItemDto+Poster.swift
@@ -35,7 +35,7 @@ extension BaseItemDto: Poster {
 
     var showTitle: Bool {
         switch type {
-        case .episode, .series, .movie, .boxSet:
+        case .episode, .series, .movie, .boxSet, .collectionFolder:
             return Defaults[.Customization.showPosterLabels]
         default:
             return true

--- a/Shared/Objects/LibraryItem.swift
+++ b/Shared/Objects/LibraryItem.swift
@@ -9,6 +9,8 @@
 import JellyfinAPI
 import SwiftUI
 
+// TODO: Look at something better that possibly doesn't depend on the viewmodel
+//       and accomodates favorites and liveTV better
 struct LibraryItem: Equatable, Poster {
 
     var library: BaseItemDto
@@ -28,5 +30,13 @@ struct LibraryItem: Equatable, Poster {
     static func == (lhs: LibraryItem, rhs: LibraryItem) -> Bool {
         lhs.library == rhs.library &&
             lhs.viewModel.libraryImages[lhs.library.id ?? ""] == rhs.viewModel.libraryImages[rhs.library.id ?? ""]
+    }
+
+    static func favorites(viewModel: MediaViewModel) -> LibraryItem {
+        .init(library: .init(name: L10n.favorites, collectionType: "favorites"), viewModel: viewModel)
+    }
+
+    static func liveTV(viewModel: MediaViewModel) -> LibraryItem {
+        .init(library: .init(name: "LiveTV", collectionType: "liveTV"), viewModel: viewModel)
     }
 }

--- a/Shared/SwiftfinStore/SwiftfinStoreDefaults.swift
+++ b/Shared/SwiftfinStore/SwiftfinStoreDefaults.swift
@@ -28,7 +28,6 @@ extension Defaults.Keys {
     static let outOfNetworkBandwidth = Key<Int>("OutOfNetworkBandwidth", default: 40_000_000, suite: .generalSuite)
 
     enum Customization {
-        static let showFlattenView = Key<Bool>("showFlattenView", default: true, suite: .generalSuite)
         static let itemViewType = Key<ItemViewType>("itemViewType", default: .compactLogo, suite: .generalSuite)
 
         static let showPosterLabels = Key<Bool>("showPosterLabels", default: true, suite: .generalSuite)

--- a/Shared/ViewModels/MediaViewModel.swift
+++ b/Shared/ViewModels/MediaViewModel.swift
@@ -13,9 +13,18 @@ import JellyfinAPI
 final class MediaViewModel: ViewModel {
 
     @Published
-    var libraries: [LibraryItem] = []
+    private var libraries: [LibraryItem] = []
     @Published
     var libraryImages: [String: [ImageSource]] = [:]
+
+    @Default(.Experimental.liveTVAlphaEnabled)
+    private var liveTVEnabled
+
+    var libraryItems: [LibraryItem] {
+        [.init(library: .init(name: L10n.favorites, collectionType: "favorites"), viewModel: self)]
+            .appending(.init(library: .init(name: "LiveTV", collectionType: "liveTV"), viewModel: self), if: liveTVEnabled)
+            .appending(libraries)
+    }
 
     private static let supportedCollectionTypes: [String] = ["boxsets", "folders", "movies", "tvshows", "unknown"]
 

--- a/Swiftfin tvOS/Views/LatestInLibraryView.swift
+++ b/Swiftfin tvOS/Views/LatestInLibraryView.swift
@@ -22,7 +22,7 @@ struct LatestInLibraryView: View {
                 Button {
                     router.route(to: \.library, (
                         viewModel: .init(
-                            parentID: viewModel.library.id!,
+                            library: viewModel.library,
                             filters: LibraryFilters(
                                 filters: [],
                                 sortOrder: [.descending],

--- a/Swiftfin tvOS/Views/MediaView.swift
+++ b/Swiftfin tvOS/Views/MediaView.swift
@@ -7,7 +7,6 @@
 //
 
 import CollectionView
-import Defaults
 import JellyfinAPI
 import Stinsen
 import SwiftUI

--- a/Swiftfin tvOS/Views/MediaView.swift
+++ b/Swiftfin tvOS/Views/MediaView.swift
@@ -21,17 +21,8 @@ struct MediaView: View {
     @ObservedObject
     var viewModel: MediaViewModel
 
-    @Default(.Experimental.liveTVAlphaEnabled)
-    var liveTVEnabled
-
-    private var libraryItems: [LibraryItem] {
-        [.init(library: .init(name: L10n.favorites, collectionType: "favorites"), viewModel: viewModel)]
-            .appending(.init(library: .init(name: "LiveTV", collectionType: "liveTV"), viewModel: viewModel), if: liveTVEnabled)
-            .appending(viewModel.libraries)
-    }
-
     var body: some View {
-        CollectionView(items: libraryItems) { _, item, _ in
+        CollectionView(items: viewModel.libraryItems) { _, item, _ in
             PosterButton(item: item, type: .landscape)
                 .scaleItem(0.8)
                 .onSelect { _ in

--- a/Swiftfin tvOS/Views/SettingsView/CustomizeViewsSettings.swift
+++ b/Swiftfin tvOS/Views/SettingsView/CustomizeViewsSettings.swift
@@ -13,16 +13,12 @@ struct CustomizeViewsSettings: View {
 
     @Default(.Customization.showPosterLabels)
     var showPosterLabels
-    @Default(.Customization.showFlattenView)
-    var showFlattenView
 
     var body: some View {
         Form {
             Section {
 
                 Toggle(L10n.showPosterLabels, isOn: $showPosterLabels)
-
-                Toggle(L10n.showFlattenView, isOn: $showFlattenView)
 
             } header: {
                 L10n.customize.text

--- a/Swiftfin/Views/HomeView/Components/LatestInLibraryView.swift
+++ b/Swiftfin/Views/HomeView/Components/LatestInLibraryView.swift
@@ -24,7 +24,7 @@ struct LatestInLibraryView: View {
         PosterHStack(title: L10n.latestWithString(viewModel.library.displayName), type: latestInLibraryPosterType, items: viewModel.items)
             .trailing {
                 Button {
-                    let libraryViewModel = LibraryViewModel(parentID: viewModel.library.id, filters: HomeViewModel.recentFilterSet)
+                    let libraryViewModel = LibraryViewModel(library: viewModel.library, filters: HomeViewModel.recentFilterSet)
                     homeRouter.route(to: \.library, (viewModel: libraryViewModel, title: viewModel.library.displayName))
                 } label: {
                     HStack {

--- a/Swiftfin/Views/ItemView/ItemView.swift
+++ b/Swiftfin/Views/ItemView/ItemView.swift
@@ -44,6 +44,8 @@ struct ItemView: View {
                 }
             case .person:
                 LibraryView(viewModel: .init(person: .init(id: item.id)))
+            case .collectionFolder:
+                LibraryView(viewModel: .init(library: item))
             default:
                 Text(L10n.notImplementedYetWithType(item.type ?? "--"))
             }

--- a/Swiftfin/Views/LibraryView/LibraryView.swift
+++ b/Swiftfin/Views/LibraryView/LibraryView.swift
@@ -125,7 +125,7 @@ struct LibraryView: View {
                         .route(to: \.filter, (
                             filters: $viewModel.filters,
                             enabledFilterType: viewModel.enabledFilterType,
-                            parentId: viewModel.parentID ?? ""
+                            parentId: viewModel.library?.id ?? ""
                         ))
                 } label: {
                     Image(systemName: "line.horizontal.3.decrease.circle")

--- a/Swiftfin/Views/MediaView.swift
+++ b/Swiftfin/Views/MediaView.swift
@@ -7,7 +7,6 @@
 //
 
 import CollectionView
-import Defaults
 import JellyfinAPI
 import Stinsen
 import SwiftUI

--- a/Swiftfin/Views/MediaView.swift
+++ b/Swiftfin/Views/MediaView.swift
@@ -19,15 +19,6 @@ struct MediaView: View {
     @ObservedObject
     var viewModel: MediaViewModel
 
-    @Default(.Experimental.liveTVAlphaEnabled)
-    var liveTVEnabled
-
-    private var libraryItems: [LibraryItem] {
-        [.init(library: .init(name: L10n.favorites, collectionType: "favorites"), viewModel: viewModel)]
-            .appending(.init(library: .init(name: "LiveTV", collectionType: "liveTV"), viewModel: viewModel), if: liveTVEnabled)
-            .appending(viewModel.libraries)
-    }
-
     private var gridLayout: NSCollectionLayoutSection.GridLayoutMode {
         if UIDevice.isPhone {
             return .fixedNumberOfColumns(2)
@@ -37,7 +28,7 @@ struct MediaView: View {
     }
 
     var body: some View {
-        CollectionView(items: libraryItems) { _, item, _ in
+        CollectionView(items: viewModel.libraryItems) { _, item, _ in
             PosterButton(item: item, type: .landscape)
                 .scaleItem(UIDevice.isPhone ? 0.9 : 1)
                 .onSelect { _ in

--- a/Swiftfin/Views/MediaView.swift
+++ b/Swiftfin/Views/MediaView.swift
@@ -18,13 +18,14 @@ struct MediaView: View {
     private var router: MediaCoordinator.Router
     @ObservedObject
     var viewModel: MediaViewModel
+
     @Default(.Experimental.liveTVAlphaEnabled)
     var liveTVEnabled
 
     private var libraryItems: [LibraryItem] {
-        [LibraryItem(library: .init(name: L10n.favorites, id: "favorites"), viewModel: viewModel)]
-            .appending(.init(library: .init(name: "LiveTV", id: "liveTV"), viewModel: viewModel), if: liveTVEnabled)
-            .appending(viewModel.libraries.map { LibraryItem(library: $0, viewModel: viewModel) })
+        [.init(library: .init(name: L10n.favorites, collectionType: "favorites"), viewModel: viewModel)]
+            .appending(.init(library: .init(name: "LiveTV", collectionType: "liveTV"), viewModel: viewModel), if: liveTVEnabled)
+            .appending(viewModel.libraries)
     }
 
     private var gridLayout: NSCollectionLayoutSection.GridLayoutMode {
@@ -40,12 +41,13 @@ struct MediaView: View {
             PosterButton(item: item, type: .landscape)
                 .scaleItem(UIDevice.isPhone ? 0.9 : 1)
                 .onSelect { _ in
-                    if item.library.id == "favorites" {
+                    switch item.library.collectionType {
+                    case "favorites":
                         router.route(to: \.library, (viewModel: .init(filters: .favorites), title: ""))
-                    } else if item.library.id == "liveTV" {
+                    case "liveTV":
                         router.route(to: \.liveTV)
-                    } else {
-                        router.route(to: \.library, (viewModel: .init(parentID: item.library.id), title: ""))
+                    default:
+                        router.route(to: \.library, (viewModel: .init(library: item.library), title: ""))
                     }
                 }
                 .imageOverlay { _ in

--- a/Swiftfin/Views/SettingsView/CustomizeViewsSettings.swift
+++ b/Swiftfin/Views/SettingsView/CustomizeViewsSettings.swift
@@ -11,8 +11,6 @@ import SwiftUI
 
 struct CustomizeViewsSettings: View {
 
-    @Default(.Customization.showFlattenView)
-    var showFlattenView
     @Default(.Customization.itemViewType)
     var itemViewType
 
@@ -45,9 +43,6 @@ struct CustomizeViewsSettings: View {
     var body: some View {
         List {
             Section {
-
-                Toggle(L10n.showFlattenView, isOn: $showFlattenView)
-
                 Picker(L10n.items, selection: $itemViewType) {
                     ForEach(ItemViewType.allCases, id: \.self) { type in
                         Text(type.localizedName).tag(type.rawValue)


### PR DESCRIPTION
- Closes https://github.com/jellyfin/Swiftfin/issues/437

Properly handles libraries, meaning that `Folders` are now properly displayed if given. They would show previously but its content was not supported.

<details>
<summary>iOS</summary>

<img src="https://user-images.githubusercontent.com/20747774/187281322-3177047c-9298-40e1-b81b-bb9145df3c4f.png" width="30%" height="30%">
</details>

<details>
<summary>tvOS</summary>

![Simulator Screen Shot - Apple TV 4K (2nd generation) - 2022-08-29 at 13 11 02](https://user-images.githubusercontent.com/20747774/187281550-0d43e7f0-f8cd-4009-bc42-24b7566868c7.png)
</details>

### Other
- Removes "Flatten Library Items", this is the `Folders` library
- Re-adds LiveTV on tvOS which was mistakenly omitted
- Libraries won't call for new pages if there is nothing to get, indicated by an empty response
- Since the `Collections` and `Folders` libraries come from User _server_ settings, this means I should start looking at how to implement these in the app
- `Folders` doesn't have backdrop photos, as expected since folders don't have backdrops
- `CollectionFolder` types have a primary photo of the server rendered text, which looks odd but nothing we can do about it.
- With `CollectionFolder` in landscape folders, they're just blank since there's no backdrop images. This can be problematic when poster labels are disabled

For the last three problems, I would prefer that _server_ enhancements be made. However, I could look at just having the `Folders` library having landscape posters with overlay text when displaying in a grid.

<details>
<summary>CollectionFolder portrait posters</summary>

<img src="https://user-images.githubusercontent.com/20747774/187281784-ff7139c6-bc34-4c4f-83f9-4f28f1f50e50.png" width="30%" height="30%">
</details>

<details>
<summary>CollectionFolder landscape posters</summary>

<img src="https://user-images.githubusercontent.com/20747774/187286365-0f3b6a17-7297-4e7d-8dfd-a393e668c1fe.png" width="30%" height="30%">
</details>