### PR TITLE
iOS/iPadOS - Media/LibraryView Loading Indicator

### DIFF
--- a/Shared/ViewModels/MediaViewModel.swift
+++ b/Shared/ViewModels/MediaViewModel.swift
@@ -37,6 +37,7 @@ final class MediaViewModel: ViewModel {
 
     func requestLibraries() {
         UserViewsAPI.getUserViews(userId: SessionManager.main.currentLogin.user.id)
+            .trackActivity(loading)
             .sink(receiveCompletion: { completion in
                 self.handleAPIRequestError(completion: completion)
             }, receiveValue: { response in

--- a/Swiftfin/Views/LibraryView/LibraryView.swift
+++ b/Swiftfin/Views/LibraryView/LibraryView.swift
@@ -116,6 +116,11 @@ struct LibraryView: View {
         }
         .toolbar {
             ToolbarItemGroup(placement: .navigationBarTrailing) {
+
+                if viewModel.isLoading && !viewModel.items.isEmpty {
+                    ProgressView()
+                }
+
                 Button {
                     switch libraryViewType {
                     case .grid:

--- a/Swiftfin/Views/MediaView.swift
+++ b/Swiftfin/Views/MediaView.swift
@@ -69,5 +69,12 @@ struct MediaView: View {
         }
         .ignoresSafeArea()
         .navigationTitle(L10n.allMedia)
+        .toolbar {
+            ToolbarItemGroup(placement: .navigationBarTrailing) {
+                if viewModel.isLoading {
+                    ProgressView()
+                }
+            }
+        }
     }
 }


### PR DESCRIPTION
Adds a loading indicator to the toolbar to `MediaView` and `LibraryView` to indicate items are being retrieved.