### PR TITLE
Enable PiP on Native Player

### DIFF
--- a/Swiftfin/Info.plist
+++ b/Swiftfin/Info.plist
@@ -63,6 +63,10 @@ network.</string>
 	</dict>
 	<key>UIApplicationSupportsIndirectInputEvents</key>
 	<true/>
+	<key>UIBackgroundModes</key>
+	<array>
+		<string>audio</string>
+	</array>
 	<key>UIFileSharingEnabled</key>
 	<true/>
 	<key>UILaunchScreen</key>

--- a/Swiftfin/Views/VideoPlayer/NativeVideoPlayer.swift
+++ b/Swiftfin/Views/VideoPlayer/NativeVideoPlayer.swift
@@ -72,6 +72,9 @@ class UINativeVideoPlayerViewController: AVPlayerViewController {
         newPlayer.allowsExternalPlayback = true
         newPlayer.appliesMediaSelectionCriteriaAutomatically = false
         newPlayer.currentItem?.externalMetadata = createMetadata()
+        
+        // enable pip
+        allowsPictureInPicturePlayback = true
 
         rateObserver = newPlayer.observe(\.rate, options: .new) { _, change in
             guard let newValue = change.newValue else { return }

--- a/Swiftfin/Views/VideoPlayer/NativeVideoPlayer.swift
+++ b/Swiftfin/Views/VideoPlayer/NativeVideoPlayer.swift
@@ -72,7 +72,7 @@ class UINativeVideoPlayerViewController: AVPlayerViewController {
         newPlayer.allowsExternalPlayback = true
         newPlayer.appliesMediaSelectionCriteriaAutomatically = false
         newPlayer.currentItem?.externalMetadata = createMetadata()
-        
+
         // enable pip
         allowsPictureInPicturePlayback = true
 


### PR DESCRIPTION
Enable Picture in Picture in a native player.

# Preview
## PiP Button on the player
![Simulator Screen Shot - iPad mini (6th generation) - 2023-06-05 at 02 40 38](https://github.com/jellyfin/Swiftfin/assets/16457495/7c27d3c5-ad94-49ec-bea4-3715234a85f8)

## PiP in Action
![Simulator Screen Shot - iPad mini (6th generation) - 2023-06-05 at 02 40 43](https://github.com/jellyfin/Swiftfin/assets/16457495/001d6eab-d641-4139-97d8-aad6638f4708)

# Additional
need to enable `Audio, AirPlay, and Picture in Picture` in `Background Modes` on capabilities
<img width="1512" alt="Screenshot 2023-06-05 at 02 43 06" src="https://github.com/jellyfin/Swiftfin/assets/16457495/8d79a20e-d8cc-45fb-a280-471c9b5d3517">
