### PR TITLE
Fix Debug Settings

### DIFF
--- a/Shared/Coordinators/SettingsCoordinator.swift
+++ b/Shared/Coordinators/SettingsCoordinator.swift
@@ -39,6 +39,11 @@ final class SettingsCoordinator: NavigationCoordinatable {
     var serverDetail = makeServerDetail
     @Route(.push)
     var videoPlayerSettings = makeVideoPlayerSettings
+
+    #if DEBUG
+    @Route(.push)
+    var debugSettings = makeDebugSettings
+    #endif
     #endif
 
     #if os(tvOS)
@@ -102,6 +107,13 @@ final class SettingsCoordinator: NavigationCoordinatable {
     func makeServerDetail(server: ServerState) -> some View {
         ServerDetailView(viewModel: .init(server: server))
     }
+
+    #if DEBUG
+    @ViewBuilder
+    func makeDebugSettings() -> some View {
+        DebugSettingsView()
+    }
+    #endif
 
     func makeVideoPlayerSettings() -> VideoPlayerSettingsCoordinator {
         VideoPlayerSettingsCoordinator()

--- a/Shared/Services/SwiftfinDefaults.swift
+++ b/Shared/Services/SwiftfinDefaults.swift
@@ -214,6 +214,6 @@ extension UserDefaults {
 
 extension Defaults.Keys {
 
-    static let sendProgressReports: Key<Bool> = .init("sendProgressReports", default: false, suite: .debugSuite)
+    static let sendProgressReports: Key<Bool> = .init("sendProgressReports", default: true, suite: .debugSuite)
 }
 #endif

--- a/Swiftfin/Views/SettingsView/DebugSettingsView.swift
+++ b/Swiftfin/Views/SettingsView/DebugSettingsView.swift
@@ -20,6 +20,7 @@ struct DebugSettingsView: View {
 
             Toggle("Send Progress Reports", isOn: $sendProgressReports)
         }
+        .navigationTitle("Debug")
     }
 }
 #endif

--- a/Swiftfin/Views/SettingsView/SettingsView.swift
+++ b/Swiftfin/Views/SettingsView/SettingsView.swift
@@ -116,6 +116,15 @@ struct SettingsView: View {
                 .onSelect {
                     router.route(to: \.log)
                 }
+
+            #if DEBUG
+
+            ChevronButton(title: "Debug")
+                .onSelect {
+                    router.route(to: \.debugSettings)
+                }
+
+            #endif
         }
         .navigationBarTitle(L10n.settings)
         .navigationBarTitleDisplayMode(.inline)


### PR DESCRIPTION
Disabling report sending is very helpful while debugging the video player and there may be more debug settings added in the future.

- accidentally had the report sending default to `false`
- forgot to add the settings view to toggle it