### PR TITLE
iOS: Increase library list item size

### DIFF
--- a/Swiftfin/Components/LibraryItemRow.swift
+++ b/Swiftfin/Components/LibraryItemRow.swift
@@ -17,13 +17,15 @@ struct LibraryItemRow: View {
     private let item: BaseItemDto
     private var onSelect: () -> Void
 
+    private let posterWidth: CGFloat = 60
+
     var body: some View {
         Button {
             onSelect()
         } label: {
             HStack(alignment: .bottom) {
-                ImageView(item.portraitPosterImageSource(maxWidth: 60))
-                    .posterStyle(type: .portrait, width: 60)
+                ImageView(item.portraitPosterImageSource(maxWidth: posterWidth))
+                    .posterStyle(type: .portrait, width: posterWidth)
                     .posterShadow()
 
                 VStack(alignment: .leading) {

--- a/Swiftfin/Components/PagingLibraryView.swift
+++ b/Swiftfin/Components/PagingLibraryView.swift
@@ -27,7 +27,7 @@ struct PagingLibraryView: View {
         if libraryGridPosterType == .landscape && UIDevice.isPhone {
             return .fixedNumberOfColumns(2)
         } else {
-            return .adaptive(withMinItemSize: libraryGridPosterType.width + (UIDevice.isIPad ? 10 : 0))
+            return .adaptive(withMinItemSize: libraryGridPosterType.width + 10)
         }
     }
 

--- a/Swiftfin/Components/PagingLibraryView.swift
+++ b/Swiftfin/Components/PagingLibraryView.swift
@@ -23,11 +23,13 @@ struct PagingLibraryView: View {
 
     private var onSelect: (BaseItemDto) -> Void
 
+    private let portraitPosterScale = 1.25
+
     private var gridLayout: NSCollectionLayoutSection.GridLayoutMode {
         if libraryGridPosterType == .landscape && UIDevice.isPhone {
             return .fixedNumberOfColumns(2)
         } else {
-            return .adaptive(withMinItemSize: libraryGridPosterType.width + 10)
+            return .adaptive(withMinItemSize: libraryGridPosterType.width * portraitPosterScale + 10)
         }
     }
 
@@ -62,7 +64,7 @@ struct PagingLibraryView: View {
     private var libraryGridView: some View {
         CollectionView(items: viewModel.items.elements) { _, item, _ in
             PosterButton(state: .item(item), type: libraryGridPosterType)
-                .scaleItem(libraryGridPosterType == .landscape && UIDevice.isPhone ? 0.85 : 1)
+                .scaleItem(libraryGridPosterType == .landscape && UIDevice.isPhone ? 0.85 : portraitPosterScale)
                 .onSelect {
                     onSelect(item)
                 }


### PR DESCRIPTION
The current library list view seems a bit crowded:

![Screenshot 2023-10-13 at 12 24 08 PM](https://github.com/jellyfin/Swiftfin/assets/13326074/284209bc-fcfc-4fda-bb07-2054409ba1ac)

With the increased size, we have three columns with a bit of padding between the items:

![Screenshot 2023-10-13 at 12 25 12 PM](https://github.com/jellyfin/Swiftfin/assets/13326074/e16bfba2-b10f-429d-bf4f-1865f0ce1009)

Unfortunately testing on a smaller screen (13 mini simulator) results in overlap with no padding. I'm not sure how to fix this, so leaving this PR as a draft for now:

![Screenshot 2023-10-13 at 12 26 02 PM](https://github.com/jellyfin/Swiftfin/assets/13326074/81005ee0-5ecd-40fd-b3dc-e57e3fefef29)
