### PR TITLE
Add audio, subtitle, playback select for tvOS

### DIFF
--- a/Shared/ViewModels/VideoPlayerManager.swift
+++ b/Shared/ViewModels/VideoPlayerManager.swift
@@ -40,6 +40,8 @@ class VideoPlayerManager: ViewModel {
     var state: VLCVideoPlayer.State = .opening
     @Published
     var subtitleTrackIndex: Int = -1
+    @Published
+    var playbackSpeed: PlaybackSpeed = PlaybackSpeed.one
 
     // MARK: ViewModel
 

--- a/Swiftfin tvOS/Components/SFSymbolButton.swift
+++ b/Swiftfin tvOS/Components/SFSymbolButton.swift
@@ -16,16 +16,7 @@ struct SFSymbolButton: UIViewRepresentable {
     private let systemName: String
     private let systemNameFocused: String?
 
-    func makeUIView(context: Context) -> some UIButton {
-        var configuration = UIButton.Configuration.plain()
-        configuration.cornerStyle = .capsule
-
-        let buttonAction = UIAction(title: "") { _ in
-            self.onSelect()
-        }
-
-        let button = UIButton(configuration: configuration, primaryAction: buttonAction)
-
+    private func makeButtonConfig(_ button: UIButton) {
         let symbolImageConfig = UIImage.SymbolConfiguration(pointSize: pointSize)
         let symbolImage = UIImage(systemName: systemName, withConfiguration: symbolImageConfig)
 
@@ -36,11 +27,26 @@ struct SFSymbolButton: UIViewRepresentable {
 
             button.setImage(focusedSymbolImage, for: .focused)
         }
+    }
+
+    func makeUIView(context: Context) -> some UIButton {
+        var configuration = UIButton.Configuration.plain()
+        configuration.cornerStyle = .capsule
+
+        let buttonAction = UIAction(title: "") { _ in
+            self.onSelect()
+        }
+
+        let button = UIButton(configuration: configuration, primaryAction: buttonAction)
+
+        makeButtonConfig(button)
 
         return button
     }
 
-    func updateUIView(_ uiView: UIViewType, context: Context) {}
+    func updateUIView(_ uiView: UIViewType, context: Context) {
+        makeButtonConfig(uiView)
+    }
 }
 
 extension SFSymbolButton {

--- a/Swiftfin tvOS/Views/VideoPlayer/Overlays/Components/ActionButtons/AutoPlayActionButton.swift
+++ b/Swiftfin tvOS/Views/VideoPlayer/Overlays/Components/ActionButtons/AutoPlayActionButton.swift
@@ -28,7 +28,6 @@ extension VideoPlayer.Overlay.ActionButtons {
                 overlayTimer.start(5)
             }
             .frame(maxWidth: 30, maxHeight: 30)
-            .id(autoPlayEnabled)
         }
     }
 }

--- a/Swiftfin tvOS/Views/VideoPlayer/Overlays/SmallMenuOverlay.swift
+++ b/Swiftfin tvOS/Views/VideoPlayer/Overlays/SmallMenuOverlay.swift
@@ -195,15 +195,15 @@ extension VideoPlayer {
 
             func body(content: Content) -> some View {
                 content
-                    .frame(height: 80)
-                    .padding(.horizontal, 50)
-                    .padding(.top)
-                    .padding(.bottom, 45)
                     .focusGuide(
                         focusGuide,
                         tag: "contents",
                         top: "sections"
                     )
+                    .frame(height: 80)
+                    .padding(.horizontal, 50)
+                    .padding(.top)
+                    .padding(.bottom, 45)
             }
         }
     }

