### PR TITLE
Add subtitle support to `NativeVideoPlayer`

### DIFF
--- a/Shared/Coordinators/VideoPlayerCoordinator.swift
+++ b/Shared/Coordinators/VideoPlayerCoordinator.swift
@@ -33,9 +33,6 @@ final class VideoPlayerCoordinator: NavigationCoordinatable {
             Group {
                 if Defaults[.VideoPlayer.videoPlayerType] == .swiftfin {
                     VideoPlayer(manager: self.videoPlayerManager)
-                        .overlay {
-                            VideoPlayer.Overlay()
-                        }
                 } else {
                     NativeVideoPlayer(manager: self.videoPlayerManager)
                 }

--- a/Shared/Extensions/JellyfinAPI/MediaSourceInfo+ItemVideoPlayerViewModel.swift
+++ b/Shared/Extensions/JellyfinAPI/MediaSourceInfo+ItemVideoPlayerViewModel.swift
@@ -17,10 +17,12 @@ extension MediaSourceInfo {
     func videoPlayerViewModel(with item: BaseItemDto, playSessionID: String) throws -> VideoPlayerViewModel {
 
         let userSession = Container.userSession.callAsFunction()
-        let playbackURL: URL
+        let playbackURL: URL?
         let streamType: StreamType
 
-        if let transcodingURL, !Defaults[.Experimental.forceDirectPlay] {
+            playbackURL = URL(string: path)
+            streamType = .strm
+        } else if let transcodingURL, !Defaults[.Experimental.forceDirectPlay] {
             guard let fullTranscodeURL = URL(string: "".appending(transcodingURL))
             else { throw JellyfinAPIError("Unable to construct transcoded url") }
             playbackURL = fullTranscodeURL
@@ -48,7 +50,7 @@ extension MediaSourceInfo {
         let subtitleStreams = mediaStreams?.filter { $0.type == .subtitle } ?? []
 
         return .init(
-            playbackURL: playbackURL,
+            playbackURL: playbackURL!,
             item: item,
             mediaSource: self,
             playSessionID: playSessionID,

--- a/Shared/Objects/StreamType.swift
+++ b/Shared/Objects/StreamType.swift
@@ -13,6 +13,7 @@ enum StreamType: Displayable {
     case direct
     case transcode
     case hls
+    case strm
 
     var displayTitle: String {
         switch self {
@@ -22,6 +23,8 @@ enum StreamType: Displayable {
             return "Transcode"
         case .hls:
             return "HLS"
+        case .strm:
+            return "STRM"
         }
     }
 }

--- a/Shared/ViewModels/VideoPlayerManager.swift
+++ b/Shared/ViewModels/VideoPlayerManager.swift
@@ -188,13 +188,7 @@ class VideoPlayerManager: ViewModel {
             let request = Paths.reportPlaybackStart(startInfo)
             let _ = try await userSession.client.send(request)
 
-            let progressTask = DispatchWorkItem {
-                self.sendProgressReport()
-            }
-
-            currentProgressWorkItem = progressTask
-
-            DispatchQueue.main.asyncAfter(deadline: .now() + 5, execute: progressTask)
+            self.sendProgressReport()
         }
     }
 

--- a/Shared/ViewModels/VideoPlayerViewModel.swift
+++ b/Shared/ViewModels/VideoPlayerViewModel.swift
@@ -45,6 +45,7 @@ class VideoPlayerViewModel: ViewModel {
                 .compactMap(\.codec)
                 .joined(separator: ","),
             isBreakOnNonKeyFrames: true,
+            subtitleMethod: SubtitleDeliveryMethod.hls,
             requireAvc: false,
             transcodingMaxAudioChannels: 6,
             videoCodec: videoStreams

--- a/Shared/ViewModels/VideoPlayerViewModel.swift
+++ b/Shared/ViewModels/VideoPlayerViewModel.swift
@@ -34,7 +34,7 @@ class VideoPlayerViewModel: ViewModel {
         let userSession = Container.userSession.callAsFunction()
 
         let parameters = Paths.GetMasterHlsVideoPlaylistParameters(
-            isStatic: true,
+            isStatic: streamType == .strm ? false : true,
             tag: mediaSource.eTag,
             playSessionID: playSessionID,
             segmentContainer: segmentContainer,
@@ -60,6 +60,8 @@ class VideoPlayerViewModel: ViewModel {
 
         let hlsStreamComponents = URLComponents(url: userSession.client.fullURL(with: request), resolvingAgainstBaseURL: false)!
             .addingQueryItem(key: "api_key", value: userSession.user.accessToken)
+        
+        print(hlsStreamComponents.url!)
 
         return hlsStreamComponents.url!
     }

--- a/Swiftfin/Views/VideoPlayer/Overlays/Components/ActionButtons/AudioActionButton.swift
+++ b/Swiftfin/Views/VideoPlayer/Overlays/Components/ActionButtons/AudioActionButton.swift
@@ -37,6 +37,9 @@ extension VideoPlayer.Overlay.ActionButtons {
                         }
                     }
                 }
+                .onAppear {
+                    videoPlayerManager.audioTrackIndex = viewModel.selectedAudioStreamIndex
+                }
             } label: {
                 content(videoPlayerManager.audioTrackIndex != -1)
                     .eraseToAnyView()

--- a/Swiftfin/Views/VideoPlayer/Overlays/Components/ActionButtons/SubtitleActionButton.swift
+++ b/Swiftfin/Views/VideoPlayer/Overlays/Components/ActionButtons/SubtitleActionButton.swift
@@ -37,6 +37,9 @@ extension VideoPlayer.Overlay.ActionButtons {
                         }
                     }
                 }
+                .onAppear {
+                    videoPlayerManager.subtitleTrackIndex = viewModel.selectedSubtitleStreamIndex
+                }
             } label: {
                 content(videoPlayerManager.subtitleTrackIndex != -1)
                     .eraseToAnyView()

--- a/Swiftfin/Views/VideoPlayer/VideoPlayer.swift
+++ b/Swiftfin/Views/VideoPlayer/VideoPlayer.swift
@@ -254,7 +254,7 @@ extension VideoPlayer {
         self.init(
             currentProgressHandler: manager.currentProgressHandler,
             videoPlayerManager: manager,
-            overlay: { EmptyView() }
+            overlay: { VideoPlayer.Overlay() }
         )
     }
 


### PR DESCRIPTION
> Basing this branch on #766, because media playback is broken on the `main` branch.

# Rationale
Currently, the native video player does not support subtitles, while `AVPlayer` and the Jellyfin API both support HLS subtitles.

> See the [Apple Documentation](https://developer.apple.com/documentation/http_live_streaming/example_playlists_for_http_live_streaming/adding_alternate_media_to_a_playlist) for an example of the `master.m3u8` that `AVPlayer` accepts.

To enable this feature, only one line of configuration needs to be added to in `VideoPlayerViewModel.swift`. (see [commit](https://github.com/jellyfin/Swiftfin/commit/9d8ffbc9551d62bba79e75af2db1ec5231b79875)) 

However, this results in a less-than-ideal user experience. I've found two cases of such an experience **for embedded subtitles**:
1. **Case: Subtitles don't show up for an extended period of time**. This is due to the fact that it seems that the `AVPlayer` requests the segments of the subtitles WebVTT file chronologically. Each time a new segment is requested, `ffmpeg` runs on the Jellyfin server for that segment of the video. This takes some time, so if the playback is started in the middle of a movie, many `ffmpeg` calls need to be made before the subtitles "catch up" to the current point in time of playback progress.
2. **Case: Subtitles disappear for some period of time before coming back again**. This seems to be a problem specifically for `.strm` files, where the media server has a rate limit or is offline for a few seconds for other reasons. Then, when the ffmpeg call for the subtitle segment happens, the request fails silently, resulting in no subtitle data for that specific segment.

# The Plan

I first need to confirm my suspicions: look in depth at the network requests on the client side and cross reference Jellyfin server logs.

After that, it seems that the most straightforward solution is to make sure that the `SegmentLength` of the subtitle request call the length of the entire media file. This is because it is not possible to modify this via a request parameter. The only segment length that can be modified is that of the video stream itself.

If the segment length of the subtitle request is the entire length of the media, `AVPlayer` will download the entire WebVTT file in one go. Monitoring this initial request and retrying if necessary, will result in a bug free experience when using subtitles in Native Player mode.

The goal is to intercept the AVPlayer request to the `master.m3u8` file, by extending `AVAssetResourceLoaderDelegate`, then changing the segmentLength URI component in the subtitle URI to be the length of the entire file.

There honestly might be a better way. I haven't looked into this for a considerable amount of time and I'm new to the whole Jellyfin ecosystem. So please don't hesitate to correct me! 🙂 


# Examples of the files in question
## Example of `master.m3u8`
```
#EXTM3U

#EXT-X-MEDIA:TYPE=SUBTITLES,GROUP-ID="subs",NAME="English - ASS",DEFAULT=NO,FORCED=NO,AUTOSELECT=YES,URI="[MediaSourceId]/Subtitles/[SubtitleIndex]/subtitles.m3u8?SegmentLength=[THIS_NEEDS_CHANGING!!! Default is 30]&api_key=[APIKey]",LANGUAGE="eng"

#EXT-X-STREAM-INF:BANDWIDTH=768000,AVERAGE-BANDWIDTH=768000,VIDEO-RANGE=SDR,CODECS="avc1.640028,mp4a.a5",RESOLUTION=1280x720,FRAME-RATE=23.976,SUBTITLES="subs"
main.m3u8?SubtitleMethod=hls&api_key=[APIKey]&mediaSourceId=[MediaSourceId]
```

## Example of `subtitles.m3u8`

```
#EXTM3U
#EXT-X-TARGETDURATION:200000
#EXT-X-VERSION:3
#EXT-X-MEDIA-SEQUENCE:0
#EXT-X-PLAYLIST-TYPE:VOD
#EXTINF:3477.113,
stream.vtt?CopyTimestamps=true&AddVttTimeMap=true&StartPositionTicks=0&EndPositionTicks=34771130000&api_key=[APIKey]
#EXT-X-ENDLIST
```