### PR TITLE
[tvOS][Bug] Fixes stale home content.

### DIFF
--- a/Shared/Coordinators/HomeCoordinator.swift
+++ b/Shared/Coordinators/HomeCoordinator.swift
@@ -15,9 +15,6 @@ final class HomeCoordinator: NavigationCoordinatable {
 
     let stack = NavigationStack(initial: \HomeCoordinator.start)
 
-    var homeView: HomeView { _homeView }
-    private lazy var _homeView = HomeView(viewModel: .init())
-
     @Root
     var start = makeStart
     @Route(.modal)
@@ -69,7 +66,8 @@ final class HomeCoordinator: NavigationCoordinatable {
     }
     #endif
 
+    @ViewBuilder
     func makeStart() -> some View {
-        homeView
+        HomeView(viewModel: .init())
     }
 }

--- a/Shared/Coordinators/HomeCoordinator.swift
+++ b/Shared/Coordinators/HomeCoordinator.swift
@@ -3,7 +3,7 @@
 // License, v2.0. If a copy of the MPL was not distributed with this
 // file, you can obtain one at https://mozilla.org/MPL/2.0/.
 //
-// Copyright (c) 2023 Jellyfin & Jellyfin Contributors
+// Copyright (c) 2024 Jellyfin & Jellyfin Contributors
 //
 
 import Foundation
@@ -14,6 +14,9 @@ import SwiftUI
 final class HomeCoordinator: NavigationCoordinatable {
 
     let stack = NavigationStack(initial: \HomeCoordinator.start)
+
+    var homeView: HomeView { _homeView }
+    private lazy var _homeView = HomeView(viewModel: .init())
 
     @Root
     var start = makeStart
@@ -66,8 +69,7 @@ final class HomeCoordinator: NavigationCoordinatable {
     }
     #endif
 
-    @ViewBuilder
     func makeStart() -> some View {
-        HomeView(viewModel: .init())
+        homeView
     }
 }

--- a/Shared/Coordinators/MainCoordinator/tvOSMainTabCoordinator.swift
+++ b/Shared/Coordinators/MainCoordinator/tvOSMainTabCoordinator.swift
@@ -3,7 +3,7 @@
 // License, v2.0. If a copy of the MPL was not distributed with this
 // file, you can obtain one at https://mozilla.org/MPL/2.0/.
 //
-// Copyright (c) 2023 Jellyfin & Jellyfin Contributors
+// Copyright (c) 2024 Jellyfin & Jellyfin Contributors
 //
 
 import Foundation
