### PR TITLE
[tvOS][Bug] Fixes season selector only showing a single season.

### DIFF
--- a/Shared/ViewModels/ItemViewModel/SeriesItemViewModel.swift
+++ b/Shared/ViewModels/ItemViewModel/SeriesItemViewModel.swift
@@ -3,7 +3,7 @@
 // License, v2.0. If a copy of the MPL was not distributed with this
 // file, you can obtain one at https://mozilla.org/MPL/2.0/.
 //
-// Copyright (c) 2023 Jellyfin & Jellyfin Contributors
+// Copyright (c) 2024 Jellyfin & Jellyfin Contributors
 //
 
 import Combine
@@ -20,9 +20,13 @@ final class SeriesItemViewModel: ItemViewModel, MenuPosterHStackModel {
     var menuSections: [BaseItemDto: [BaseItemDto]]
     var menuSectionSort: (BaseItemDto, BaseItemDto) -> Bool
 
+    /// A list of seasons in this series. Resolved once. Populated when `menuSelection` is published.
+    var seasons: [BaseItemDto]
+
     override init(item: BaseItemDto) {
         self.menuSections = [:]
         self.menuSectionSort = { i, j in i.indexNumber ?? -1 < j.indexNumber ?? -1 }
+        self.seasons = []
 
         super.init(item: item)
 
@@ -136,6 +140,7 @@ final class SeriesItemViewModel: ItemViewModel, MenuPosterHStackModel {
             if let firstSeason = seasons.first {
                 self.getEpisodesForSeason(firstSeason)
                 await MainActor.run {
+                    self.seasons = seasons
                     self.menuSelection = firstSeason
                 }
             }

--- a/Shared/ViewModels/ItemViewModel/SeriesItemViewModel.swift
+++ b/Shared/ViewModels/ItemViewModel/SeriesItemViewModel.swift
@@ -117,7 +117,7 @@ final class SeriesItemViewModel: ItemViewModel, MenuPosterHStackModel {
     func select(section: BaseItemDto) {
         self.menuSelection = section
 
-        if let seasonData = menuSections[section], seasonData.isEmpty {
+        if let episodes = menuSections[section], episodes.isEmpty {
             getEpisodesForSeason(section)
         }
     }
@@ -131,7 +131,7 @@ final class SeriesItemViewModel: ItemViewModel, MenuPosterHStackModel {
             let request = Paths.getSeasons(seriesID: item.id!, parameters: parameters)
             let response = try await userSession.client.send(request)
 
-            let seasons = response.value.items ?? []
+            guard let seasons = response.value.items else { return }
             if let firstSeason = seasons.first {
                 self.getEpisodesForSeason(firstSeason)
                 await MainActor.run {

--- a/Shared/ViewModels/ItemViewModel/SeriesItemViewModel.swift
+++ b/Shared/ViewModels/ItemViewModel/SeriesItemViewModel.swift
@@ -132,12 +132,14 @@ final class SeriesItemViewModel: ItemViewModel, MenuPosterHStackModel {
             let response = try await userSession.client.send(request)
 
             guard let seasons = response.value.items else { return }
+            await MainActor.run {
+                for season in seasons {
+                    self.menuSections[season] = []
+                }
+            }
             if let firstSeason = seasons.first {
                 self.getEpisodesForSeason(firstSeason)
                 await MainActor.run {
-                    for season in seasons {
-                        self.menuSections[season] = []
-                    }
                     self.menuSelection = firstSeason
                 }
             }

--- a/Swiftfin tvOS/Views/ItemView/SeriesItemView/Components/SeriesEpisodeSelector.swift
+++ b/Swiftfin tvOS/Views/ItemView/SeriesItemView/Components/SeriesEpisodeSelector.swift
@@ -3,7 +3,7 @@
 // License, v2.0. If a copy of the MPL was not distributed with this
 // file, you can obtain one at https://mozilla.org/MPL/2.0/.
 //
-// Copyright (c) 2023 Jellyfin & Jellyfin Contributors
+// Copyright (c) 2024 Jellyfin & Jellyfin Contributors
 //
 
 import Introspect
@@ -47,7 +47,7 @@ extension SeriesEpisodeSelector {
         var body: some View {
             ScrollView(.horizontal, showsIndicators: false) {
                 HStack {
-                    ForEach(viewModel.menuSections.keys.sorted(by: { viewModel.menuSectionSort($0, $1) }), id: \.self) { season in
+                    ForEach(viewModel.seasons.sorted(by: { viewModel.menuSectionSort($0, $1) }), id: \.self) { season in
                         Button {
                             Text(season.displayTitle)
                                 .fontWeight(.semibold)
@@ -159,7 +159,6 @@ extension SeriesEpisodeSelector {
             }
             .onChange(of: viewModel.menuSelection) { _ in
                 lastFocusedEpisodeID = items.first?.id
-                wrappedScrollView?.scrollToTop(animated: false)
             }
             .onChange(of: focusedEpisodeID) { episodeIndex in
                 guard let episodeIndex = episodeIndex else { return }

--- a/Swiftfin tvOS/Views/ItemView/SeriesItemView/Components/SeriesEpisodeSelector.swift
+++ b/Swiftfin tvOS/Views/ItemView/SeriesItemView/Components/SeriesEpisodeSelector.swift
@@ -47,7 +47,7 @@ extension SeriesEpisodeSelector {
         var body: some View {
             ScrollView(.horizontal, showsIndicators: false) {
                 HStack {
-                    ForEach(viewModel.seasons.sorted(by: { viewModel.menuSectionSort($0, $1) }), id: \.self) { season in
+                    ForEach(viewModel.menuSections.keys.sorted(by: { viewModel.menuSectionSort($0, $1) }), id: \.self) { season in
                         Button {
                             Text(season.displayTitle)
                                 .fontWeight(.semibold)


### PR DESCRIPTION
Upon initial view load, only the first season is loaded into `menuSections` when the episode list is resolved.

This change stores the list of all seasons, which contain their display name.  When changing the series selector, `menuSections` is updated with season details.

Also when changing seasons in the picker, the containing scroll view scrolled to the top of the page.  This was jarring.  This change also removes that behavior.