--- a/Swiftfin tvOS/Views/VideoPlayer/Overlays/SmallMenuOverlay.swift
+++ b/Swiftfin tvOS/Views/VideoPlayer/Overlays/SmallMenuOverlay.swift
@@ -51,7 +51,10 @@ extension VideoPlayer {
                         videoPlayerManager.subtitleTrackIndex = mediaStream.index ?? -1
                         videoPlayerManager.proxy.setSubtitleTrack(.absolute(mediaStream.index ?? -1))
                     } label: {
-                        Label(mediaStream.displayTitle ?? L10n.noTitle, systemImage: videoPlayerManager.subtitleTrackIndex == mediaStream.index ? "checkmark.circle.fill" : "circle")
+                        Label(
+                            mediaStream.displayTitle ?? L10n.noTitle,
+                            systemImage: videoPlayerManager.subtitleTrackIndex == mediaStream.index ? "checkmark.circle.fill" : "circle"
+                        )
                     }
                 }
             }
@@ -65,7 +68,7 @@ extension VideoPlayer {
                 top: "sections"
             )
         }
-        
+
         @ViewBuilder
         private var audioMenu: some View {
             HStack {
@@ -74,7 +77,10 @@ extension VideoPlayer {
                         videoPlayerManager.audioTrackIndex = mediaStream.index ?? -1
                         videoPlayerManager.proxy.setAudioTrack(.absolute(mediaStream.index ?? -1))
                     } label: {
-                        Label(mediaStream.displayTitle ?? L10n.noTitle, systemImage: videoPlayerManager.audioTrackIndex == mediaStream.index ? "checkmark.circle.fill" : "circle")
+                        Label(
+                            mediaStream.displayTitle ?? L10n.noTitle,
+                            systemImage: videoPlayerManager.audioTrackIndex == mediaStream.index ? "checkmark.circle.fill" : "circle"
+                        )
                     }
                 }
             }
@@ -88,7 +94,7 @@ extension VideoPlayer {
                 top: "sections"
             )
         }
-        
+
         @ViewBuilder
         private var playbackSpeedMenu: some View {
             HStack {
@@ -97,7 +103,10 @@ extension VideoPlayer {
                         videoPlayerManager.playbackSpeed = speed
                         videoPlayerManager.proxy.setRate(.absolute(Float(speed.rawValue)))
                     } label: {
-                        Label(speed.displayTitle , systemImage: speed == videoPlayerManager.playbackSpeed ? "checkmark.circle.fill" : "circle")
+                        Label(
+                            speed.displayTitle,
+                            systemImage: speed == videoPlayerManager.playbackSpeed ? "checkmark.circle.fill" : "circle"
+                        )
                     }
                 }
             }

--- a/Swiftfin tvOS/Views/VideoPlayer/Overlays/SmallMenuOverlay.swift
+++ b/Swiftfin tvOS/Views/VideoPlayer/Overlays/SmallMenuOverlay.swift
@@ -189,10 +189,10 @@ extension VideoPlayer {
                 .focused(focused, equals: section)
             }
         }
-        
+
         struct MenuStyle: ViewModifier {
             var focusGuide: FocusGuide
-            
+
             func body(content: Content) -> some View {
                 content
                     .frame(height: 80)

--- a/Swiftfin tvOS/Views/VideoPlayer/Overlays/SmallMenuOverlay.swift
+++ b/Swiftfin tvOS/Views/VideoPlayer/Overlays/SmallMenuOverlay.swift
@@ -58,15 +58,7 @@ extension VideoPlayer {
                     }
                 }
             }
-            .frame(height: 80)
-            .padding(.horizontal, 50)
-            .padding(.top)
-            .padding(.bottom, 45)
-            .focusGuide(
-                focusGuide,
-                tag: "contents",
-                top: "sections"
-            )
+            .modifier(MenuStyle(focusGuide: focusGuide))
         }
 
         @ViewBuilder
@@ -84,15 +76,7 @@ extension VideoPlayer {
                     }
                 }
             }
-            .frame(height: 80)
-            .padding(.horizontal, 50)
-            .padding(.top)
-            .padding(.bottom, 45)
-            .focusGuide(
-                focusGuide,
-                tag: "contents",
-                top: "sections"
-            )
+            .modifier(MenuStyle(focusGuide: focusGuide))
         }
 
         @ViewBuilder
@@ -110,15 +94,7 @@ extension VideoPlayer {
                     }
                 }
             }
