### PR TITLE
Fix nested button in tvOS

### DIFF
--- a/Swiftfin tvOS/Views/ServerListView.swift
+++ b/Swiftfin tvOS/Views/ServerListView.swift
@@ -83,17 +83,13 @@ struct ServerListView: View {
                     Button {
                         router.route(to: \.connectToServer)
                     } label: {
-                        Button {
-                            router.route(to: \.connectToServer)
-                        } label: {
-                            L10n.connect.text
-                                .bold()
-                                .font(.callout)
-                                .frame(width: 400, height: 75)
-                                .background(Color.jellyfinPurple)
-                        }
-                        .buttonStyle(.card)
+                        L10n.connect.text
+                            .bold()
+                            .font(.callout)
+                            .frame(width: 400, height: 75)
+                            .background(Color.jellyfinPurple)
                     }
+                    .buttonStyle(.card)
                 }
             }
             .contentView {}


### PR DESCRIPTION
Fixed a part of the tvOS code where a button's label was another button, which affected the focus highlighting and text color. You can see the difference by running in the simulator with no servers connected. It's the very first "Connect" button, shown before the screen where you connect to a server.

This is my first PR for Swiftfin, LMK if I missed a step of the process.