### PR TITLE
show episodes instead of series in recently added view

### DIFF
--- a/Swiftfin tvOS/Views/HomeView/HomeContentView.swift
+++ b/Swiftfin tvOS/Views/HomeView/HomeContentView.swift
@@ -24,7 +24,7 @@ extension HomeView {
 
                     if viewModel.resumeItems.isEmpty {
                         CinematicRecentlyAddedView(viewModel: .init(
-                            itemTypes: [.movie, .series],
+                            itemTypes: [.movie, .episode],
                             filters: .init(sortOrder: [APISortOrder.descending.filter], sortBy: [SortBy.dateAdded.filter])
                         ))
 
@@ -40,7 +40,7 @@ extension HomeView {
 
                         if viewModel.hasRecentlyAdded {
                             RecentlyAddedView(viewModel: .init(
-                                itemTypes: [.movie, .series],
+                                itemTypes: [.movie, .episode],
                                 filters: .init(sortOrder: [APISortOrder.descending.filter], sortBy: [SortBy.dateAdded.filter])
                             ))
                         }


### PR DESCRIPTION
Previously it listed the recently added *series* which is pretty unuseful i think. If anyone wants that, they're still listed in the "Latest X" sections

<img width="1614" alt="image" src="https://github.com/jellyfin/Swiftfin/assets/622455/f847be2e-27e2-4714-ac29-7a5722129c4d">