@@ -33,8 +33,10 @@ final class MainTabCoordinator: TabCoordinatable {
     @Route(tabItem: makeSettingsTab)
     var settings = makeSettings
 
+    var homeCoordinator = HomeCoordinator()
+
     func makeHome() -> NavigationViewCoordinator<HomeCoordinator> {
-        NavigationViewCoordinator(HomeCoordinator())
+        NavigationViewCoordinator(homeCoordinator)
     }
 
     @ViewBuilder
@@ -109,5 +111,17 @@ final class MainTabCoordinator: TabCoordinatable {
     func makeSettingsTab(isActive: Bool) -> some View {
         Image(systemName: "gearshape.fill")
             .accessibilityLabel(L10n.settings)
+    }
+
+    @ViewBuilder
+    func customize(_ view: AnyView) -> some View {
+        weak var weakSelf = self
+        view.onAppear(perform: {
+            weakSelf?.viewDidAppear()
+        })
+    }
+
+    private func viewDidAppear() {
+        homeCoordinator.homeView.viewModel.refresh()
     }
 }

--- a/Shared/Coordinators/MainCoordinator/tvOSMainTabCoordinator.swift
+++ b/Shared/Coordinators/MainCoordinator/tvOSMainTabCoordinator.swift
@@ -33,10 +33,8 @@ final class MainTabCoordinator: TabCoordinatable {
     @Route(tabItem: makeSettingsTab)
     var settings = makeSettings
 
-    var homeCoordinator = HomeCoordinator()
-
     func makeHome() -> NavigationViewCoordinator<HomeCoordinator> {
-        NavigationViewCoordinator(homeCoordinator)
+        NavigationViewCoordinator(HomeCoordinator())
     }
 
     @ViewBuilder
@@ -111,17 +109,5 @@ final class MainTabCoordinator: TabCoordinatable {
     func makeSettingsTab(isActive: Bool) -> some View {
         Image(systemName: "gearshape.fill")
             .accessibilityLabel(L10n.settings)
-    }
-
-    @ViewBuilder
-    func customize(_ view: AnyView) -> some View {
-        weak var weakSelf = self
-        view.onAppear(perform: {
-            weakSelf?.viewDidAppear()
-        })
-    }
-
-    private func viewDidAppear() {
-        homeCoordinator.homeView.viewModel.refresh()
     }
 }

--- a/Shared/Objects/AppNotifications.swift
+++ b/Shared/Objects/AppNotifications.swift
@@ -1,0 +1,14 @@
+//
+// Swiftfin is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, you can obtain one at https://mozilla.org/MPL/2.0/.
+//
+// Copyright (c) 2024 Jellyfin & Jellyfin Contributors
+//
+
+import Foundation
+
+enum AppNotifications {
+    // Posted when the now playing data has likely become stale.
+    static let nowPlayingDidChange = Notification.Name(rawValue: "nowPlayingDidChange")
+}

--- a/Shared/ViewModels/VideoPlayerManager/VideoPlayerManager.swift
+++ b/Shared/ViewModels/VideoPlayerManager/VideoPlayerManager.swift
@@ -3,7 +3,7 @@
 // License, v2.0. If a copy of the MPL was not distributed with this
 // file, you can obtain one at https://mozilla.org/MPL/2.0/.
 //
-// Copyright (c) 2023 Jellyfin & Jellyfin Contributors
+// Copyright (c) 2024 Jellyfin & Jellyfin Contributors
 //
 
 import Combine
@@ -221,6 +221,7 @@ class VideoPlayerManager: ViewModel {
             let request = Paths.reportPlaybackStopped(stopInfo)
             let _ = try await userSession.client.send(request)
         }
+        NotificationCenter.default.post(name: AppNotifications.nowPlayingDidChange, object: nil)
     }
 
     func sendPauseReport() {

--- a/Swiftfin tvOS/Views/HomeView/HomeView.swift
+++ b/Swiftfin tvOS/Views/HomeView/HomeView.swift
@@ -3,7 +3,7 @@
 // License, v2.0. If a copy of the MPL was not distributed with this
 // file, you can obtain one at https://mozilla.org/MPL/2.0/.
 //
-// Copyright (c) 2023 Jellyfin & Jellyfin Contributors
+// Copyright (c) 2024 Jellyfin & Jellyfin Contributors
 //
 
 import Defaults
@@ -34,5 +34,11 @@ struct HomeView: View {
         }
         .edgesIgnoringSafeArea(.top)
         .edgesIgnoringSafeArea(.horizontal)
+        .onAppear(perform: {
+            viewModel.isVisible = true
+        })
+        .onDisappear(perform: {
+            viewModel.isVisible = false
+        })
     }
 }

--- a/Swiftfin.xcodeproj/project.pbxproj
+++ b/Swiftfin.xcodeproj/project.pbxproj
@@ -158,6 +158,8 @@
 		BD0BA22C2AD6503B00306A8D /* OnlineVideoPlayerManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD0BA22A2AD6503B00306A8D /* OnlineVideoPlayerManager.swift */; };
 		BD0BA22E2AD6508C00306A8D /* DownloadVideoPlayerManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD0BA22D2AD6508C00306A8D /* DownloadVideoPlayerManager.swift */; };
 		BD0BA22F2AD6508C00306A8D /* DownloadVideoPlayerManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD0BA22D2AD6508C00306A8D /* DownloadVideoPlayerManager.swift */; };
