### PR TITLE
Minor UI fixes, force orientation

### DIFF
--- a/Shared/Coordinators/VideoPlayerCoordinator.swift
+++ b/Shared/Coordinators/VideoPlayerCoordinator.swift
@@ -41,9 +41,9 @@ final class VideoPlayerCoordinator: NavigationCoordinatable {
         }
         .ignoresSafeArea()
         .hideSystemOverlays()
-//        .onAppear {
-//            AppDelegate.changeOrientation(.landscape)
-//        }
+        .onAppear {
+            AppDelegate.enterPlaybackOrientation()
+        }
 
         #else
 

--- a/Swiftfin/App/AppDelegate.swift
+++ b/Swiftfin/App/AppDelegate.swift
@@ -38,17 +38,37 @@ class AppDelegate: NSObject, UIApplicationDelegate {
         AppDelegate.orientationLock
     }
 
-    static func changeOrientation(_ orientation: UIInterfaceOrientationMask) {
+    static func enterPlaybackOrientation() {
+        AppDelegate.changeOrientation(.landscape)
+    }
 
-//        guard UIDevice.isPhone else { return }
-//
-//        Self.orientationLock = orientation
-//
-//        if #available(iOS 16, *) {
-//            let windowScene = UIApplication.shared.connectedScenes.first as? UIWindowScene
-//            windowScene?.requestGeometryUpdate(.iOS(interfaceOrientations: orientation))
-//        } else {
-//            UIDevice.current.setValue(UIInterfaceOrientation.landscapeRight.rawValue, forKey: "orientation")
-//        }
+    static func leavePlaybackOrientation() {
+        if UIDevice.isIPad {
+            AppDelegate.changeOrientation(.allButUpsideDown)
+        } else {
+            // On iPhone, users likely want to return to portrait mode after leaving playback.
+            // However, we don't want to lock them into portrait mode, so switch back after a delay.
+            AppDelegate.changeOrientation(.portrait)
+
+            // 0.25 seconds is about the time to switch from landscape to portrait.
+            // Changing orientation again too early will cause the top time/battery bar to remain
+            // at the side instead of moving up top, like it should.
+            DispatchQueue.main.asyncAfter(deadline: .now() + 0.25) {
+                AppDelegate.changeOrientation(.allButUpsideDown)
+            }
+        }
+    }
+
+    private static func changeOrientation(_ orientation: UIInterfaceOrientationMask) {
+        guard UIDevice.isPhone || UIDevice.isIPad else { return }
+
+        orientationLock = orientation
+
+        if #available(iOS 16, *) {
+            let windowScene = UIApplication.shared.connectedScenes.first as? UIWindowScene
+            windowScene?.requestGeometryUpdate(.iOS(interfaceOrientations: orientation))
+        } else {
+            UIDevice.current.setValue(UIInterfaceOrientation.landscapeRight.rawValue, forKey: "orientation")
+        }
     }
 }

--- a/Swiftfin/Views/VideoPlayer/Overlays/ChapterOverlay.swift
+++ b/Swiftfin/Views/VideoPlayer/Overlays/ChapterOverlay.swift
@@ -65,8 +65,7 @@ extension VideoPlayer.Overlay {
                             .foregroundColor(accentColor)
                     }
                 }
-                .padding(.leading, safeAreaInsets.leading)
-                .padding(.trailing, safeAreaInsets.trailing)
+                .padding(.horizontal)
 
                 ScrollViewReader { proxy in
                     ScrollView(.horizontal, showsIndicators: false) {
@@ -115,8 +114,6 @@ extension VideoPlayer.Overlay {
                                 }
                             }
                         }
-                        .padding(.leading, safeAreaInsets.leading)
-                        .padding(.trailing, safeAreaInsets.trailing)
                         .padding(.bottom)
                     }
                     .onChange(of: currentOverlayType) { newValue in
@@ -142,6 +139,8 @@ extension VideoPlayer.Overlay {
                 )
                 .allowsHitTesting(false)
             }
+            .padding(.leading, safeAreaInsets.leading)
+            .padding(.trailing, safeAreaInsets.trailing)
         }
     }
 }

--- a/Swiftfin/Views/VideoPlayer/Overlays/ChapterOverlay.swift
+++ b/Swiftfin/Views/VideoPlayer/Overlays/ChapterOverlay.swift
@@ -65,7 +65,8 @@ extension VideoPlayer.Overlay {
                             .foregroundColor(accentColor)
                     }
                 }
