### PR TITLE
Fix transcode URL construction bug

### DIFF
--- a/Shared/Extensions/JellyfinAPI/MediaSourceInfo+ItemVideoPlayerViewModel.swift
+++ b/Shared/Extensions/JellyfinAPI/MediaSourceInfo+ItemVideoPlayerViewModel.swift
@@ -21,9 +21,7 @@ extension MediaSourceInfo {
         let streamType: StreamType
 
         if let transcodingURL, !Defaults[.Experimental.forceDirectPlay] {
-            guard let fullTranscodeURL = URL(string: transcodingURL, relativeTo: userSession.server.currentURL)
-            else { throw JellyfinAPIError("Unable to construct transcoded url") }
-            playbackURL = fullTranscodeURL
+            playbackURL = userSession.client.fullURL(with: transcodingURL)
             streamType = .transcode
         } else {
 


### PR DESCRIPTION
I found this while mucking around the code; When the url is `/video/` etc., it gets incorrectly added onto the current server URL.

I have no idea why, but the way below seems to work properly, and after I added this method, it seems to work correctly on my Apple TV HD.

Otherwise, the transcode URL will have no host and no scheme, causing the player to exit immediately without error.