### PR TITLE
Fix quick connect

### DIFF
--- a/Shared/Coordinators/QuickConnectCoordinator.swift
+++ b/Shared/Coordinators/QuickConnectCoordinator.swift
@@ -25,6 +25,8 @@ final class QuickConnectCoordinator: NavigationCoordinatable {
 
     @ViewBuilder
     func makeStart() -> some View {
-        QuickConnectView(viewModel: viewModel)
+        QuickConnectView(viewModel: viewModel.quickConnectViewModel, signIn: { authSecret in
+            self.viewModel.send(.signInWithQuickConnect(authSecret: authSecret))
+        })
     }
 }

--- a/Shared/ViewModels/QuickConnectViewModel.swift
+++ b/Shared/ViewModels/QuickConnectViewModel.swift
@@ -1,0 +1,172 @@
+//
+// Swiftfin is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, you can obtain one at https://mozilla.org/MPL/2.0/.
+//
+// Copyright (c) 2024 Jellyfin & Jellyfin Contributors
+//
+
+import CoreStore
+import Defaults
+import Factory
+import Foundation
+import JellyfinAPI
+import Pulse
+
+/// Handles getting and exposing quick connect code and related states and polling for authentication secret and
+/// exposing it to a consumer.
+/// __Does not handle using the authentication secret itself to sign in.__
+final class QuickConnectViewModel: ViewModel, Stateful {
+    // MARK: Action
+
+    enum Action {
+        case startQuickConnect
+        case cancelQuickConnect
+    }
+
+    // MARK: State
+
+    // The typical quick connect lifecycle is as follows:
+    enum State: Equatable {
+        // 0. User has not interacted with quick connect
+        case initial
+        // 1. User clicks quick connect
+        case fetchingSecret
+        // 2. We fetch a secret and code from the server
+        // 3. Display the code to user, poll for authentication from server using secret
+        // 4. User enters code to the server
+        case awaitingAuthentication(code: String)
+        // 5. Authentication poll succeeds with another secret. A consumer uses this secret to sign in.
+        //    In particular, the responsibility to consume this secret and handle any errors and state changes
+        //    is deferred to the consumer.
+        case authenticated(secret: String)
+        // Store the error and surface it to user if possible
+        case error(QuickConnectError)
+    }
+
+    // TODO: Consider giving these errors a message and using it in the QuickConnectViews
+    enum QuickConnectError: Error {
+        case fetchSecretFailed
+        case pollingFailed
+        case unknown
+    }
+
+    @Published
+    var state: State = .initial
+
+    let client: JellyfinClient
+
+    /// How often to poll quick connect auth
+    private let quickConnectPollTimeoutSeconds: Int = 5
+    private let quickConnectMaxRetries: Int = 200
+
+    private var quickConnectPollTask: Task<String, any Error>?
+
+    init(client: JellyfinClient) {
+        self.client = client
+        super.init()
+    }
+
+    func respond(to action: Action) -> State {
+        switch action {
+        case .startQuickConnect:
+            Task {
+                await fetchAuthCode()
+            }
+            return .fetchingSecret
+        case .cancelQuickConnect:
+            stopQuickConnectAuthCheck()
+            return .initial
+        }
+    }
+
+    /// Retrieves sign in secret, and stores it in the state for a consumer to use.
+    private func fetchAuthCode() async {
+        do {
+            await MainActor.run {
+                state = .fetchingSecret
+            }
+            let (initiateSecret, code) = try await startQuickConnect()
+
+            await MainActor.run {
+                state = .awaitingAuthentication(code: code)
+            }
+            let authSecret = try await pollForAuthSecret(initialSecret: initiateSecret)
+
+            await MainActor.run {
+                state = .authenticated(secret: authSecret)
+            }
+        } catch let error as QuickConnectError {
+            await MainActor.run {
+                state = .error(error)
+            }
+        } catch {
+            await MainActor.run {
+                state = .error(.unknown)
+            }
+        }
+    }
+
+    /// Gets secret and code to start quick connect authorization flow.
+    private func startQuickConnect() async throws -> (secret: String, code: String) {
+        logger.debug("Attempting to start quick connect...")
+
+        let initiatePath = Paths.initiate
+        let response = try await client.send(initiatePath)
+
+        guard let secret = response.value.secret,
+              let code = response.value.code
+        else {
+            throw QuickConnectError.fetchSecretFailed
+        }
+
+        return (secret, code)
+    }
+
+    private func pollForAuthSecret(initialSecret: String) async throws -> String {
+        let task = Task {
+            var authSecret: String?
+            for _ in 1 ... quickConnectMaxRetries {
+                authSecret = try await checkAuth(initialSecret: initialSecret)
+                if authSecret != nil { break }
+
+                try await Task.sleep(nanoseconds: UInt64(1_000_000_000 * quickConnectPollTimeoutSeconds))
+            }
+            guard let authSecret = authSecret else {
+                logger.warning("Hit max retries while using quick connect, did the `pollForAuthSecret` task keep running after signing in?")
+                throw QuickConnectError.pollingFailed
+            }
+            return authSecret
+        }
+
+        quickConnectPollTask = task
+        return try await task.result.get()
+    }
+
+    private func checkAuth(initialSecret: String) async throws -> String? {
+        logger.debug("Attempting to poll for quick connect auth")
+
+        let connectPath = Paths.connect(secret: initialSecret)
+        do {
+            let response = try await client.send(connectPath)
+
+            guard response.value.isAuthenticated ?? false else {
+                return nil
+            }
+            guard let authSecret = response.value.secret else {
+                logger.debug("Quick connect response was authorized but secret missing")
+                throw QuickConnectError.pollingFailed
+            }
+            return authSecret
+        } catch {
+            throw QuickConnectError.pollingFailed
+        }
+    }
+
+    private func stopQuickConnectAuthCheck() {
+        logger.debug("Stopping quick connect")
+
+        state = .initial
+        quickConnectPollTask?.cancel()
+    }
+}

