### PR TITLE
Adds "use fmp4" experimental option

### DIFF
--- a/Shared/Extensions/JellyfinAPIExtensions/BaseItemDto+VideoPlayerViewModel.swift
+++ b/Shared/Extensions/JellyfinAPIExtensions/BaseItemDto+VideoPlayerViewModel.swift
@@ -21,6 +21,7 @@ extension BaseItemDto {
         let tempOverkillBitrate = 360_000_000
         builder.setMaxBitrate(bitrate: tempOverkillBitrate)
         let profile = builder.buildProfile()
+        let segmentContainer = Defaults[.Experimental.usefmp4Hls] ? "mp4" : "ts"
 
         let getPostedPlaybackInfoRequest = GetPostedPlaybackInfoRequest(
             userId: SessionManager.main.currentLogin.user.id,
@@ -95,7 +96,7 @@ extension BaseItemDto {
                     tag: currentMediaSource.eTag,
                     deviceProfileId: nil,
                     playSessionId: response.playSessionId,
-                    segmentContainer: "ts",
+                    segmentContainer: segmentContainer,
                     segmentLength: nil,
                     minSegments: 2,
                     deviceId: UIDevice.vendorUUIDString,

--- a/Shared/Objects/DeviceProfileBuilder.swift
+++ b/Shared/Objects/DeviceProfileBuilder.swift
@@ -8,6 +8,7 @@
 
 // lol can someone buy me a coffee this took forever :|
 
+import Defaults
 import Foundation
 import JellyfinAPI
 
@@ -43,6 +44,7 @@ class DeviceProfileBuilder {
     }
 
     public func buildProfile() -> ClientCapabilitiesDeviceProfile {
+        let segmentContainer = Defaults[.Experimental.usefmp4Hls] ? "mp4" : "ts"
         let maxStreamingBitrate = bitrate
         let maxStaticBitrate = bitrate
         let musicStreamingTranscodingBitrate = bitrate
@@ -99,7 +101,7 @@ class DeviceProfileBuilder {
         if supportsFeature(minimumSupported: .A8X) {
             if supportsFeature(minimumSupported: .A9) {
                 transcodingProfiles = [TranscodingProfile(
-                    container: "ts",
+                    container: segmentContainer,
                     type: .video,
                     videoCodec: "h264,hevc,mpeg4",
                     audioCodec: "aac,mp3,wav,eac3,ac3,flac,opus",
@@ -111,7 +113,7 @@ class DeviceProfileBuilder {
                 )]
             } else {
                 transcodingProfiles = [TranscodingProfile(
-                    container: "ts",
+                    container: segmentContainer,
                     type: .video,
                     videoCodec: "h264,mpeg4",
                     audioCodec: "aac,mp3,wav,eac3,ac3,opus",
@@ -127,7 +129,7 @@ class DeviceProfileBuilder {
         // Device supports FLAC?
         if supportsFeature(minimumSupported: .A10X) {
             transcodingProfiles = [TranscodingProfile(
-                container: "ts",
+                container: segmentContainer,
                 type: .video,
                 videoCodec: "hevc,h264,mpeg4",
                 audioCodec: "aac,mp3,wav,ac3,eac3,flac,opus",

--- a/Shared/SwiftfinStore/SwiftfinStoreDefaults.swift
+++ b/Shared/SwiftfinStore/SwiftfinStoreDefaults.swift
@@ -116,6 +116,7 @@ extension Defaults.Keys {
         )
         static let forceDirectPlay = Key<Bool>("forceDirectPlay", default: false, suite: .generalSuite)
         static let nativePlayer = Key<Bool>("nativePlayer", default: false, suite: .generalSuite)
+        static let usefmp4Hls = Key<Bool>("usefmp4Hls", default: false, suite: .generalSuite)
         static let liveTVAlphaEnabled = Key<Bool>("liveTVAlphaEnabled", default: false, suite: .generalSuite)
         static let liveTVForceDirectPlay = Key<Bool>("liveTVForceDirectPlay", default: false, suite: .generalSuite)
         static let liveTVNativePlayer = Key<Bool>("liveTVNativePlayer", default: false, suite: .generalSuite)

--- a/Swiftfin tvOS/Views/SettingsView/ExperimentalSettingsView.swift
+++ b/Swiftfin tvOS/Views/SettingsView/ExperimentalSettingsView.swift
@@ -17,6 +17,8 @@ struct ExperimentalSettingsView: View {
     var syncSubtitleStateWithAdjacent
     @Default(.Experimental.nativePlayer)
     var nativePlayer
+    @Default(.Experimental.usefmp4Hls)
+    var usefmp4Hls
 
     @Default(.Experimental.liveTVAlphaEnabled)
     var liveTVAlphaEnabled
@@ -34,6 +36,8 @@ struct ExperimentalSettingsView: View {
                 Toggle("Sync Subtitles with Adjacent Episodes", isOn: $syncSubtitleStateWithAdjacent)
 
                 Toggle("Native Player", isOn: $nativePlayer)
+
+                Toggle("Use fmp4 with HLS", isOn: $usefmp4Hls)
 
             } header: {
                 L10n.experimental.text

--- a/Swiftfin/Views/SettingsView/ExperimentalSettingsView.swift
+++ b/Swiftfin/Views/SettingsView/ExperimentalSettingsView.swift
@@ -17,6 +17,9 @@ struct ExperimentalSettingsView: View {
     var syncSubtitleStateWithAdjacent
     @Default(.Experimental.nativePlayer)
     var nativePlayer
+    @Default(.Experimental.usefmp4Hls)
+    var usefmp4Hls
+
     @Default(.Experimental.liveTVAlphaEnabled)
     var liveTVAlphaEnabled
     @Default(.Experimental.liveTVForceDirectPlay)
@@ -33,6 +36,8 @@ struct ExperimentalSettingsView: View {
                 Toggle("Sync Subtitles with Adjacent Episodes", isOn: $syncSubtitleStateWithAdjacent)
 
                 Toggle("Native Player", isOn: $nativePlayer)
+
+                Toggle("Use fmp4 with HLS", isOn: $usefmp4Hls)
 
             } header: {
                 L10n.experimental.text


### PR DESCRIPTION
Fixes issue https://github.com/jellyfin/Swiftfin/issues/610

Adds a new experimental option that makes the native player use fmp4 segment container instead of ts. HEVC/HDR is only supported in fmp4 stream as documented here: "The container format for HEVC video MUST be fMP4.", https://developer.apple.com/documentation/http_live_streaming/http_live_streaming_hls_authoring_specification_for_apple_devices

FYI, fmp4 setting is already available in the web client:
<img width="862" alt="Screenshot 2022-11-01 at 10 12 26 AM" src="https://user-images.githubusercontent.com/109486/199282022-4107c0e6-6afe-48d0-a04d-307d1ae47d64.png">

**The new experimental option**
![IMG_0046](https://user-images.githubusercontent.com/109486/199281557-87996961-8b15-417d-b355-4732449a819e.PNG)

**HDR now works as expected on my Apple TV**
![IMG_0045](https://user-images.githubusercontent.com/109486/199281542-250ed728-1292-42a0-8818-8dac82c724b9.jpeg)
