### PR TITLE
Wrong route type open search result item

### DIFF
--- a/Shared/Coordinators/SearchCoordinator.swift
+++ b/Shared/Coordinators/SearchCoordinator.swift
@@ -17,7 +17,7 @@ final class SearchCoordinator: NavigationCoordinatable {
 
     @Root
     var start = makeStart
-    @Route(.modal)
+    @Route(.push)
     var item = makeItem
     @Route(.push)
     var library = makeLibrary


### PR DESCRIPTION
If using .modal open ViewController it does not have a NavigationController so it is not possible to open child ViewControllers.
TestFlight version (78) uses .push and works fine