### PR TITLE
tvOS: Show full-resolution logo

### DIFF
--- a/Swiftfin tvOS/Resources/Assets.xcassets/jellyfin-blob-blue.imageset/Contents.json
+++ b/Swiftfin tvOS/Resources/Assets.xcassets/jellyfin-blob-blue.imageset/Contents.json
@@ -8,5 +8,8 @@
   "info" : {
     "author" : "xcode",
     "version" : 1
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/Swiftfin/Resources/Assets.xcassets/jellyfin-blob-blue.imageset/Contents.json
+++ b/Swiftfin/Resources/Assets.xcassets/jellyfin-blob-blue.imageset/Contents.json
@@ -8,5 +8,8 @@
   "info" : {
     "author" : "xcode",
     "version" : 1
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }


### PR DESCRIPTION
This enables "Preserve Vector Data" on the Jellyfin blob logo asset (see [https://stackoverflow.com/a/74765777](https://stackoverflow.com/a/74765777)). Here is the difference on a 3rd generation Apple TV 4K:

![diff](https://github.com/jellyfin/Swiftfin/assets/88516341/562b8c6d-8bf1-4855-b680-52d1fa97d3dc)

This is mainly for the tvOS app. While I've also applied the same change to the iOS version of the asset for consistency (and potential future use in SwiftUI views), its current use as a splash screen means there's no visible impact in the iOS version.