--- a/Shared/ViewModels/UserSignInViewModel.swift
+++ b/Shared/ViewModels/UserSignInViewModel.swift
@@ -13,9 +13,39 @@ import Foundation
 import JellyfinAPI
 import Pulse
 
-final class UserSignInViewModel: ViewModel {
+final class UserSignInViewModel: ViewModel, Stateful {
+    // MARK: Action
+
+    enum Action {
+        case signInWithUserPass(username: String, password: String)
+        case signInWithQuickConnect(authSecret: String)
+        case cancelSignIn
+    }
+
+    // MARK: State
+
+    enum State: Equatable {
+        case initial
+        case signingIn
+        case signedIn
+        case error(SignInError)
+    }
+
+    // TODO: Add more detailed errors
+    enum SignInError: Error {
+        case unknown
+    }
+
+    @Published
+    var state: State = .initial
     @Published
     private(set) var publicUsers: [UserDto] = []
+    @Published
+    private(set) var quickConnectEnabled = false
+
+    private var signInTask: Task<Void, Never>?
+
+    let quickConnectViewModel: QuickConnectViewModel
 
     let client: JellyfinClient
     let server: SwiftfinStore.State.Server
@@ -26,10 +56,43 @@ final class UserSignInViewModel: ViewModel {
             sessionDelegate: URLSessionProxyDelegate()
         )
         self.server = server
+        self.quickConnectViewModel = .init(client: client)
         super.init()
     }
 
-    func signIn(username: String, password: String) async throws {
+    func respond(to action: Action) -> State {
+        switch action {
+        case let .signInWithUserPass(username, password):
+            guard state != .signingIn else { return .signingIn }
+            Task {
+                do {
+                    try await signIn(username: username, password: password)
+                } catch {
+                    await MainActor.run {
+                        state = .error(.unknown)
+                    }
+                }
+            }
+            return .signingIn
+        case let .signInWithQuickConnect(authSecret):
+            guard state != .signingIn else { return .signingIn }
+            Task {
+                do {
+                    try await signIn(quickConnectSecret: authSecret)
+                } catch {
+                    await MainActor.run {
+                        state = .error(.unknown)
+                    }
+                }
+            }
+            return .signingIn
+        case .cancelSignIn:
+            self.signInTask?.cancel()
+            return .initial
+        }
+    }
+
+    private func signIn(username: String, password: String) async throws {
         let username = username.trimmingCharacters(in: .whitespacesAndNewlines)
             .trimmingCharacters(in: .objectReplacement)
         let password = password.trimmingCharacters(in: .whitespacesAndNewlines)
@@ -41,6 +104,27 @@ final class UserSignInViewModel: ViewModel {
 
         do {
             user = try await createLocalUser(response: response)
+        } catch {
+            if case let SwiftfinStore.Error.existingUser(existingUser) = error {
+                user = existingUser
+            } else {
+                throw error
+            }
+        }
+
+        Defaults[.lastServerUserID] = user.id
+        Container.userSession.reset()
+        Notifications[.didSignIn].post()
+    }
+
+    private func signIn(quickConnectSecret: String) async throws {
+        let quickConnectPath = Paths.authenticateWithQuickConnect(.init(secret: quickConnectSecret))
+        let response = try await client.send(quickConnectPath)
+
+        let user: UserState
+
+        do {
+            user = try await createLocalUser(response: response.value)
         } catch {
             if case let SwiftfinStore.Error.existingUser(existingUser) = error {
                 user = existingUser
@@ -107,66 +191,6 @@ final class UserSignInViewModel: ViewModel {
         return user
     }
 
-    // MARK: - Quick Connect
-
-    /// The typical quick connect lifecycle is as follows:
-    /// 1. User clicks quick connect
-    /// 2. We fetch a secret and code from the server
-    /// 3. Display the code to user, poll for authentication from server using secret
-    /// 4. User enters code to the server
-    /// 5. Authentication poll succeeds with another secret, use secret to log in
-
-    @Published
-    private(set) var quickConnectEnabled = false
-    /// To maintain logic within this view model, we expose this property to track the status during quick connect execution.
-    @Published
-    private(set) var quickConnectStatus: QuickConnectStatus?
-
-    /// How often to poll quick connect auth
-    private let quickConnectPollTimeoutSeconds: UInt64 = 5
-
-    private var quickConnectPollTask: Task<String, any Error>?
-
-    enum QuickConnectStatus {
-        case fetchingSecret
-        case awaitingAuthentication(code: String)
-        // Store the error and surface it to user if possible
-        case error(Error)
-        case authorized
-    }
-
-    enum QuickConnectError: Error {
-        case fetchSecretFailed
-        case pollingFailed
-    }
-
-    /// Signs in with quick connect. Returns whether sign in was successful.
-    func signInWithQuickConnect() async -> Bool {
-        do {
-            await MainActor.run {
-                quickConnectStatus = .fetchingSecret
-            }
-            let (initiateSecret, code) = try await startQuickConnect()
-
-            await MainActor.run {
-                quickConnectStatus = .awaitingAuthentication(code: code)
-            }
-            let authSecret = try await pollForAuthSecret(initialSecret: initiateSecret)
-
-            try await signIn(quickConnectSecret: authSecret)
-            await MainActor.run {
-                quickConnectStatus = .authorized
-            }
-
-            return true
-        } catch {
-            await MainActor.run {
-                quickConnectStatus = .error(error)
-            }
-            return false
-        }
-    }
-
     func checkQuickConnect() async throws {
         let quickConnectEnabledPath = Paths.getEnabled
         let response = try await client.send(quickConnectEnabledPath)
@@ -176,83 +200,5 @@ final class UserSignInViewModel: ViewModel {
         await MainActor.run {
             quickConnectEnabled = isEnabled ?? false
         }
-    }
-
-    /// Gets secret and code to start quick connect authorization flow.
-    private func startQuickConnect() async throws -> (secret: String, code: String) {
-        logger.debug("Attempting to start quick connect...")
-
-        let initiatePath = Paths.initiate
-        let response = try await client.send(initiatePath)
-
-        guard let secret = response.value.secret,
-              let code = response.value.code
-        else {
-            throw QuickConnectError.fetchSecretFailed
-        }
-
-        return (secret, code)
-    }
-
-    private func pollForAuthSecret(initialSecret: String) async throws -> String {
-        let task = Task {
-            var authSecret: String?
-            repeat {
-                authSecret = try await checkAuth(initialSecret: initialSecret)
-                try await Task.sleep(nanoseconds: 1_000_000_000 * quickConnectPollTimeoutSeconds)
-            } while authSecret == nil
-            return authSecret!
-        }
-
-        quickConnectPollTask = task
-        return try await task.result.get()
-    }
-
-    private func checkAuth(initialSecret: String) async throws -> String? {
-        logger.debug("Attempting to poll for quick connect auth")
-
-        let connectPath = Paths.connect(secret: initialSecret)
-        do {
-            let response = try await client.send(connectPath)
-
-            guard response.value.isAuthenticated ?? false else {
-                return nil
-            }
-            guard let authSecret = response.value.secret else {
-                logger.debug("Quick connect response was authorized but secret missing")
-                throw QuickConnectError.pollingFailed
-            }
-            return authSecret
-        } catch {
-            throw QuickConnectError.pollingFailed
-        }
-    }
-
-    func stopQuickConnectAuthCheck() {
-        logger.debug("Stopping quick connect")
-
-        quickConnectStatus = nil
-        quickConnectPollTask?.cancel()
-    }
-
-    private func signIn(quickConnectSecret: String) async throws {
-        let quickConnectPath = Paths.authenticateWithQuickConnect(.init(secret: quickConnectSecret))
-        let response = try await client.send(quickConnectPath)
-
-        let user: UserState
-
-        do {
-            user = try await createLocalUser(response: response.value)
-        } catch {
-            if case let SwiftfinStore.Error.existingUser(existingUser) = error {
-                user = existingUser
-            } else {
-                throw error
-            }
-        }
-
-        Defaults[.lastServerUserID] = user.id
-        Container.userSession.reset()
-        Notifications[.didSignIn].post()
     }
 }

--- a/Swiftfin tvOS/Views/QuickConnectView.swift
+++ b/Swiftfin tvOS/Views/QuickConnectView.swift
@@ -9,16 +9,15 @@
 import SwiftUI
 
 struct QuickConnectView: View {
-    @EnvironmentObject
-    private var router: QuickConnectCoordinator.Router
-
     @ObservedObject
     var viewModel: UserSignInViewModel
+    @Binding
+    var isPresentingQuickConnect: Bool
 
     func quickConnectWaitingAuthentication(quickConnectCode: String) -> some View {
         Text(quickConnectCode)
             .tracking(10)
-            .font(.largeTitle)
+            .font(.title)
             .monospacedDigit()
             .frame(maxWidth: .infinity)
     }
@@ -33,11 +32,7 @@ struct QuickConnectView: View {
     }
 
     var quickConnectLoading: some View {
-        HStack {
-            Spacer()
-            ProgressView()
-            Spacer()
-        }
+        ProgressView()
     }
 
     @ViewBuilder
@@ -53,32 +48,40 @@ struct QuickConnectView: View {
     }
 
     var body: some View {
-        VStack(alignment: .leading, spacing: 20) {
-            L10n.quickConnectStep1.text
+        VStack(alignment: .center) {
+            L10n.quickConnect.text
+                .font(.title3)
+                .fontWeight(.semibold)
 
-            L10n.quickConnectStep2.text
+            Group {
+                VStack(alignment: .leading, spacing: 20) {
+                    L10n.quickConnectStep1.text
 
-            L10n.quickConnectStep3.text
-                .padding(.bottom)
+                    L10n.quickConnectStep2.text
 
-            quickConnectBody
+                    L10n.quickConnectStep3.text
+                }
+                .padding(.vertical)
 
-            Spacer()
+                quickConnectBody
+            }
+            .padding(.bottom)
+
+            Button {
+                isPresentingQuickConnect = false
+            } label: {
+                L10n.close.text
+                    .frame(width: 400, height: 75)
+            }
+            .buttonStyle(.plain)
         }
-        .padding(.horizontal)
-        .navigationTitle(L10n.quickConnect)
         .onAppear {
             Task {
-                if await viewModel.signInWithQuickConnect() {
-                    router.dismissCoordinator()
-                }
+                await viewModel.signInWithQuickConnect()
             }
         }
         .onDisappear {
             viewModel.stopQuickConnectAuthCheck()
-        }
-        .navigationCloseButton {
-            router.dismissCoordinator()
         }
     }
 }

--- a/Swiftfin tvOS/Views/UserSignInView.swift
+++ b/Swiftfin tvOS/Views/UserSignInView.swift
@@ -12,7 +12,6 @@ import Stinsen
 import SwiftUI
 
 struct UserSignInView: View {
-
     enum FocusedField {
         case username
         case password
@@ -130,13 +129,8 @@ struct UserSignInView: View {
         }
     }
 
-    @ViewBuilder
-    private var quickConnect: some View {
-        VStack(alignment: .center) {
-            L10n.quickConnect.text
-                .font(.title3)
-                .fontWeight(.semibold)
-
+    func quickConnectWaitingAuthentication(quickConnectCode: String) -> some View {
+        Group {
             VStack(alignment: .leading, spacing: 20) {
                 L10n.quickConnectStep1.text
 
@@ -146,11 +140,48 @@ struct UserSignInView: View {
             }
             .padding(.vertical)
 
-            Text(viewModel.quickConnectCode ?? "------")
+            Text(quickConnectCode)
                 .tracking(10)
                 .font(.title)
                 .monospacedDigit()
                 .frame(maxWidth: .infinity)
+        }
+    }
+
+    var quickConnectFailed: some View {
+        Label {
+            Text("Failed to retrieve quick connect code")
+        } icon: {
+            Image(systemName: "exclamationmark.circle.fill")
+                .foregroundColor(.red)
+        }
+    }
+
+    var quickConnectLoading: some View {
+        ProgressView()
+    }
+
+    @ViewBuilder
+    var quickConnectBody: some View {
+        switch viewModel.quickConnectStatus {
+        case let .awaitingAuthentication(_, code):
+            quickConnectWaitingAuthentication(quickConnectCode: code)
+        case nil, .fetchingSecret:
+            quickConnectLoading
+        case .fetchingSecretFailed:
+            quickConnectFailed
+        }
+    }
+
+    @ViewBuilder
+    private var quickConnect: some View {
+        VStack(alignment: .center) {
+            L10n.quickConnect.text
+                .font(.title3)
+                .fontWeight(.semibold)
+
+            quickConnectBody
+                .padding(.bottom)
 
             Button {
                 isPresentingQuickConnect = false
@@ -175,7 +206,6 @@ struct UserSignInView: View {
 
     var body: some View {
         ZStack {
-
             ImageView(viewModel.userSession.client.fullURL(with: Paths.getSplashscreen()))
                 .ignoresSafeArea()
 

--- a/Swiftfin.xcodeproj/project.pbxproj
+++ b/Swiftfin.xcodeproj/project.pbxproj
@@ -759,6 +759,9 @@
 		E1FE69AA28C29CC20021BC93 /* LandscapePosterProgressBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1FE69A928C29CC20021BC93 /* LandscapePosterProgressBar.swift */; };
 		E43918662AD5C8310045A18C /* ScenePhaseChangeModifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = E43918652AD5C8310045A18C /* ScenePhaseChangeModifier.swift */; };
 		E43918672AD5C8310045A18C /* ScenePhaseChangeModifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = E43918652AD5C8310045A18C /* ScenePhaseChangeModifier.swift */; };
+		EA2073A12BAE35A400D8C78F /* QuickConnectViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = EA2073A02BAE35A400D8C78F /* QuickConnectViewModel.swift */; };
+		EA2073A22BAE35A400D8C78F /* QuickConnectViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = EA2073A02BAE35A400D8C78F /* QuickConnectViewModel.swift */; };
+		EADD26FD2BAE4A6C002F05DE /* QuickConnectView.swift in Sources */ = {isa = PBXBuildFile; fileRef = EADD26FC2BAE4A6C002F05DE /* QuickConnectView.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXCopyFilesBuildPhase section */
@@ -1292,6 +1295,8 @@
 		E1FE69A628C29B720021BC93 /* ProgressBar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProgressBar.swift; sourceTree = "<group>"; };
 		E1FE69A928C29CC20021BC93 /* LandscapePosterProgressBar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LandscapePosterProgressBar.swift; sourceTree = "<group>"; };
 		E43918652AD5C8310045A18C /* ScenePhaseChangeModifier.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScenePhaseChangeModifier.swift; sourceTree = "<group>"; };
+		EA2073A02BAE35A400D8C78F /* QuickConnectViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QuickConnectViewModel.swift; sourceTree = "<group>"; };
+		EADD26FC2BAE4A6C002F05DE /* QuickConnectView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QuickConnectView.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -1441,6 +1446,7 @@
 				BD0BA2292AD6501300306A8D /* VideoPlayerManager */,
 				E14A08CA28E6831D004FC984 /* VideoPlayerViewModel.swift */,
 				625CB57B2678CE1000530A6E /* ViewModel.swift */,
+				EA2073A02BAE35A400D8C78F /* QuickConnectViewModel.swift */,
 			);
 			path = ViewModels;
 			sourceTree = "<group>";
@@ -2070,6 +2076,7 @@
 				E193D546271941C500900D82 /* UserListView.swift */,
 				E193D548271941CC00900D82 /* UserSignInView.swift */,
 				5310694F2684E7EE00CFFDBA /* VideoPlayer */,
+				EADD26FC2BAE4A6C002F05DE /* QuickConnectView.swift */,
 			);
 			path = Views;
 			sourceTree = "<group>";
@@ -3228,6 +3235,7 @@
 				E1575E6A293E77B5001665B1 /* RoundedCorner.swift in Sources */,
 				E1DD55382B6EE533007501C0 /* Task.swift in Sources */,
 				E1575EA1293E7B1E001665B1 /* String.swift in Sources */,
+				EADD26FD2BAE4A6C002F05DE /* QuickConnectView.swift in Sources */,
 				E1E6C45429B1304E0064123F /* ChaptersActionButton.swift in Sources */,
 				E1E6C44229AECCD50064123F /* ActionButtons.swift in Sources */,
 				E1575E78293E77B5001665B1 /* TrailingTimestampType.swift in Sources */,
@@ -3314,6 +3322,7 @@
 				E12376B02A33D6AE001F5B44 /* AboutViewCard.swift in Sources */,
 				E12A9EF929499E0100731C3A /* JellyfinClient.swift in Sources */,
 				E148128328C1443D003B8787 /* NameGuidPair.swift in Sources */,
+				EA2073A22BAE35A400D8C78F /* QuickConnectViewModel.swift in Sources */,
 				E1579EA82B97DC1500A31CA1 /* Eventful.swift in Sources */,
 				E185920828CDAAA200326F80 /* SimilarItemsHStack.swift in Sources */,
 				E10E842C29A589860064EA49 /* NonePosterButton.swift in Sources */,
@@ -3528,6 +3537,7 @@
 				E1E1644128BB301900323B0A /* Array.swift in Sources */,
 				E18CE0AF28A222240092E7F1 /* PublicUserSignInView.swift in Sources */,
 				E129429828F4785200796AC6 /* CaseIterablePicker.swift in Sources */,
+				EA2073A12BAE35A400D8C78F /* QuickConnectViewModel.swift in Sources */,
 				E18E01E5288747230022598C /* CinematicScrollView.swift in Sources */,
 				E154965E296CA2EF00C4EF88 /* DownloadTask.swift in Sources */,
 				535BAE9F2649E569005FA86D /* ItemView.swift in Sources */,

--- a/Swiftfin/Views/UserSignInView/Components/PublicUserSignInView.swift
+++ b/Swiftfin/Views/UserSignInView/Components/PublicUserSignInView.swift
@@ -10,9 +10,7 @@ import JellyfinAPI
 import SwiftUI
 
 extension UserSignInView {
-
     struct PublicUserSignInView: View {
-
         @ObservedObject
         var viewModel: UserSignInViewModel
 
@@ -25,10 +23,8 @@ extension UserSignInView {
             DisclosureGroup {
                 SecureField(L10n.password, text: $password)
                 Button {
-                    Task {
-                        guard let username = publicUser.name else { return }
-                        try? await viewModel.signIn(username: username, password: password)
-                    }
+                    guard let username = publicUser.name else { return }
+                    viewModel.send(.signInWithUserPass(username: username, password: password))
                 } label: {
                     L10n.signIn.text
                 }

--- a/Swiftfin/Views/UserSignInView/UserSignInView.swift
+++ b/Swiftfin/Views/UserSignInView/UserSignInView.swift
@@ -10,7 +10,6 @@ import Stinsen
 import SwiftUI
 
 struct UserSignInView: View {
-
     @EnvironmentObject
     private var router: UserSignInCoordinator.Router
 
@@ -21,10 +20,6 @@ struct UserSignInView: View {
     private var isPresentingSignInError: Bool = false
     @State
     private var password: String = ""
-    @State
-    private var signInError: Error?
-    @State
-    private var signInTask: Task<Void, Never>?
     @State
     private var username: String = ""
 
@@ -39,28 +34,15 @@ struct UserSignInView: View {
                 .disableAutocorrection(true)
                 .autocapitalization(.none)
 
-            if viewModel.isLoading {
+            if case .signingIn = viewModel.state {
                 Button(role: .destructive) {
-                    viewModel.isLoading = false
-                    signInTask?.cancel()
+                    viewModel.send(.cancelSignIn)
                 } label: {
                     L10n.cancel.text
                 }
             } else {
                 Button {
-                    let task = Task {
-                        viewModel.isLoading = true
-
-                        do {
-                            try await viewModel.signIn(username: username, password: password)
-                        } catch {
-                            signInError = error
-                            isPresentingSignInError = true
-                        }
-
-                        viewModel.isLoading = false
-                    }
-                    signInTask = task
+                    viewModel.send(.signInWithUserPass(username: username, password: password))
                 } label: {
                     L10n.signIn.text
                 }
@@ -104,9 +86,16 @@ struct UserSignInView: View {
         .headerProminence(.increased)
     }
 
+    var errorText: some View {
+        var text: String?
+        if case let .error(error) = viewModel.state {
+            text = error.localizedDescription
+        }
+        return Text(text ?? .emptyDash)
+    }
+
     var body: some View {
         List {
-
             signInSection
 
             if viewModel.quickConnectEnabled {
@@ -119,13 +108,22 @@ struct UserSignInView: View {
 
             publicUsersSection
         }
+        .onChange(of: viewModel.state) { newState in
+            if case .error = newState {
+                // If we encountered the error as we switched from quick connect navigation to this view,
+                // it's possible that the alert doesn't show, so wait a little bit
+                DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
+                    isPresentingSignInError = true
+                }
+            }
+        }
         .alert(
             L10n.error,
             isPresented: $isPresentingSignInError
         ) {
             Button(L10n.dismiss, role: .cancel)
         } message: {
-            Text(signInError?.localizedDescription ?? .emptyDash)
+            errorText
         }
         .navigationTitle(L10n.signIn)
         .onAppear {
@@ -135,8 +133,7 @@ struct UserSignInView: View {
             }
         }
         .onDisappear {
-            viewModel.isLoading = false
-            viewModel.stopQuickConnectAuthCheck()
+            viewModel.send(.cancelSignIn)
         }
     }
 }


### PR DESCRIPTION
# Purpose

Quick connect encountered a race condition where the task to monitor fails before the secret was properly fetched. This meant that even after authorization, nothing was monitoring for the authorization status and you'd have to close the quick connect menu and reopen it to authorize.

Additionally on iOS, after authorization, `QuickConnectView` uninitializes (as it should), but then reinitializes and uninitializes immediately after for some reason. This causes a strange state in `UserSignInViewModel` where an extra monitor task is spawned and keeps repeating forever. 

XCode gives a "Publishing changes from background threads is not allowed..." in `NavigationCoordinatable:600` after authorization, so I'm guessing it's something to do with the `router.dismissCoordinator()` in `QuickConnectView`, but wrapping that with `MainActor.run` didn't fix it.

## Bug showcase

(Poll rate was increased here)

![quick_connect_keep_polling](https://github.com/jellyfin/Swiftfin/assets/22553678/7110559f-d968-40a6-b678-b2eb7e9e94a1)

# Fix

- Add `quickConnectState` property to properly block and signal to `checkAuthStatus` when we're ready to poll
  - It now stores the quick connect secret & code since we wait for authorization if and only if we have the secret & code
  - Display these states
- Add `quickConnectMonitorTaskID` property to enforce that only one monitor task should be running at a time, and a for a single source of truth for the task status. 
  - Otherwise, letting the task recurse onto itself over and over with no oversight gets out of hand really easily.
  - Cancelling the task would be nice, but I've had issues with that
- Add `quickConnectMaxRetries` property as a failsafe. In case `UserSignInViewModel` does enter a weird state, we don't want to silently poll for authentication during the entire session.
- Move quick connect stuff to its own section, add docs for the quick connect lifecycle

# Testing

- Check that authorization works after first time entering code
- Checked that polling no longer happens after authorization
- Checked that the new loading & error screens look fine

<details><summary>iOS</summary>
<p>

![Simulator Screen Recording - iPhone 14 Pro - 2023-11-09 at 13 31 21](https://github.com/jellyfin/Swiftfin/assets/22553678/440c28d9-2e18-490b-bfcc-c328660172a0)

</p>
</details> 


<details><summary>tvOS</summary>
<p>

![Simulator Screen Recording - Apple TV - 2023-11-09 at 13 23 46](https://github.com/jellyfin/Swiftfin/assets/22553678/5b9156db-b321-4f52-9a9c-5fcf3d47687a)

</p>
</details> 

# Notes

I did try just using `Task.cancel` before the `taskID` approach, but it's been extremely unreliable and unpredictable for me. It didn't stop `checkAuthStatus` from spawning more tasks unless it was cancelled extremely early. I can elaborate if needed.
