### PR TITLE
Ignore Object Replacement Character

### DIFF
--- a/Shared/Extensions/StringExtensions.swift
+++ b/Shared/Extensions/StringExtensions.swift
@@ -55,3 +55,7 @@ extension String {
         return textSize.width
     }
 }
+
+public extension CharacterSet {
+    static var objectReplacement: CharacterSet = .init(charactersIn: "\u{fffc}")
+}

--- a/Shared/ViewModels/ConnectToServerViewModel.swift
+++ b/Shared/ViewModels/ConnectToServerViewModel.swift
@@ -46,17 +46,11 @@ final class ConnectToServerViewModel: ViewModel {
 
     func connectToServer(uri: String, redirectCount: Int = 0) {
 
-        #if targetEnvironment(simulator)
-            var uri = uri
-            if uri == "http://localhost" || uri == "localhost" {
-                uri = "http://localhost:8096"
-            }
-        #endif
+        let uri = uri.trimmingCharacters(in: .whitespacesAndNewlines)
+            .trimmingCharacters(in: .objectReplacement)
 
-        let trimmedURI = uri.trimmingCharacters(in: .whitespaces)
-
-        LogManager.log.debug("Attempting to connect to server at \"\(trimmedURI)\"", tag: "connectToServer")
-        SessionManager.main.connectToServer(with: trimmedURI)
+        LogManager.log.debug("Attempting to connect to server at \"\(uri)\"", tag: "connectToServer")
+        SessionManager.main.connectToServer(with: uri)
             .trackActivity(loading)
             .sink(receiveCompletion: { completion in
                 // This is disgusting. ViewModel Error handling overall needs to be refactored

--- a/Shared/ViewModels/UserSignInViewModel.swift
+++ b/Shared/ViewModels/UserSignInViewModel.swift
@@ -48,6 +48,11 @@ final class UserSignInViewModel: ViewModel {
     func signIn(username: String, password: String) {
         LogManager.log.debug("Attempting to login to server at \"\(server.currentURI)\"", tag: "login")
 
+        let username = username.trimmingCharacters(in: .whitespacesAndNewlines)
+            .trimmingCharacters(in: .objectReplacement)
+        let password = password.trimmingCharacters(in: .whitespacesAndNewlines)
+            .trimmingCharacters(in: .objectReplacement)
+
         SessionManager.main.signInUser(server: server, username: username, password: password)
             .trackActivity(loading)
             .sink { completion in


### PR DESCRIPTION
- Closes https://github.com/jellyfin/Swiftfin/issues/447

Wasn't a whitespace issue, Siri Dictation will sometimes add `u\{fffc}`, object replacement character, to the end of a string. These are the only places where it matters.