### PR TITLE
Basic Algorithm Cleanup

### DIFF
--- a/Shared/Extensions/Array.swift
+++ b/Shared/Extensions/Array.swift
@@ -31,7 +31,7 @@ extension Array {
     }
 
     func oneSatisfies(_ predicate: (Element) throws -> Bool) rethrows -> Bool {
-        try first(where: predicate) != nil
+        try contains(where: predicate)
     }
 
     func prepending(_ element: Element) -> [Element] {

--- a/Shared/Extensions/JellyfinAPI/BaseItemDto.swift
+++ b/Shared/Extensions/JellyfinAPI/BaseItemDto.swift
@@ -165,36 +165,38 @@ extension BaseItemDto {
     var fullChapterInfo: [ChapterInfo.FullInfo] {
         guard let chapters else { return [] }
 
-        let ranges: [Range<Int>] = []
-            .appending(chapters.map(\.startTimeSeconds))
+        let ranges: [Range<Int>] = chapters
+            .map(\.startTimeSeconds)
             .appending(runTimeSeconds + 1)
             .adjacentPairs()
             .map { $0 ..< $1 }
-
-        return chapters
+        
+        return zip(chapters, ranges)
             .enumerated()
-            .map { index, chapterInfo in
-
-                let client = Container.userSession.callAsFunction().client
+            .map { i, zip in
+                
                 let parameters = Paths.GetItemImageParameters(
                     maxWidth: 500,
                     quality: 90,
-                    imageIndex: index
+                    imageIndex: i
                 )
+                
                 let request = Paths.getItemImage(
                     itemID: id ?? "",
                     imageType: ImageType.chapter.rawValue,
                     parameters: parameters
                 )
-
-                let imageURL = client.fullURL(with: request)
-
-                let range = ranges.first(where: { $0.first == chapterInfo.startTimeSeconds }) ?? startTimeSeconds ..< startTimeSeconds + 1
-
-                return ChapterInfo.FullInfo(
-                    chapterInfo: chapterInfo,
+                
+                let imageURL = Container
+                    .userSession
+                    .callAsFunction()
+                    .client
+                    .fullURL(with: request)
+                
+                return .init(
+                    chapterInfo: zip.0,
                     imageSource: .init(url: imageURL),
-                    secondsRange: range
+                    secondsRange: zip.1
                 )
             }
     }

--- a/Shared/Extensions/JellyfinAPI/BaseItemDto.swift
+++ b/Shared/Extensions/JellyfinAPI/BaseItemDto.swift
@@ -170,29 +170,29 @@ extension BaseItemDto {
             .appending(runTimeSeconds + 1)
             .adjacentPairs()
             .map { $0 ..< $1 }
-        
+
         return zip(chapters, ranges)
             .enumerated()
             .map { i, zip in
-                
+
                 let parameters = Paths.GetItemImageParameters(
                     maxWidth: 500,
                     quality: 90,
                     imageIndex: i
                 )
-                
+
                 let request = Paths.getItemImage(
                     itemID: id ?? "",
                     imageType: ImageType.chapter.rawValue,
                     parameters: parameters
                 )
-                
+
                 let imageURL = Container
                     .userSession
                     .callAsFunction()
                     .client
                     .fullURL(with: request)
-                
+
                 return .init(
                     chapterInfo: zip.0,
                     imageSource: .init(url: imageURL),


### PR DESCRIPTION
Just saw this in passing and had a few minutes. Saves us a few precious nanoseconds of our lives.

- `contains` is more correct over allocating a local object and nil checking
- make `ChapterInfo.FullInfo` creation O(n) instead of O(n^2)