### PR TITLE
Fix transcodingURL

### DIFF
--- a/Shared/Extensions/JellyfinAPI/MediaSourceInfo+ItemVideoPlayerViewModel.swift
+++ b/Shared/Extensions/JellyfinAPI/MediaSourceInfo+ItemVideoPlayerViewModel.swift
@@ -21,7 +21,7 @@ extension MediaSourceInfo {
         let streamType: StreamType
 
         if let transcodingURL, !Defaults[.Experimental.forceDirectPlay] {
-            guard let fullTranscodeURL = URL(string: "".appending(transcodingURL))
+            guard let fullTranscodeURL = URL(string: transcodingURL, relativeTo: userSession.server.currentURL)
             else { throw JellyfinAPIError("Unable to construct transcoded url") }
             playbackURL = fullTranscodeURL
             streamType = .transcode


### PR DESCRIPTION
Add server base URL to fullTranscodeURL

Fixes https://github.com/jellyfin/Swiftfin/issues/759

I am not that familiar with JellyfinAPI, so I am not sure if this is the correct method, but this seems to work. Before this fix, the URL was of the form "/videos/..." whereas normally the playbackURL starts with "http://[server info]/Videos/..."