### PR TITLE
Hide system overlays in player

### DIFF
--- a/Swiftfin/Extensions/View/iOSViewExtensions.swift
+++ b/Swiftfin/Extensions/View/iOSViewExtensions.swift
@@ -62,4 +62,10 @@ extension View {
             }
         }
     }
+    
+    /// Runs arbitrary code before returning a modified view. Taken from:
+    /// https://blog.overdesigned.net/posts/2020-09-23-swiftui-availability/
+    func modify<T: View>(@ViewBuilder _ modifier: (Self) -> T) -> some View {
+        return modifier(self)
+    }
 }

--- a/Swiftfin/Views/VideoPlayer/VideoPlayer.swift
+++ b/Swiftfin/Views/VideoPlayer/VideoPlayer.swift
@@ -242,6 +242,14 @@ struct VideoPlayer: View {
             audioOffset = 0
             subtitleOffset = 0
         }
+        .modify {
+//            Fixes #582
+            if #available(iOS 16.0, *) {
+                $0.persistentSystemOverlays(.hidden)
+            } else {
+                $0
+            }
+        }
     }
 }
 


### PR DESCRIPTION
Fixes #582.

Looks like iOS 16 added a new modifier that threw off whatever you were doing before :)