### PR TITLE
Fix Video Player Overlay

### DIFF
--- a/Shared/Coordinators/VideoPlayerCoordinator.swift
+++ b/Shared/Coordinators/VideoPlayerCoordinator.swift
@@ -33,9 +33,6 @@ final class VideoPlayerCoordinator: NavigationCoordinatable {
             Group {
                 if Defaults[.VideoPlayer.videoPlayerType] == .swiftfin {
                     VideoPlayer(manager: self.videoPlayerManager)
-                        .overlay {
-                            VideoPlayer.Overlay()
-                        }
                 } else {
                     NativeVideoPlayer(manager: self.videoPlayerManager)
                 }

--- a/Swiftfin/Views/VideoPlayer/VideoPlayer.swift
+++ b/Swiftfin/Views/VideoPlayer/VideoPlayer.swift
@@ -101,7 +101,6 @@ struct VideoPlayer: View {
 
     private let gestureStateHandler: GestureStateHandler = .init()
     private let updateViewProxy: UpdateViewProxy = .init()
-    private var overlay: () -> any View
 
     @ViewBuilder
     private var playerView: some View {
@@ -155,19 +154,16 @@ struct VideoPlayer: View {
                             }
                         }
 
-                    Group {
-                        overlay()
-                            .eraseToAnyView()
-                    }
-                    .environmentObject(splitContentViewProxy)
-                    .environmentObject(videoPlayerManager)
-                    .environmentObject(videoPlayerManager.currentProgressHandler)
-                    .environmentObject(videoPlayerManager.currentViewModel!)
-                    .environmentObject(videoPlayerManager.proxy)
-                    .environment(\.aspectFilled, $isAspectFilled)
-                    .environment(\.isPresentingOverlay, $isPresentingOverlay)
-                    .environment(\.isScrubbing, $isScrubbing)
-                    .environment(\.playbackSpeed, $playbackSpeed)
+                    VideoPlayer.Overlay()
+                        .environmentObject(splitContentViewProxy)
+                        .environmentObject(videoPlayerManager)
+                        .environmentObject(videoPlayerManager.currentProgressHandler)
+                        .environmentObject(videoPlayerManager.currentViewModel!)
+                        .environmentObject(videoPlayerManager.proxy)
+                        .environment(\.aspectFilled, $isAspectFilled)
+                        .environment(\.isPresentingOverlay, $isPresentingOverlay)
+                        .environment(\.isScrubbing, $isScrubbing)
+                        .environment(\.playbackSpeed, $playbackSpeed)
                 }
             }
             .splitContent {
@@ -253,13 +249,8 @@ extension VideoPlayer {
     init(manager: VideoPlayerManager) {
         self.init(
             currentProgressHandler: manager.currentProgressHandler,
-            videoPlayerManager: manager,
-            overlay: { EmptyView() }
+            videoPlayerManager: manager   
         )
-    }
-
-    func overlay(@ViewBuilder _ content: @escaping () -> any View) -> Self {
-        copy(modifying: \.overlay, with: content)
     }
 }
 

--- a/Swiftfin/Views/VideoPlayer/VideoPlayer.swift
+++ b/Swiftfin/Views/VideoPlayer/VideoPlayer.swift
@@ -249,7 +249,7 @@ extension VideoPlayer {
     init(manager: VideoPlayerManager) {
         self.init(
             currentProgressHandler: manager.currentProgressHandler,
-            videoPlayerManager: manager   
+            videoPlayerManager: manager
         )
     }
 }


### PR DESCRIPTION
- Closes #768

Fixes the crash when playing a video using the Swiftfin video player. I chose a bad name (`overlay`) and it instead uses the `SwiftUI.overlay` function. This worked in 5.7 and broke in 5.8, but it's good this happened anyways.

The original intent with the passed overlay was that we could use the video player in many contexts that aren't TV episodes or movies, like live tv (which is how it works today), and just use a different overlay for each. For example, it would be very cool if live tv had a different overlay for a live tv context (LIVE, guide, etc.)

However, the `VideoPlayer` implementation heavily depends on `VideoPlayer.Overlay` when being used for gestures and actions, which may not make sense in all contexts ... maybe. For now, everything will use the same overlay and when someone wants to make a custom overlay for live tv, the entire video player layer will be a separate view/implementation.