### PR TITLE
AirPlay should continue to work while app is backgrounded

### DIFF
--- a/Swiftfin/Info.plist
+++ b/Swiftfin/Info.plist
@@ -63,6 +63,10 @@ network.</string>
 	</dict>
 	<key>UIApplicationSupportsIndirectInputEvents</key>
 	<true/>
+	<key>UIBackgroundModes</key>
+	<array>
+		<string>audio</string>
+	</array>
 	<key>UIFileSharingEnabled</key>
 	<true/>
 	<key>UILaunchScreen</key>


### PR DESCRIPTION
This change only affects the Native Player. When the app is backgrounded while a video is playing, one of two things happens:
1. If AirPlay is active, the video continues to play on the AirPlay receiver
2. If AirPlay is not active, the video continues to play in a picture-in-picture window

Fixes https://github.com/jellyfin/Swiftfin/issues/741