### PR TITLE
[tvOS][QOL] Supports back button click when in the native player.

### DIFF
--- a/Shared/Coordinators/VideoPlayerCoordinator.swift
+++ b/Shared/Coordinators/VideoPlayerCoordinator.swift
@@ -45,7 +45,7 @@ final class VideoPlayerCoordinator: NavigationCoordinatable {
             AppDelegate.enterPlaybackOrientation()
         }
 
-        #else // os(iOS)
+        #else
         if Defaults[.VideoPlayer.videoPlayerType] == .swiftfin {
             PreferenceUIHostingControllerView {
                 Group {
@@ -56,6 +56,6 @@ final class VideoPlayerCoordinator: NavigationCoordinatable {
         } else {
             NativeVideoPlayer(manager: self.videoPlayerManager)
         }
-        #endif // os(iOS)
+        #endif 
     }
 }

--- a/Shared/Coordinators/VideoPlayerCoordinator.swift
+++ b/Shared/Coordinators/VideoPlayerCoordinator.swift
@@ -3,7 +3,7 @@
 // License, v2.0. If a copy of the MPL was not distributed with this
 // file, you can obtain one at https://mozilla.org/MPL/2.0/.
 //
-// Copyright (c) 2023 Jellyfin & Jellyfin Contributors
+// Copyright (c) 2024 Jellyfin & Jellyfin Contributors
 //
 
 import Defaults
@@ -45,19 +45,17 @@ final class VideoPlayerCoordinator: NavigationCoordinatable {
             AppDelegate.enterPlaybackOrientation()
         }
 
-        #else
-
-        PreferenceUIHostingControllerView {
-            Group {
-                if Defaults[.VideoPlayer.videoPlayerType] == .swiftfin {
+        #else // os(iOS)
+        if Defaults[.VideoPlayer.videoPlayerType] == .swiftfin {
+            PreferenceUIHostingControllerView {
+                Group {
                     VideoPlayer(manager: self.videoPlayerManager)
-                } else {
-                    NativeVideoPlayer(manager: self.videoPlayerManager)
                 }
             }
+            .ignoresSafeArea()
+        } else {
+            NativeVideoPlayer(manager: self.videoPlayerManager)
         }
-        .ignoresSafeArea()
-
-        #endif
+        #endif // os(iOS)
     }
 }

--- a/Shared/Coordinators/VideoPlayerCoordinator.swift
+++ b/Shared/Coordinators/VideoPlayerCoordinator.swift
@@ -48,14 +48,12 @@ final class VideoPlayerCoordinator: NavigationCoordinatable {
         #else
         if Defaults[.VideoPlayer.videoPlayerType] == .swiftfin {
             PreferenceUIHostingControllerView {
-                Group {
-                    VideoPlayer(manager: self.videoPlayerManager)
-                }
+                VideoPlayer(manager: self.videoPlayerManager)
             }
             .ignoresSafeArea()
         } else {
             NativeVideoPlayer(manager: self.videoPlayerManager)
         }
-        #endif 
+        #endif
     }
 }

--- a/Swiftfin tvOS/Views/VideoPlayer/NativeVideoPlayer.swift
+++ b/Swiftfin tvOS/Views/VideoPlayer/NativeVideoPlayer.swift
@@ -58,7 +58,7 @@ struct NativeVideoPlayerView: UIViewControllerRepresentable {
 
 // TODO: Refactor such that this does not subclass AVPlayerViewController. Subclassing is not
 // supported according to the apple docs.
-class UINativeVideoPlayerViewController: AVPlayerViewController, AVPlayerViewControllerDelegate {
+class UINativeVideoPlayerViewController: AVPlayerViewController {
 
     let videoPlayerManager: VideoPlayerManager
 
@@ -105,7 +105,6 @@ class UINativeVideoPlayerViewController: AVPlayerViewController, AVPlayerViewCon
         }
 
         player = newPlayer
-        self.delegate = self
     }
 
     @available(*, unavailable)
@@ -173,12 +172,5 @@ class UINativeVideoPlayerViewController: AVPlayerViewController, AVPlayerViewCon
         player?.pause()
 
         videoPlayerManager.sendStopReport()
-    }
-
-    // MARK: AVPlayerViewControllerDelegateFunctions
-
-    public func playerViewControllerShouldDismiss(_ playerViewController: AVPlayerViewController) -> Bool {
-        dismiss(animated: true)
-        return true
     }
 }

