### PR TITLE
CI - Fix SPM Cache Directory

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,7 +44,7 @@ jobs:
       - name: Cache Swift packages
         uses: actions/cache@v3
         with:
-          path: .build
+          path: PackageCache
           key: ${{ runner.os }}-${{ matrix.scheme }}-spm-${{ hashFiles('**/Package.resolved') }}
           restore-keys: ${{ runner.os }}-${{ matrix.scheme }}-spm-
       
@@ -57,5 +57,6 @@ jobs:
           command: |
             xcodebuild build -project "Swiftfin.xcodeproj" \
             -scheme "${{ matrix.scheme }}" \
+            -clonedSourcePackagesDirPath PackageCache \
             CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO          
       


### PR DESCRIPTION
The Build workflows are completing with the following warning when attempting to cache Swift Packages:
`Warning: Path Validation Error: Path(s) specified in the action for caching do(es) not exist, hence no cache is being saved.`

To resolve this I created a dedicated directory for the SPM cache.