-                .padding(.horizontal)
+                .padding(.leading, UIDevice.isIPad ? nil : safeAreaInsets.leading)
+                .padding(.trailing, UIDevice.isIPad ? nil : safeAreaInsets.trailing)
 
                 ScrollViewReader { proxy in
                     ScrollView(.horizontal, showsIndicators: false) {
@@ -114,6 +115,8 @@ extension VideoPlayer.Overlay {
                                 }
                             }
                         }
+                        .padding(.leading, safeAreaInsets.leading)
+                        .padding(.trailing, safeAreaInsets.trailing)
                         .padding(.bottom)
                     }
                     .onChange(of: currentOverlayType) { newValue in
@@ -139,8 +142,6 @@ extension VideoPlayer.Overlay {
                 )
                 .allowsHitTesting(false)
             }
-            .padding(.leading, safeAreaInsets.leading)
-            .padding(.trailing, safeAreaInsets.trailing)
         }
     }
 }

--- a/Swiftfin/Views/VideoPlayer/Overlays/ChapterOverlay.swift
+++ b/Swiftfin/Views/VideoPlayer/Overlays/ChapterOverlay.swift
@@ -65,8 +65,11 @@ extension VideoPlayer.Overlay {
                             .foregroundColor(accentColor)
                     }
                 }