-            .frame(height: 80)
-            .padding(.horizontal, 50)
-            .padding(.top)
-            .padding(.bottom, 45)
-            .focusGuide(
-                focusGuide,
-                tag: "contents",
-                top: "sections"
-            )
+            .modifier(MenuStyle(focusGuide: focusGuide))
         }
 
         var body: some View {
@@ -211,6 +187,23 @@ extension VideoPlayer {
                 .buttonStyle(.plain)
                 .background(.clear)
                 .focused(focused, equals: section)
+            }
+        }
+        
+        struct MenuStyle: ViewModifier {
+            var focusGuide: FocusGuide
+            
+            func body(content: Content) -> some View {
+                content
+                    .frame(height: 80)
+                    .padding(.horizontal, 50)
+                    .padding(.top)
+                    .padding(.bottom, 45)
+                    .focusGuide(
+                        focusGuide,
+                        tag: "contents",
+                        top: "sections"
+                    )
             }
         }
     }

--- a/Swiftfin tvOS/Views/VideoPlayer/Overlays/SmallMenuOverlay.swift
+++ b/Swiftfin tvOS/Views/VideoPlayer/Overlays/SmallMenuOverlay.swift
@@ -14,7 +14,6 @@ extension VideoPlayer {
 
         enum MenuSection: String, Displayable {
             case audio
-            case chapters
             case playbackSpeed
             case subtitles
 
@@ -22,8 +21,6 @@ extension VideoPlayer {
                 switch self {
                 case .audio:
                     return "Audio"
-                case .chapters:
-                    return "Chapters"
                 case .playbackSpeed:
                     return "Playback Speed"
                 case .subtitles:
@@ -50,12 +47,57 @@ extension VideoPlayer {
         private var subtitleMenu: some View {
             HStack {
                 ForEach(viewModel.subtitleStreams, id: \.self) { mediaStream in
-                    Button {} label: {
-                        if videoPlayerManager.subtitleTrackIndex == mediaStream.index {
-                            Label(mediaStream.displayTitle ?? L10n.noTitle, systemImage: "checkmark")
-                        } else {
-                            Text(mediaStream.displayTitle ?? L10n.noTitle)
-                        }
+                    Button {
+                        videoPlayerManager.subtitleTrackIndex = mediaStream.index ?? -1
+                        videoPlayerManager.proxy.setSubtitleTrack(.absolute(mediaStream.index ?? -1))
+                    } label: {
+                        Label(mediaStream.displayTitle ?? L10n.noTitle, systemImage: videoPlayerManager.subtitleTrackIndex == mediaStream.index ? "checkmark.circle.fill" : "circle")
+                    }
+                }
+            }
+            .frame(height: 80)
+            .padding(.horizontal, 50)
+            .padding(.top)
+            .padding(.bottom, 45)
+            .focusGuide(
+                focusGuide,
+                tag: "contents",
+                top: "sections"
+            )
+        }
+        
+        @ViewBuilder
+        private var audioMenu: some View {
+            HStack {
+                ForEach(viewModel.audioStreams, id: \.self) { mediaStream in
+                    Button {
+                        videoPlayerManager.audioTrackIndex = mediaStream.index ?? -1
+                        videoPlayerManager.proxy.setAudioTrack(.absolute(mediaStream.index ?? -1))
+                    } label: {
+                        Label(mediaStream.displayTitle ?? L10n.noTitle, systemImage: videoPlayerManager.audioTrackIndex == mediaStream.index ? "checkmark.circle.fill" : "circle")
+                    }
+                }
+            }
+            .frame(height: 80)
+            .padding(.horizontal, 50)
+            .padding(.top)
+            .padding(.bottom, 45)
+            .focusGuide(
+                focusGuide,
+                tag: "contents",
+                top: "sections"
+            )
+        }
+        
+        @ViewBuilder
+        private var playbackSpeedMenu: some View {
+            HStack {
+                ForEach(PlaybackSpeed.allCases, id: \.self) { speed in
+                    Button {
+                        videoPlayerManager.playbackSpeed = speed
+                        videoPlayerManager.proxy.setRate(.absolute(Float(speed.rawValue)))
+                    } label: {
+                        Label(speed.displayTitle , systemImage: speed == videoPlayerManager.playbackSpeed ? "checkmark.circle.fill" : "circle")
                     }
                 }
             }
@@ -98,14 +140,6 @@ extension VideoPlayer {
                             focused: $focusedSection,
                             lastFocused: $lastFocusedSection
                         )
-
-                        if !viewModel.chapters.isEmpty {
-                            SectionButton(
-                                section: .chapters,
-                                focused: $focusedSection,
-                                lastFocused: $lastFocusedSection
-                            )
-                        }
                     }
                     .focusGuide(
                         focusGuide,
@@ -123,6 +157,10 @@ extension VideoPlayer {
                     switch lastFocusedSection {
                     case .subtitles:
                         subtitleMenu
+                    case .audio:
+                        audioMenu
+                    case .playbackSpeed:
+                        playbackSpeedMenu
                     default:
                         Button {
                             Text("None")

--- a/Swiftfin tvOS/Views/VideoPlayer/Overlays/SmallMenuOverlay.swift
+++ b/Swiftfin tvOS/Views/VideoPlayer/Overlays/SmallMenuOverlay.swift
@@ -38,7 +38,7 @@ extension VideoPlayer {
         private var focusedSection: MenuSection?
 
         @State
-        private var lastFocusedSection: MenuSection?
+        private var lastFocusedSection: MenuSection = .subtitles
 
         @StateObject
         private var focusGuide: FocusGuide = .init()
@@ -170,10 +170,6 @@ extension VideoPlayer {
                         audioMenu
                     case .playbackSpeed:
                         playbackSpeedMenu
-                    default:
-                        Button {
-                            Text("None")
-                        }
                     }
                 }
             }
@@ -198,7 +194,7 @@ extension VideoPlayer {
 
             let section: MenuSection
             let focused: FocusState<MenuSection?>.Binding
-            let lastFocused: Binding<MenuSection?>
+            let lastFocused: Binding<MenuSection>
 
             var body: some View {
                 Button {

--- a/Swiftfin/Views/VideoPlayer/Overlays/Components/ActionButtons/PlaybackSpeedActionButton.swift
+++ b/Swiftfin/Views/VideoPlayer/Overlays/Components/ActionButtons/PlaybackSpeedActionButton.swift
@@ -36,10 +36,6 @@ extension VideoPlayer.Overlay.ActionButtons {
                         }
                     }
                 }
-
-                if !PlaybackSpeed.allCases.map(\.rawValue).contains(where: { $0 == Double(videoPlayerManager.playbackSpeed.rawValue) }) {
-                    Label(String(format: "%.2f", videoPlayerManager.playbackSpeed.rawValue).appending("x"), systemImage: "checkmark")
-                }
             } label: {
                 content().eraseToAnyView()
             }

--- a/Swiftfin/Views/VideoPlayer/Overlays/Components/ActionButtons/PlaybackSpeedActionButton.swift
+++ b/Swiftfin/Views/VideoPlayer/Overlays/Components/ActionButtons/PlaybackSpeedActionButton.swift
@@ -13,10 +13,6 @@ extension VideoPlayer.Overlay.ActionButtons {
 
     struct PlaybackSpeedMenu: View {
 
-        @Environment(\.playbackSpeed)
-        @Binding
-        private var playbackSpeed
-
         @EnvironmentObject
         private var overlayTimer: TimerProxy
         @EnvironmentObject
@@ -30,10 +26,10 @@ extension VideoPlayer.Overlay.ActionButtons {
             Menu {
                 ForEach(PlaybackSpeed.allCases, id: \.self) { speed in
                     Button {
-                        playbackSpeed = Float(speed.rawValue)
+                        videoPlayerManager.playbackSpeed = speed
                         videoPlayerProxy.setRate(.absolute(Float(speed.rawValue)))
                     } label: {
-                        if Float(speed.rawValue) == playbackSpeed {
+                        if speed == videoPlayerManager.playbackSpeed {
                             Label(speed.displayTitle, systemImage: "checkmark")
                         } else {
                             Text(speed.displayTitle)
@@ -41,8 +37,8 @@ extension VideoPlayer.Overlay.ActionButtons {
                     }
                 }
 
-                if !PlaybackSpeed.allCases.map(\.rawValue).contains(where: { $0 == Double(playbackSpeed) }) {
-                    Label(String(format: "%.2f", playbackSpeed).appending("x"), systemImage: "checkmark")
+                if !PlaybackSpeed.allCases.map(\.rawValue).contains(where: { $0 == Double(videoPlayerManager.playbackSpeed.rawValue) }) {
+                    Label(String(format: "%.2f", videoPlayerManager.playbackSpeed.rawValue).appending("x"), systemImage: "checkmark")
                 }
             } label: {
                 content().eraseToAnyView()


### PR DESCRIPTION
# Purpose

- Audio/subtitle/playback selection was completely missing in tvOS
- Opening up the audio/subtitle/playback selection menu opened to a button that said "None"
- Toggling autoplay reset focus

# Changes

- Add audio, subtitle, and playback selection in tvOS
- Move `playbackSpeed` property into `VideoPlayerManager` to keep consistency with audio and subtitle property
- Make unselected label have unfilled circle icon, make selected label have checkmark circle filled icon

# Testing

- Check audio, subtitle and playback select work in tvOS
- Tested both iOS and tvOS to make sure the `playbackSpeed` move didn't break anything
- Removed chapter select from the enum in `SmallMenuOverlay` because chapter selection already exists outside of that menu

| Before | After |
|--------|--------|
| [track select before](https://imgur.com/IR8BR5Y)  | [track select after](https://imgur.com/xM2Wntc) |
| <img width="1627" alt="image" src="https://github.com/jellyfin/Swiftfin/assets/22553678/d0de3131-98e7-45c8-afea-d5f81a34fc60">  | <img width="1625" alt="image" src="https://github.com/jellyfin/Swiftfin/assets/22553678/414fd249-a1be-450e-83f4-10ed4220c7e6"> |
| <img width="1625" alt="image" src="https://github.com/jellyfin/Swiftfin/assets/22553678/f239a679-215d-46fb-92d7-858c42f79fe7"> | <img width="1627" alt="image" src="https://github.com/jellyfin/Swiftfin/assets/22553678/b53a40f8-b07f-4049-8496-5a7a0f61c95e"> |
| ![button_reset](https://github.com/jellyfin/Swiftfin/assets/22553678/1c6bf13f-34e7-4473-b166-f4ca2162fa85) | ![button_reset_fix](https://github.com/jellyfin/Swiftfin/assets/22553678/bbf44896-6be6-46ac-a032-01aba9a7b75e) |
| ![none_button](https://github.com/jellyfin/Swiftfin/assets/22553678/91cf0c6e-eabf-405a-a67a-e902dcbf5683) | ![none_button_fix](https://github.com/jellyfin/Swiftfin/assets/22553678/731c7b16-72dc-4556-b8e9-42c001d818d7) |

### iOS playback speed works

![ios_playbackspeed](https://github.com/jellyfin/Swiftfin/assets/22553678/50ef768a-8c8e-4a0c-ac9e-3bd6118d9a2c)

# Notes

While working on the fix, I noticed:

- Audio/subtitle were not set when loading video on tvOS in `VideoPlayerManager`, so opening the selection menu shows that no audio/subtitle track is selected until manual selection
- ~~Opening the `SmallMenuOverlay` for the first time makes the default `Text("None")` button because `lastFocusedSection` is not set by default~~ — fixed in this PR now

**Do we want these problems fixed in this PR?**

## TODO

- [x] Attach before and after images
- [x] ~~(Maybe) change `playbackSpeed` in `VideoPlayerManager` to `Float` in case we ever want to apply a nonstandard speed~~ — lmk if we want this.
- [x] ~~(Maybe) refactor out shared code among the selection menus in `SmallMenuOverlay`~~ — lmk if we want this