### PR TITLE
Log decoding errors

### DIFF
--- a/Shared/ViewModels/ViewModel.swift
+++ b/Shared/ViewModels/ViewModel.swift
@@ -50,6 +50,21 @@ class ViewModel: ObservableObject {
                     networkError = .HTTPURLError(response: errorResponse, displayMessage: displayMessage)
                     logger
                         .error("Request failed: HTTP URL request failed with description: \(errorResponse.localizedDescription)")
+
+                case let .error(_, _, _, baseError as DecodingError):
+                    networkError = .JellyfinError(response: errorResponse, displayMessage: displayMessage)
+                    if case let .dataCorrupted(decodeContext) = baseError {
+                        let codingPath = decodeContext.codingPath.map(\.stringValue).joined(separator: ",")
+                        let underlyingError = decodeContext.debugDescription
+                        logger
+                            .error(
+                                "Request failed: JSON Decoding failed: Underlying Error: \(underlyingError) - Coding Path: [\(codingPath)]"
+                            )
+                    } else {
+                        logger
+                            .error("Request failed: JSON Decoding failed!")
+                    }
+
                 default:
                     networkError = .JellyfinError(response: errorResponse, displayMessage: displayMessage)
                     // Able to use user-facing friendly description here since just HTTP status codes


### PR DESCRIPTION
While debugging issue #621 I noticed the app does not log JSON decoding errors.  They are logged with an error code of 200 and description of "Unknown Error".

This patch logs the errors as a decoding error and includes the associated data to help debug such issues.  Perhaps it might also help to assign an error code (maybe -3) for such errors?