--- a/Swiftfin tvOS/Views/VideoPlayer/NativeVideoPlayer.swift
+++ b/Swiftfin tvOS/Views/VideoPlayer/NativeVideoPlayer.swift
@@ -3,7 +3,7 @@
 // License, v2.0. If a copy of the MPL was not distributed with this
 // file, you can obtain one at https://mozilla.org/MPL/2.0/.
 //
-// Copyright (c) 2023 Jellyfin & Jellyfin Contributors
+// Copyright (c) 2024 Jellyfin & Jellyfin Contributors
 //
 
 import AVKit
@@ -37,7 +37,6 @@ struct NativeVideoPlayer: View {
             if let _ = videoPlayerManager.currentViewModel {
                 playerView
             } else {
-//                VideoPlayer.LoadingView()
                 Text("Loading")
             }
         }
@@ -57,7 +56,9 @@ struct NativeVideoPlayerView: UIViewControllerRepresentable {
     func updateUIViewController(_ uiViewController: UINativeVideoPlayerViewController, context: Context) {}
 }
 
-class UINativeVideoPlayerViewController: AVPlayerViewController {
+// TODO: Refactor such that this does not subclass AVPlayerViewController. Subclassing is not
+// supported according to the apple docs.
+class UINativeVideoPlayerViewController: AVPlayerViewController, AVPlayerViewControllerDelegate {
 
     let videoPlayerManager: VideoPlayerManager
 
@@ -104,6 +105,7 @@ class UINativeVideoPlayerViewController: AVPlayerViewController {
         }
 
         player = newPlayer
+        self.delegate = self
     }
 
     @available(*, unavailable)
@@ -171,5 +173,12 @@ class UINativeVideoPlayerViewController: AVPlayerViewController {
         player?.pause()
 
         videoPlayerManager.sendStopReport()
+    }
+
+    // MARK: AVPlayerViewControllerDelegateFunctions
+
+    public func playerViewControllerShouldDismiss(_ playerViewController: AVPlayerViewController) -> Bool {
+        dismiss(animated: true)
+        return true
     }
 }

--- a/Swiftfin tvOS/Views/VideoPlayer/NativeVideoPlayer.swift
+++ b/Swiftfin tvOS/Views/VideoPlayer/NativeVideoPlayer.swift
@@ -37,7 +37,7 @@ struct NativeVideoPlayer: View {
             if let _ = videoPlayerManager.currentViewModel {
                 playerView
             } else {
-                // TODO: Implement more polished loading screen.
+//                VideoPlayer.LoadingView()
                 Text("Loading")
             }
         }

--- a/Swiftfin tvOS/Views/VideoPlayer/NativeVideoPlayer.swift
+++ b/Swiftfin tvOS/Views/VideoPlayer/NativeVideoPlayer.swift
@@ -37,6 +37,7 @@ struct NativeVideoPlayer: View {
             if let _ = videoPlayerManager.currentViewModel {
                 playerView
             } else {
+                // TODO: Implement more polished loading screen.
                 Text("Loading")
             }
         }


### PR DESCRIPTION
Conforms `UINativeVideoPlayerViewController` to `AVPlayerViewControllerDelegate` and implements `playerViewControllerShouldDismiss`.  This method is called by AV player view controller when the player should be dismissed.  This function is only called when the playback overlay is not displayed otherwise a back button press will dismiss the overlay.

Fixes #925