### PR TITLE
Support for `.strm` files.

### DIFF
--- a/Shared/Coordinators/VideoPlayerCoordinator.swift
+++ b/Shared/Coordinators/VideoPlayerCoordinator.swift
@@ -33,9 +33,6 @@ final class VideoPlayerCoordinator: NavigationCoordinatable {
             Group {
                 if Defaults[.VideoPlayer.videoPlayerType] == .swiftfin {
                     VideoPlayer(manager: self.videoPlayerManager)
-                        .overlay {
-                            VideoPlayer.Overlay()
-                        }
                 } else {
                     NativeVideoPlayer(manager: self.videoPlayerManager)
                 }

--- a/Shared/Extensions/JellyfinAPI/MediaSourceInfo+ItemVideoPlayerViewModel.swift
+++ b/Shared/Extensions/JellyfinAPI/MediaSourceInfo+ItemVideoPlayerViewModel.swift
@@ -17,10 +17,12 @@ extension MediaSourceInfo {
     func videoPlayerViewModel(with item: BaseItemDto, playSessionID: String) throws -> VideoPlayerViewModel {
 
         let userSession = Container.userSession.callAsFunction()
-        let playbackURL: URL
+        let playbackURL: URL?
         let streamType: StreamType
 
-        if let transcodingURL, !Defaults[.Experimental.forceDirectPlay] {
+            playbackURL = URL(string: path)
+            streamType = .strm
+        } else if let transcodingURL, !Defaults[.Experimental.forceDirectPlay] {
             guard let fullTranscodeURL = URL(string: "".appending(transcodingURL))
             else { throw JellyfinAPIError("Unable to construct transcoded url") }
             playbackURL = fullTranscodeURL
@@ -48,7 +50,7 @@ extension MediaSourceInfo {
         let subtitleStreams = mediaStreams?.filter { $0.type == .subtitle } ?? []
 
         return .init(
-            playbackURL: playbackURL,
+            playbackURL: playbackURL!,
             item: item,
             mediaSource: self,
             playSessionID: playSessionID,

--- a/Shared/Objects/StreamType.swift
+++ b/Shared/Objects/StreamType.swift
@@ -13,6 +13,7 @@ enum StreamType: Displayable {
     case direct
     case transcode
     case hls
+    case strm
 
     var displayTitle: String {
         switch self {
@@ -22,6 +23,8 @@ enum StreamType: Displayable {
             return "Transcode"
         case .hls:
             return "HLS"
+        case .strm:
+            return "STRM"
         }
     }
 }

--- a/Shared/ViewModels/VideoPlayerManager.swift
+++ b/Shared/ViewModels/VideoPlayerManager.swift
@@ -188,13 +188,7 @@ class VideoPlayerManager: ViewModel {
             let request = Paths.reportPlaybackStart(startInfo)
             let _ = try await userSession.client.send(request)
 
-            let progressTask = DispatchWorkItem {
-                self.sendProgressReport()
-            }
-
-            currentProgressWorkItem = progressTask
-
-            DispatchQueue.main.asyncAfter(deadline: .now() + 5, execute: progressTask)
+            self.sendProgressReport()
         }
     }
 

--- a/Shared/ViewModels/VideoPlayerViewModel.swift
+++ b/Shared/ViewModels/VideoPlayerViewModel.swift
@@ -34,7 +34,7 @@ class VideoPlayerViewModel: ViewModel {
         let userSession = Container.userSession.callAsFunction()
 
         let parameters = Paths.GetMasterHlsVideoPlaylistParameters(
-            isStatic: true,
+            isStatic: streamType == .strm ? false : true,
             tag: mediaSource.eTag,
             playSessionID: playSessionID,
             segmentContainer: segmentContainer,
@@ -60,6 +60,8 @@ class VideoPlayerViewModel: ViewModel {
 
         let hlsStreamComponents = URLComponents(url: userSession.client.fullURL(with: request), resolvingAgainstBaseURL: false)!
             .addingQueryItem(key: "api_key", value: userSession.user.accessToken)
+        
+        print(hlsStreamComponents.url!)
 
         return hlsStreamComponents.url!
     }

--- a/Swiftfin/Views/VideoPlayer/Overlays/Components/ActionButtons/AudioActionButton.swift
+++ b/Swiftfin/Views/VideoPlayer/Overlays/Components/ActionButtons/AudioActionButton.swift
@@ -37,6 +37,9 @@ extension VideoPlayer.Overlay.ActionButtons {
                         }
                     }
                 }
+                .onAppear {
+                    videoPlayerManager.audioTrackIndex = viewModel.selectedAudioStreamIndex
+                }
             } label: {
                 content(videoPlayerManager.audioTrackIndex != -1)
                     .eraseToAnyView()

--- a/Swiftfin/Views/VideoPlayer/Overlays/Components/ActionButtons/SubtitleActionButton.swift
+++ b/Swiftfin/Views/VideoPlayer/Overlays/Components/ActionButtons/SubtitleActionButton.swift
@@ -37,6 +37,9 @@ extension VideoPlayer.Overlay.ActionButtons {
                         }
                     }
                 }
+                .onAppear {
+                    videoPlayerManager.subtitleTrackIndex = viewModel.selectedSubtitleStreamIndex
+                }
             } label: {
                 content(videoPlayerManager.subtitleTrackIndex != -1)
                     .eraseToAnyView()

--- a/Swiftfin/Views/VideoPlayer/VideoPlayer.swift
+++ b/Swiftfin/Views/VideoPlayer/VideoPlayer.swift
@@ -254,7 +254,7 @@ extension VideoPlayer {
         self.init(
             currentProgressHandler: manager.currentProgressHandler,
             videoPlayerManager: manager,
-            overlay: { EmptyView() }
+            overlay: { VideoPlayer.Overlay() }
         )
     }
 


### PR DESCRIPTION
# Rationale

My whole library consists of `.strm` files. This makes Swiftfin pretty much useless for me in the current state, which is a shame, because I really love the idea of Swiftfin.

# The Plan
The `.strm` file extension and file type is natively supported by Jellyfin. They are files that contain a single line with a streaming URL. Ideally, this streaming URL should be played back directly on the client device itself, without any involvement from the transcoding or remuxing engine of the Jellyfin server. This is why my focus will be on the VLC player, not the native player, as the VLC player can support many more file types out of the box.

The easiest solution seems to:
1. Check if the requested media is indeed in `.strm` format.
2. Plug the URL from that `.strm` file directly into the native player or VLCKit player (the `path` property of `MediaSourceInfo` contains this URL out of the box).

## VLC `VideoPlayer`
The VLC video player functionality just consists of checking if a file is a `.strm` file (by checking if the `path` property of `MediaSourceInfo` starts with `http(s)://` and playing it back directly.

## `NativeVideoPlayer`
Here, the only change needed is to set the `isStatic` property in `hlsPlaybackUrl` of the `VideoPlayerManager` to false when it is requesting an HLS stream of an `.strm` file. However, subtitles are a little more complicated, as subtitles cannot directly be injected into the `AVPlayer` instance. I will need to do a deeper dive into the Apple documentation to figure out how to combine the `master.m3u8` stream of the video with the `subtitles.m3u8` stream of the subtitles.