### PR TITLE
prevent direct play of Dolby TrueHD and DTS

### DIFF
--- a/Shared/Objects/DeviceProfileBuilder.swift
+++ b/Shared/Objects/DeviceProfileBuilder.swift
@@ -83,16 +83,6 @@ class DeviceProfileBuilder {
             )] // H.264/HEVC with Dolby Digital - No Atmos - Vision
         }
 
-        // Device supports Dolby Atmos?
-        if supportsFeature(minimumSupported: .A12) {
-            directPlayProfiles = [DirectPlayProfile(
-                container: "mov,mp4,mkv,webm",
-                audioCodec: "aac,mp3,wav,ac3,eac3,flac,truehd,dts,dca,opus",
-                videoCodec: "h264,hevc,dvhe,dvh1,h264,hevc,hev1,mpeg4,vp9",
-                type: .video
-            )] // H.264/HEVC with Dolby Digital & Atmos - Vision
-        }
-
         // Build transcoding profiles
         var transcodingProfiles: [TranscodingProfile] = []
         transcodingProfiles = [TranscodingProfile(container: "ts", type: .video, videoCodec: "h264,mpeg4", audioCodec: "aac,mp3,wav")]


### PR DESCRIPTION
AFAIK, no Apple devices support Dolby TrueHD or any DTS audio format. Some do support Dolby Atmos, but only over Dolby Digital Plus (EAC3). This PR removes the code block for A12 and up devices which wrongly assumes that they support Dolby TrueHD and DTS. This should force the Jellyfin server to transcode these kinds of audio tracks to compatible formats. Currently, they are sent to the Swiftfin client as-is, which results in no audio.

This should fix the problems described in #643 and #676. I understand that there is currently a refactor for the Device Profile Builder underway in #519, but that has been going on for 6+ months. This is meant as a hot-fix until that effort is complete.

This code HAS NOT been tested.