### PR TITLE
Don't build non-existent image URLs

### DIFF
--- a/Shared/Extensions/JellyfinAPI/BaseItemDto+Images.swift
+++ b/Shared/Extensions/JellyfinAPI/BaseItemDto+Images.swift
@@ -105,6 +105,17 @@ extension BaseItemDto {
         return client.fullURL(with: request)
     }
 
+    private func getImageTag(for type: ImageType) -> String? {
+        switch type {
+        case .backdrop:
+            return backdropImageTags?.first
+        case .screenshot:
+            return screenshotImageTags?.first
+        default:
+            return imageTags?[type.rawValue]
+        }
+    }
+
     fileprivate func _imageSource(_ type: ImageType, maxWidth: Int?, maxHeight: Int?) -> ImageSource {
         let url = _imageURL(type, maxWidth: maxWidth, maxHeight: maxHeight, itemID: id ?? "")
         let blurHash = blurHash(type)

--- a/Shared/Extensions/JellyfinAPI/BaseItemDto+Images.swift
+++ b/Shared/Extensions/JellyfinAPI/BaseItemDto+Images.swift
@@ -19,7 +19,7 @@ extension BaseItemDto {
         _ type: ImageType,
         maxWidth: Int? = nil,
         maxHeight: Int? = nil
-    ) -> URL {
+    ) -> URL? {
         _imageURL(type, maxWidth: maxWidth, maxHeight: maxHeight, itemID: id ?? "")
     }
 
@@ -27,7 +27,7 @@ extension BaseItemDto {
         _ type: ImageType,
         maxWidth: CGFloat? = nil,
         maxHeight: CGFloat? = nil
-    ) -> URL {
+    ) -> URL? {
         _imageURL(type, maxWidth: Int(maxWidth), maxHeight: Int(maxHeight), itemID: id ?? "")
     }
 
@@ -52,11 +52,11 @@ extension BaseItemDto {
 
     // MARK: Series Images
 
-    func seriesImageURL(_ type: ImageType, maxWidth: Int? = nil, maxHeight: Int? = nil) -> URL {
+    func seriesImageURL(_ type: ImageType, maxWidth: Int? = nil, maxHeight: Int? = nil) -> URL? {
         _imageURL(type, maxWidth: maxWidth, maxHeight: maxHeight, itemID: seriesID ?? "")
     }
 
-    func seriesImageURL(_ type: ImageType, maxWidth: CGFloat? = nil, maxHeight: CGFloat? = nil) -> URL {
+    func seriesImageURL(_ type: ImageType, maxWidth: CGFloat? = nil, maxHeight: CGFloat? = nil) -> URL? {
         _imageURL(type, maxWidth: Int(maxWidth), maxHeight: Int(maxHeight), itemID: seriesID ?? "")
     }
 
@@ -80,11 +80,13 @@ extension BaseItemDto {
         maxWidth: Int?,
         maxHeight: Int?,
         itemID: String
-    ) -> URL {
+    ) -> URL? {
+        guard let imageTags = imageTags else { return nil }
+        
         // TODO: See if the scaling is actually right so that it isn't so big
         let scaleWidth = maxWidth == nil ? nil : UIScreen.main.scale(maxWidth!)
         let scaleHeight = maxHeight == nil ? nil : UIScreen.main.scale(maxHeight!)
-        let tag = imageTags?[type.rawValue]
+        let tag = imageTags[type.rawValue]
 
         let client = Container.userSession.callAsFunction().client
         let parameters = Paths.GetItemImageParameters(

--- a/Shared/Extensions/JellyfinAPI/BaseItemDto+Images.swift
+++ b/Shared/Extensions/JellyfinAPI/BaseItemDto+Images.swift
@@ -85,11 +85,8 @@ extension BaseItemDto {
         // TODO: See if the scaling is actually right so that it isn't so big
         let scaleWidth = maxWidth == nil ? nil : UIScreen.main.scale(maxWidth!)
         let scaleHeight = maxHeight == nil ? nil : UIScreen.main.scale(maxHeight!)
-        let tag = getImageTag(for: type)
 
-        if tag == nil && type != .backdrop {
-            return nil
-        }
+        guard let tag = getImageTag(for: type) else { return nil }
 
         let client = Container.userSession.callAsFunction().client
         let parameters = Paths.GetItemImageParameters(

--- a/Shared/Extensions/JellyfinAPI/BaseItemDto+Images.swift
+++ b/Shared/Extensions/JellyfinAPI/BaseItemDto+Images.swift
@@ -82,7 +82,7 @@ extension BaseItemDto {
         itemID: String
     ) -> URL? {
         guard let imageTags = imageTags else { return nil }
-        
+
         // TODO: See if the scaling is actually right so that it isn't so big
         let scaleWidth = maxWidth == nil ? nil : UIScreen.main.scale(maxWidth!)
         let scaleHeight = maxHeight == nil ? nil : UIScreen.main.scale(maxHeight!)

--- a/Shared/Extensions/JellyfinAPI/BaseItemDto+Images.swift
+++ b/Shared/Extensions/JellyfinAPI/BaseItemDto+Images.swift
@@ -86,7 +86,8 @@ extension BaseItemDto {
         // TODO: See if the scaling is actually right so that it isn't so big
         let scaleWidth = maxWidth == nil ? nil : UIScreen.main.scale(maxWidth!)
         let scaleHeight = maxHeight == nil ? nil : UIScreen.main.scale(maxHeight!)
-        let tag = imageTags[type.rawValue]
+
+        guard let tag = imageTags[type.rawValue] else { return nil }
 
         let client = Container.userSession.callAsFunction().client
         let parameters = Paths.GetItemImageParameters(

--- a/Shared/Extensions/JellyfinAPI/BaseItemDto+Images.swift
+++ b/Shared/Extensions/JellyfinAPI/BaseItemDto+Images.swift
@@ -81,13 +81,15 @@ extension BaseItemDto {
         maxHeight: Int?,
         itemID: String
     ) -> URL? {
-        guard let imageTags = imageTags else { return nil }
 
         // TODO: See if the scaling is actually right so that it isn't so big
         let scaleWidth = maxWidth == nil ? nil : UIScreen.main.scale(maxWidth!)
         let scaleHeight = maxHeight == nil ? nil : UIScreen.main.scale(maxHeight!)
+        let tag = getImageTag(for: type)
 
-        guard let tag = imageTags[type.rawValue] else { return nil }
+        if tag == nil && type != .backdrop {
+            return nil
+        }
 
         let client = Container.userSession.callAsFunction().client
         let parameters = Paths.GetItemImageParameters(


### PR DESCRIPTION
I believe this fixes #884 as an image URL will only be returned if there are image tags, and without a URL LazyImage should result in the failure case. I don't have a Jellyfin server setup so I could be wrong with my changes so guidance would be appreciated.