### PR TITLE
Use `jump` with native double tap gesture instead of single tap gesture in Video Player 

### DIFF
--- a/Shared/Objects/GestureAction.swift
+++ b/Shared/Objects/GestureAction.swift
@@ -29,27 +29,13 @@ enum LongPressAction: String, GestureAction {
     }
 }
 
-enum MultiTapAction: String, GestureAction {
-
-    case none
-    case jump
-
-    var displayTitle: String {
-        switch self {
-        case .none:
-            return L10n.none
-        case .jump:
-            return "Jump"
-        }
-    }
-}
-
 enum DoubleTouchAction: String, GestureAction {
 
     case none
     case aspectFill
     case gestureLock
     case pausePlay
+    case jump
 
     var displayTitle: String {
         switch self {
@@ -61,6 +47,8 @@ enum DoubleTouchAction: String, GestureAction {
             return "Gesture Lock"
         case .pausePlay:
             return "Pause/Play"
+        case .jump:
+            return "Jump"
         }
     }
 }

--- a/Shared/Services/SwiftfinDefaults.swift
+++ b/Shared/Services/SwiftfinDefaults.swift
@@ -131,10 +131,9 @@ extension Defaults.Keys {
                 default: .gestureLock,
                 suite: .generalSuite
             )
-            static let multiTapGesture: Key<MultiTapAction> = .init("videoPlayerMultiTapGesture", default: .none, suite: .generalSuite)
             static let doubleTouchGesture: Key<DoubleTouchAction> = .init(
                 "videoPlayerDoubleTouchGesture",
-                default: .none,
+                default: .jump,
                 suite: .generalSuite
             )
             static let pinchGesture: Key<PinchAction> = .init("videoPlayerSwipeGesture", default: .aspectFill, suite: .generalSuite)

--- a/Shared/ViewModels/VideoPlayerViewModel.swift
+++ b/Shared/ViewModels/VideoPlayerViewModel.swift
@@ -70,7 +70,7 @@ class VideoPlayerViewModel: ViewModel {
         configuration.startTime = .seconds(max(0, item.startTimeSeconds - Defaults[.VideoPlayer.resumeOffset]))
         configuration.audioIndex = .absolute(selectedAudioStreamIndex)
         configuration.subtitleIndex = .absolute(selectedSubtitleStreamIndex)
-        configuration.subtitleSize = .absolute(Defaults[.VideoPlayer.Subtitle.subtitleSize])
+        configuration.subtitleSize = .absolute(32 - Defaults[.VideoPlayer.Subtitle.subtitleSize])
         configuration.subtitleColor = .absolute(Defaults[.VideoPlayer.Subtitle.subtitleColor].uiColor)
 
         if let font = UIFont(name: Defaults[.VideoPlayer.Subtitle.subtitleFontName], size: 0) {

--- a/Swiftfin/Views/SettingsView/GestureSettingsView.swift
+++ b/Swiftfin/Views/SettingsView/GestureSettingsView.swift
@@ -22,8 +22,6 @@ struct GestureSettingsView: View {
     private var horizontalSwipeGesture
     @Default(.VideoPlayer.Gesture.longPressGesture)
     private var longPressGesture
-    @Default(.VideoPlayer.Gesture.multiTapGesture)
-    private var multiTapGesture
     @Default(.VideoPlayer.Gesture.doubleTouchGesture)
     private var doubleTouchGesture
     @Default(.VideoPlayer.Gesture.pinchGesture)
@@ -45,8 +43,6 @@ struct GestureSettingsView: View {
                     .disabled(horizontalPanGesture != .none && horizontalSwipeGesture == .none)
 
                 EnumPicker(title: "Long Press", selection: $longPressGesture)
-
-                EnumPicker(title: "Multi Tap", selection: $multiTapGesture)
 
                 EnumPicker(title: "Double Touch", selection: $doubleTouchGesture)
 

--- a/Swiftfin/Views/VideoPlayer/VideoPlayer.swift
+++ b/Swiftfin/Views/VideoPlayer/VideoPlayer.swift
@@ -59,8 +59,6 @@ struct VideoPlayer: View {
     private var horizontalSwipeGesture
     @Default(.VideoPlayer.Gesture.longPressGesture)
     private var longPressGesture
-    @Default(.VideoPlayer.Gesture.multiTapGesture)
-    private var multiTapGesture
     @Default(.VideoPlayer.Gesture.doubleTouchGesture)
     private var doubleTouchGesture
     @Default(.VideoPlayer.Gesture.pinchGesture)
@@ -146,8 +144,8 @@ struct VideoPlayer: View {
                         .onHorizontalSwipe(translation: 100, velocity: 1500, sameSwipeDirectionTimeout: 1, handleHorizontalSwipe)
                         .onLongPress(minimumDuration: 2, handleLongPress)
                         .onPinch(handlePinchGesture)
-                        .onTap(samePointPadding: 10, samePointTimeout: 0.7, handleTapGesture)
-                        .onDoubleTouch(handleDoubleTouchGesture)
+                        .onTap(handleTapGesture)
+                        .onDoubleTouch(doubleTapTimeout: 0.7, handleDoubleTouchGesture)
                         .onVerticalPan {
                             if $1.x <= 0.5 {
                                 handlePan(action: verticalGestureLeft, state: $0, point: -$1.y, velocity: $2, translation: $3)
@@ -339,28 +337,14 @@ extension VideoPlayer {
         }
     }
 
-    private func handleTapGesture(unitPoint: UnitPoint, taps: Int) {
+    private func handleTapGesture(unitPoint: UnitPoint) {
         guard !isGestureLocked else {
             updateViewProxy.present(systemName: "lock.fill", title: "Gestures Locked")
             return
         }
-
-        if taps > 1 && multiTapGesture != .none {
-
-            withAnimation(.linear(duration: 0.1)) {
-                isPresentingOverlay = false
-            }
-
-            switch multiTapGesture {
-            case .none:
-                return
-            case .jump:
-                jumpAction(unitPoint: unitPoint, amount: taps - 1)
-            }
-        } else {
-            withAnimation(.linear(duration: 0.1)) {
-                isPresentingOverlay = !isPresentingOverlay
-            }
+        
+        withAnimation(.linear(duration: 0.1)) {
+            isPresentingOverlay = !isPresentingOverlay
         }
     }
 
@@ -374,11 +358,12 @@ extension VideoPlayer {
         case .none:
             return
         case .aspectFill: ()
-//            aspectFillAction(state: state, unitPoint: unitPoint, scale: <#T##CGFloat#>)
         case .gestureLock:
             guard !isPresentingOverlay else { return }
             isGestureLocked.toggle()
         case .pausePlay: ()
+        case .jump:
+            jumpAction(unitPoint: unitPoint, amount: taps)
         }
     }
 }

--- a/Swiftfin/Views/VideoPlayer/VideoPlayer.swift
+++ b/Swiftfin/Views/VideoPlayer/VideoPlayer.swift
@@ -231,7 +231,7 @@ struct VideoPlayer: View {
             videoPlayerManager.proxy.setSubtitleDelay(.ticks(newValue))
         }
         .onChange(of: subtitleSize) { newValue in
-            videoPlayerManager.proxy.setSubtitleSize(.absolute(24 - newValue))
+            videoPlayerManager.proxy.setSubtitleSize(.absolute(32 - newValue))
         }
         .onChange(of: videoPlayerManager.currentViewModel) { newViewModel in
             guard let newViewModel else { return }


### PR DESCRIPTION
The problem with the current video player is that it is using single tap gesture with a custom timeout for `jump` action. This has multiple disadvantages

1. The overlay screen will always show in the first tap
2. Since it's not a native double tap gesture, I've experienced a scenario that this PR will address.

Scenario
1. first, tap on the player screen ( this will always shows the overlay )
2. since the overlay is shown, I want to hide it by tapping again.
3. The player recognizes the second tap within the timeout period and causes the player to perform `jump` instead.

What this PR will address
1. The first tap on the player will not show the overlay anymore. (the overlay will be shown only if the double tap gesture is not performed).
2. Will address the behavior scenario mentioned above.