+		BE036E222B536E600005A13F /* AppNotifications.swift in Sources */ = {isa = PBXBuildFile; fileRef = BE036E212B536E600005A13F /* AppNotifications.swift */; };
+		BE036E232B5371810005A13F /* AppNotifications.swift in Sources */ = {isa = PBXBuildFile; fileRef = BE036E212B536E600005A13F /* AppNotifications.swift */; };
 		C400DB6A27FE894F007B65FE /* LiveTVChannelsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C400DB6927FE894F007B65FE /* LiveTVChannelsView.swift */; };
 		C400DB6B27FE8C97007B65FE /* LiveTVChannelItemElement.swift in Sources */ = {isa = PBXBuildFile; fileRef = C4E52304272CE68800654268 /* LiveTVChannelItemElement.swift */; };
 		C400DB6D27FE8E65007B65FE /* LiveTVChannelItemWideElement.swift in Sources */ = {isa = PBXBuildFile; fileRef = C400DB6C27FE8E65007B65FE /* LiveTVChannelItemWideElement.swift */; };
@@ -914,6 +916,7 @@
 		AE8C3158265D6F90008AA076 /* bitrates.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = bitrates.json; sourceTree = "<group>"; };
 		BD0BA22A2AD6503B00306A8D /* OnlineVideoPlayerManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnlineVideoPlayerManager.swift; sourceTree = "<group>"; };
 		BD0BA22D2AD6508C00306A8D /* DownloadVideoPlayerManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DownloadVideoPlayerManager.swift; sourceTree = "<group>"; };
+		BE036E212B536E600005A13F /* AppNotifications.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppNotifications.swift; sourceTree = "<group>"; };
 		C400DB6927FE894F007B65FE /* LiveTVChannelsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LiveTVChannelsView.swift; sourceTree = "<group>"; };
 		C400DB6C27FE8E65007B65FE /* LiveTVChannelItemWideElement.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LiveTVChannelItemWideElement.swift; sourceTree = "<group>"; };
 		C40CD924271F8D1E000FB198 /* ItemTypeLibraryViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ItemTypeLibraryViewModel.swift; sourceTree = "<group>"; };
@@ -1538,6 +1541,7 @@
 		535870AB2669D8D300D05A09 /* Objects */ = {
 			isa = PBXGroup;
 			children = (
+				BE036E212B536E600005A13F /* AppNotifications.swift */,
 				E1D4BF802719D22800A11E64 /* AppAppearance.swift */,
 				53192D5C265AA78A008A4215 /* DeviceProfileBuilder.swift */,
 				E17FB55128C119D400311DFE /* Displayable.swift */,
@@ -3072,6 +3076,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				BE036E232B5371810005A13F /* AppNotifications.swift in Sources */,
 				E193D53627193F8500900D82 /* LibraryCoordinator.swift in Sources */,
 				E1CCC3D228C858A50020ED54 /* UserProfileButton.swift in Sources */,
 				C4BE07742725EB66003F4AD1 /* LiveTVProgramsView.swift in Sources */,
@@ -3353,6 +3358,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				BE036E222B536E600005A13F /* AppNotifications.swift in Sources */,
 				E11245B428D97D5D00D8A977 /* BottomBarView.swift in Sources */,
 				E17FB55528C1250B00311DFE /* SimilarItemsHStack.swift in Sources */,
 				5364F455266CA0DC0026ECBA /* BaseItemPerson.swift in Sources */,


### PR DESCRIPTION
When the tab bar controller appears on the screen the home view's content is refreshed.  This refreshes the content when it might be stale, like the user returning to the main page from the player.

Attaches an action on the tab bar coordinator's view.  Exposes the home coordinator's view model to refresh from the tab coordinator.

An alternative is to attach the onAppear to `HomeView` directly, however this action is fired on tab switch.  At the moment the content does not update on tab switch.

Fixes #904