### PR TITLE
Swift 5.7 Base Fixes

### DIFF
--- a/Shared/Coordinators/MainCoordinator/iOSMainCoordinator.swift
+++ b/Shared/Coordinators/MainCoordinator/iOSMainCoordinator.swift
@@ -20,7 +20,7 @@ final class MainCoordinator: NavigationCoordinatable {
     @Injected(LogManager.service)
     private var logger
 
-    var stack: NavigationStack<MainCoordinator>
+    var stack: Stinsen.NavigationStack<MainCoordinator>
 
     @Root
     var mainTab = makeMainTab

--- a/Shared/Coordinators/MainCoordinator/tvOSMainCoordinator.swift
+++ b/Shared/Coordinators/MainCoordinator/tvOSMainCoordinator.swift
@@ -17,7 +17,7 @@ final class MainCoordinator: NavigationCoordinatable {
     @Injected(LogManager.service)
     private var logger
 
-    var stack = NavigationStack<MainCoordinator>(initial: \MainCoordinator.mainTab)
+    var stack = Stinsen.NavigationStack<MainCoordinator>(initial: \MainCoordinator.mainTab)
 
     @Root
     var mainTab = makeMainTab

--- a/Swiftfin.xcodeproj/project.pbxproj
+++ b/Swiftfin.xcodeproj/project.pbxproj
@@ -3435,7 +3435,7 @@
 			repositoryURL = "https://github.com/JohnEstropia/CoreStore.git";
 			requirement = {
 				kind = upToNextMajorVersion;
-				minimumVersion = 8.1.0;
+				minimumVersion = 9.0.0;
 			};
 		};
 		E13DD3D127168E65009D4DAF /* XCRemoteSwiftPackageReference "Defaults" */ = {

--- a/Swiftfin.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Swiftfin.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -41,8 +41,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/JohnEstropia/CoreStore.git",
       "state" : {
-        "revision" : "496145761ab30e8cf1c44220c0882b95e6b41077",
-        "version" : "8.1.0"
+        "revision" : "25593754913d228777f14634bc6f493dbeb4e9fb",
+        "version" : "9.0.0"
       }
     },
     {


### PR DESCRIPTION
- Part of https://github.com/jellyfin/Swiftfin/issues/578

Updates CoreStore to 9.0.0 and namespaces `Stinsen.NavigationStack`