### PR TITLE
Update ci.yml

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,6 +53,7 @@ jobs:
         with:
           max_attempts: 3
           retry_on: error
+          timeout_minutes: 60
           command: |
             xcodebuild build -project "Swiftfin.xcodeproj" \
             -scheme "${{ matrix.scheme }}" \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,7 @@ on:
     branches: [ main ]
   pull_request:
     types:
+      - opened
       - synchronize
       - ready_for_review
     branches: [ main ]
@@ -46,9 +47,13 @@ jobs:
           key: ${{ runner.os }}-${{ matrix.scheme }}-spm-${{ hashFiles('**/Package.resolved') }}
           restore-keys: ${{ runner.os }}-${{ matrix.scheme }}-spm-
       
-      - name: xcodebuild!
-        run: |
-          xcodebuild build -project "Swiftfin.xcodeproj" \
-          -scheme "${{ matrix.scheme }}" \
-          CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO          
+      - name: Build
+        uses: nick-fields/retry@v2
+        with:
+          max_attempts: 3
+          retry_on: error
+          command: |
+            xcodebuild build -project "Swiftfin.xcodeproj" \
+            -scheme "${{ matrix.scheme }}" \
+            CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO          
       

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,7 @@ on:
   pull_request:
     types:
       - opened
+      - reopened
       - synchronize
       - ready_for_review
     branches: [ main ]

--- a/.github/workflows/lint-pr.yaml
+++ b/.github/workflows/lint-pr.yaml
@@ -3,6 +3,8 @@ name: "Lint 🧹"
 on:
   pull_request:
     types:
+      - opened
+      - reopened
       - synchronize
       - ready_for_review
     branches: [ main ]


### PR DESCRIPTION
- [x] run CI on opened PRs
	- verified by having this PR go straight to opened and checks ran
- [x] attempt to build correctly
	- implementing retries gets the build system part way the first time with VLCKit + VLCUI, and then finalizes the second time. To be clear, I still see the entire VLCUI system as merely a trick of SPM + libraries so if this becomes a problem in the future I will instead just copy the files over.