### PR TITLE
Resize Landscape Posters in Grid

### DIFF
--- a/Swiftfin/Views/LibraryView/LibraryView.swift
+++ b/Swiftfin/Views/LibraryView/LibraryView.swift
@@ -64,15 +64,16 @@ struct LibraryView: View {
     private var libraryGridView: some View {
         CollectionView(items: viewModel.items) { _, item, _ in
             PosterButton(item: item, type: libraryGridPosterType)
+                .scaleItem(libraryGridPosterType == .landscape && UIDevice.isPhone ? 0.85 : 1)
                 .onSelect { item in
                     router.route(to: \.item, item)
                 }
-                .scaleItem(libraryGridPosterType == .landscape && UIDevice.isPhone ? 0.8 : 1)
         }
         .layout { _, layoutEnvironment in
             .grid(
                 layoutEnvironment: layoutEnvironment,
-                layoutMode: gridLayout
+                layoutMode: gridLayout,
+                sectionInsets: .init(top: 0, leading: 10, bottom: 0, trailing: 10)
             )
         }
         .willReachEdge(insets: .init(top: 0, leading: 0, bottom: 200, trailing: 0)) { edge in

--- a/Swiftfin/Views/MediaView.swift
+++ b/Swiftfin/Views/MediaView.swift
@@ -38,7 +38,7 @@ struct MediaView: View {
     var body: some View {
         CollectionView(items: libraryItems) { _, item, _ in
             PosterButton(item: item, type: .landscape)
-                .scaleItem(UIDevice.isPhone ? 0.9 : 1)
+                .scaleItem(UIDevice.isPhone ? 0.85 : 1)
                 .onSelect { _ in
                     if item.library.id == "favorites" {
                         router.route(to: \.library, (viewModel: .init(filters: .favorites), title: ""))


### PR DESCRIPTION
When I created the landscape poster grid on https://github.com/jellyfin/Swiftfin/pull/541 I used a different scale than the library views so this makes them consistent. When I tested on multiple iPhone screen sizes, I notice that the grid spacing are different due to the ... screen sizes being different. I had to make the new scale accommodate this problem. These differences also appear on iPads and using different poster types. So, I may have to look at manually creating scales for different screen types or some other mechanism for creating consistent grid spacing, possibly with another `ScaledMetric` property.

<details>
<summary>iPhone 13 Mini</summary>

<img src="https://user-images.githubusercontent.com/20747774/187288669-657562ee-4fb9-4695-8734-08f4761b2a58.png" width="30%" height="30%">
</details>

<details>
<summary>iPhone 13</summary>

<img src="https://user-images.githubusercontent.com/20747774/187288885-6d13d782-512b-4734-8257-f4b03047ef58.png" width="30%" height="30%">
</details>

<details>
<summary>iPhone 13 Pro</summary>

<img src="https://user-images.githubusercontent.com/20747774/187288927-f05ca167-fc1d-47fe-9b96-14e5a0414222.png" width="30%" height="30%">
</details>

<details>
<summary>iPhone 13 Pro Max</summary>

<img src="https://user-images.githubusercontent.com/20747774/187288975-fdf7c6ca-a9f5-40ce-ad47-c95d1e74caf0.png" width="30%" height="30%">
</details>