-                .padding(.leading, UIDevice.isIPad ? nil : safeAreaInsets.leading)
-                .padding(.trailing, UIDevice.isIPad ? nil : safeAreaInsets.trailing)
+                .padding(.leading, safeAreaInsets.leading)
+                .padding(.trailing, safeAreaInsets.trailing)
+                .if(UIDevice.isIPad) { view in
+                    view.padding(.horizontal)
+                }
 
                 ScrollViewReader { proxy in
                     ScrollView(.horizontal, showsIndicators: false) {
@@ -118,6 +121,9 @@ extension VideoPlayer.Overlay {
                         .padding(.leading, safeAreaInsets.leading)
                         .padding(.trailing, safeAreaInsets.trailing)
                         .padding(.bottom)
+                        .if (UIDevice.isIPad) { view in
+                            view.padding(.horizontal)
+                        }
                     }
                     .onChange(of: currentOverlayType) { newValue in
                         guard newValue == .chapters else { return }

--- a/Swiftfin/Views/VideoPlayer/Overlays/ChapterOverlay.swift
+++ b/Swiftfin/Views/VideoPlayer/Overlays/ChapterOverlay.swift
@@ -121,7 +121,7 @@ extension VideoPlayer.Overlay {
                         .padding(.leading, safeAreaInsets.leading)
                         .padding(.trailing, safeAreaInsets.trailing)
                         .padding(.bottom)
-                        .if (UIDevice.isIPad) { view in
+                        .if(UIDevice.isIPad) { view in
                             view.padding(.horizontal)
                         }
                     }

--- a/Swiftfin/Views/VideoPlayer/Overlays/Components/ActionButtons/AspectFillActionButton.swift
+++ b/Swiftfin/Views/VideoPlayer/Overlays/Components/ActionButtons/AspectFillActionButton.swift
@@ -38,6 +38,7 @@ extension VideoPlayer.Overlay.ActionButtons {
                     UIView.animate(withDuration: 0.2) {
                         videoPlayerProxy.aspectFill(1)
                     }
+
                 }
             } label: {
                 content(aspectFilled).eraseToAnyView()

--- a/Swiftfin/Views/VideoPlayer/Overlays/Components/ActionButtons/AspectFillActionButton.swift
+++ b/Swiftfin/Views/VideoPlayer/Overlays/Components/ActionButtons/AspectFillActionButton.swift
@@ -38,7 +38,6 @@ extension VideoPlayer.Overlay.ActionButtons {
                     UIView.animate(withDuration: 0.2) {
                         videoPlayerProxy.aspectFill(1)
                     }
-
                 }
             } label: {
                 content(aspectFilled).eraseToAnyView()

--- a/Swiftfin/Views/VideoPlayer/Overlays/Components/TopBarView.swift
+++ b/Swiftfin/Views/VideoPlayer/Overlays/Components/TopBarView.swift
@@ -29,9 +29,8 @@ extension VideoPlayer.Overlay {
                 HStack(alignment: .center) {
                     Button {
                         videoPlayerProxy.stop()
-                        router.dismissCoordinator {
-                            AppDelegate.changeOrientation(.portrait)
-                        }
+                        AppDelegate.leavePlaybackOrientation()
+                        router.dismissCoordinator()
                     } label: {
                         Image(systemName: "xmark")
                             .padding()

--- a/Swiftfin/Views/VideoPlayer/Overlays/Components/TopBarView.swift
+++ b/Swiftfin/Views/VideoPlayer/Overlays/Components/TopBarView.swift
@@ -36,6 +36,7 @@ extension VideoPlayer.Overlay {
                         Image(systemName: "xmark")
                             .padding()
                     }
+                    .contentShape(Rectangle())
                     .buttonStyle(ScalingButtonStyle(scale: 0.8))
 
                     Text(viewModel.item.displayTitle)

--- a/Swiftfin/Views/VideoPlayer/VideoPlayer.swift
+++ b/Swiftfin/Views/VideoPlayer/VideoPlayer.swift
@@ -130,9 +130,8 @@ struct VideoPlayer: View {
                                 {
                                     videoPlayerManager.selectNextViewModel()
                                 } else {
-                                    router.dismissCoordinator {
-                                        AppDelegate.changeOrientation(.portrait)
-                                    }
+                                    AppDelegate.leavePlaybackOrientation()
+                                    router.dismissCoordinator()
                                 }
                             }
                         }


### PR DESCRIPTION
# Purpose

1. X button to close video player had too small of a clickable area
2. "Chapters" and "Current" text in chapter select menu had too little padding on iPad
3. Portrait orientation was allowed during video playback
  a. UI barely fit on small screens; even worse when trying to open "Advanced" menu
  b. On iPad, changing from landscape to portrait caused major problems that forced closing the app

## Related images/videos


<img width="457" alt="image" src="https://github.com/jellyfin/Swiftfin/assets/22553678/e8ad0b62-7b7a-419b-bec5-c8487401c0f1">

![orientation_breaking](https://github.com/jellyfin/Swiftfin/assets/22553678/db7c2ab3-7658-4743-b262-d63d5b51394d)

# Changes

1. Add `contentShape(Rectangle())` to the X button
2. Add padding to the HStack surrounding "Chapters" and "Current"; refactor safe area padding to outermost stack
3. Lock orientation to landscape during playback — mostly uncommented existing code

# Testing

- Verifying X button clickable by physically pressing it with thumb
- Verifying rotations and chapters text look good on iOS 14 and 16 on iPhone and iPad

| Before | After |
|--------|--------|
| [can't click X](https://matrix.to/#/!UGqxMjsElfCqgeDJBO:matrix.org/$oW-D3AuDVDaIWh5hRsbNbPzGC1ZkUH6-Tiar5Zwtf4g?via=bonifacelabs.ca&via=t2bot.io&via=matrix.org) | [can click X](https://matrix.to/#/!UGqxMjsElfCqgeDJBO:matrix.org/$6U60Zb3jmFc6t4-eMZLN7aSXuiwpDOytlpeKpYYNezs?via=bonifacelabs.ca&via=t2bot.io&via=matrix.org) |
| <img width="934" alt="image" src="https://github.com/jellyfin/Swiftfin/assets/22553678/398a597e-1395-4d5c-9c84-aad3da8fac61"> | <img width="912" alt="image" src="https://github.com/jellyfin/Swiftfin/assets/22553678/0fb84450-e55c-4c61-b89f-f215463dc4fb"> |
| <img width="921" alt="image" src="https://github.com/jellyfin/Swiftfin/assets/22553678/652d692f-247d-43aa-aa06-49fbc46f5166"> | <img width="925" alt="image" src="https://github.com/jellyfin/Swiftfin/assets/22553678/eb4f397a-eacd-4382-9c4e-3c058c63247f"> |
| <img width="457" alt="image" src="https://github.com/jellyfin/Swiftfin/assets/22553678/e8ad0b62-7b7a-419b-bec5-c8487401c0f1"> | ![orientation_force](https://github.com/jellyfin/Swiftfin/assets/22553678/f148ce2e-8a60-40b9-b35a-1dbcd32c2080) |
