### PR TITLE
Minor UI Update for ConnectToServer View

### DIFF
--- a/Swiftfin/Views/ConnectToServerView.swift
+++ b/Swiftfin/Views/ConnectToServerView.swift
@@ -33,7 +33,13 @@ struct ConnectToServerView: View {
     @State
     private var isPresentingError: Bool = false
     @State
-    private var url = "http://"
+    private var url = ""
+    @State
+    private var urlPrefix = "http://"
+    @State
+    private var urlPostfix = ""
+
+    private let prefixOptions = ["http://", "https://"]
 
     private func connectToServer() {
         let task = Task {
@@ -64,11 +70,22 @@ struct ConnectToServerView: View {
     @ViewBuilder
     private var connectSection: some View {
         Section {
-            TextField(L10n.serverURL, text: $url)
-                .disableAutocorrection(true)
-                .autocapitalization(.none)
-                .keyboardType(.URL)
-
+            HStack {
+                Menu {
+                    Picker(selection: $urlPrefix) {
+                        ForEach(prefixOptions) { value in
+                            Text(value)
+                                .tag(value)
+                        }
+                    } label: {}
+                } label: {
+                    Text(urlPrefix)
+                }.id(urlPrefix)
+                TextField(L10n.serverURL, text: $urlPostfix)
+                    .disableAutocorrection(true)
+                    .autocapitalization(.none)
+                    .keyboardType(.URL)
+            }
             if isConnecting {
                 Button(role: .destructive) {
                     connectionTask?.cancel()
@@ -78,11 +95,12 @@ struct ConnectToServerView: View {
                 }
             } else {
                 Button {
+                    url = urlPrefix + urlPostfix
                     connectToServer()
                 } label: {
                     L10n.connect.text
                 }
-                .disabled(URL(string: url) == nil || isConnecting)
+                .disabled(URL(string: urlPrefix + urlPostfix) == nil || isConnecting)
             }
         } header: {
             L10n.connectToJellyfinServer.text


### PR DESCRIPTION
Adds a picker before the text field to select 'http://' or 'https://', meaning default 'http://' text is not needed.
Original method just seemed a bit clunky when using the app, however there may be some reason why something other than http/s needs to be entered that I don't know about, so please let me know.

https://github.com/jellyfin/Swiftfin/assets/156718015/f5fa8dc9-0771-4929-824b-87a7f60d0efc

This is my first PR, so please let me know if I have done anything incorrectly. Thanks
