### PR TITLE
Similar Poster Types and Image View Initials

### DIFF
--- a/Shared/SwiftfinStore/SwiftfinStoreDefaults.swift
+++ b/Shared/SwiftfinStore/SwiftfinStoreDefaults.swift
@@ -34,7 +34,7 @@ extension Defaults.Keys {
         static let nextUpPosterType = Key<PosterType>("nextUpPosterType", default: .portrait, suite: .generalSuite)
         static let recentlyAddedPosterType = Key<PosterType>("recentlyAddedPosterType", default: .portrait, suite: .generalSuite)
         static let latestInLibraryPosterType = Key<PosterType>("latestInLibraryPosterType", default: .portrait, suite: .generalSuite)
-        static let recommendedPosterType = Key<PosterType>("recommendedPosterType", default: .portrait, suite: .generalSuite)
+        static let similarPosterType = Key<PosterType>("similarPosterType", default: .portrait, suite: .generalSuite)
         static let searchPosterType = Key<PosterType>("searchPosterType", default: .portrait, suite: .generalSuite)
 
         enum Episodes {

--- a/Shared/Views/ImageView.swift
+++ b/Shared/Views/ImageView.swift
@@ -59,7 +59,8 @@ struct ImageView<ImageType: View, PlaceholderView: View, FailureView: View>: Vie
         } else if let blurHash = currentSource.blurHash {
             BlurHashView(blurHash: blurHash, size: .Circle(radius: 16))
         } else {
-            EmptyView()
+            Color.secondarySystemFill
+                .opacity(0.5)
         }
     }
 

--- a/Shared/Views/InitialFailureView.swift
+++ b/Shared/Views/InitialFailureView.swift
@@ -18,8 +18,8 @@ struct InitialFailureView: View {
 
     var body: some View {
         ZStack {
-            Rectangle()
-                .foregroundColor(Color(UIColor.darkGray))
+            Color.secondarySystemFill
+                .opacity(0.5)
 
             Text(initials)
                 .font(.largeTitle)

--- a/Swiftfin/Components/PosterButton.swift
+++ b/Swiftfin/Components/PosterButton.swift
@@ -55,8 +55,14 @@ struct PosterButton<Item: Poster, Content: View, ImageOverlay: View, ContextMenu
                     switch type {
                     case .portrait:
                         ImageView(item.portraitPosterImageSource(maxWidth: itemWidth))
+                            .failure {
+                                InitialFailureView(item.displayName.initials)
+                            }
                     case .landscape:
                         ImageView(item.landscapePosterImageSources(maxWidth: itemWidth, single: singleImage))
+                            .failure {
+                                InitialFailureView(item.displayName.initials)
+                            }
                     }
                 }
                 .overlay {

--- a/Swiftfin/Views/ItemView/Components/SimilarItemsHStack.swift
+++ b/Swiftfin/Views/ItemView/Components/SimilarItemsHStack.swift
@@ -6,11 +6,15 @@
 // Copyright (c) 2022 Jellyfin & Jellyfin Contributors
 //
 
+import Defaults
 import JellyfinAPI
 import SwiftUI
 
 extension ItemView {
     struct SimilarItemsHStack: View {
+
+        @Default(.Customization.similarPosterType)
+        private var similarPosterType
 
         @EnvironmentObject
         private var router: ItemCoordinator.Router
@@ -19,7 +23,7 @@ extension ItemView {
         var body: some View {
             PosterHStack(
                 title: L10n.recommended,
-                type: .portrait,
+                type: similarPosterType,
                 items: items
             )
             .onSelect { item in

--- a/Swiftfin/Views/ItemView/iOS/ScrollViews/CinematicScrollView.swift
+++ b/Swiftfin/Views/ItemView/iOS/ScrollViews/CinematicScrollView.swift
@@ -118,6 +118,9 @@ extension ItemView.CinematicScrollView {
                 VStack(alignment: .center, spacing: 10) {
                     ImageView(viewModel.item.imageURL(.logo, maxWidth: UIScreen.main.bounds.width))
                         .resizingMode(.aspectFit)
+                        .placeholder {
+                            EmptyView()
+                        }
                         .failure {
                             Text(viewModel.item.displayName)
                                 .font(.largeTitle)

--- a/Swiftfin/Views/ItemView/iOS/ScrollViews/CompactLogoScrollView.swift
+++ b/Swiftfin/Views/ItemView/iOS/ScrollViews/CompactLogoScrollView.swift
@@ -147,6 +147,9 @@ extension ItemView.CompactLogoScrollView {
             VStack(alignment: .center, spacing: 10) {
                 ImageView(viewModel.item.imageURL(.logo, maxWidth: UIScreen.main.bounds.width, maxHeight: 100))
                     .resizingMode(.aspectFit)
+                    .placeholder {
+                        EmptyView()
+                    }
                     .failure {
                         Text(viewModel.item.displayName)
                             .font(.largeTitle)

--- a/Swiftfin/Views/SettingsView/CustomizeViewsSettings.swift
+++ b/Swiftfin/Views/SettingsView/CustomizeViewsSettings.swift
@@ -27,8 +27,8 @@ struct CustomizeViewsSettings: View {
     var recentlyAddedPosterType
     @Default(.Customization.latestInLibraryPosterType)
     var latestInLibraryPosterType
-    @Default(.Customization.recommendedPosterType)
-    var recommendedPosterType
+    @Default(.Customization.similarPosterType)
+    var similarPosterType
     @Default(.Customization.searchPosterType)
     var searchPosterType
     @Default(.Customization.Library.gridPosterType)
@@ -79,12 +79,11 @@ struct CustomizeViewsSettings: View {
                     }
                 }
 
-                // TODO: Take time to do this for a lot of views
-//                Picker(L10n.recommended, selection: $recommendedPosterType) {
-//                    ForEach(PosterType.allCases, id: \.self) { type in
-//                        Text(type.localizedName).tag(type.rawValue)
-//                    }
-//                }
+                Picker(L10n.recommended, selection: $similarPosterType) {
+                    ForEach(PosterType.allCases, id: \.self) { type in
+                        Text(type.localizedName).tag(type.rawValue)
+                    }
+                }
 
                 Picker(L10n.search, selection: $searchPosterType) {
                     ForEach(PosterType.allCases, id: \.self) { type in


### PR DESCRIPTION
- Implements similar item poster type customization
- Different fallback loading view so that views are still selectable and it doesn't look as empty
- Use initials as failure for posters