### PR TITLE
iOS - Temporarily Disable LiveTV and Advanced Video Player Action

### DIFF
--- a/Shared/Objects/VideoPlayerActionButton.swift
+++ b/Shared/Objects/VideoPlayerActionButton.swift
@@ -9,9 +9,10 @@
 import Defaults
 import Foundation
 
+// TODO: atow, advanced was removed to be redesigned before being released
 enum VideoPlayerActionButton: String, CaseIterable, Defaults.Serializable, Displayable, Identifiable {
 
-    case advanced
+//    case advanced
     case aspectFill
     case audio
     case autoPlay
@@ -23,8 +24,8 @@ enum VideoPlayerActionButton: String, CaseIterable, Defaults.Serializable, Displ
 
     var displayTitle: String {
         switch self {
-        case .advanced:
-            return "Advanced"
+//        case .advanced:
+//            return "Advanced"
         case .aspectFill:
             return "Aspect Fill"
         case .audio:
@@ -50,8 +51,8 @@ enum VideoPlayerActionButton: String, CaseIterable, Defaults.Serializable, Displ
 
     var settingsSystemImage: String {
         switch self {
-        case .advanced:
-            return "gearshape.fill"
+//        case .advanced:
+//            return "gearshape.fill"
         case .aspectFill:
             return "arrow.up.left.and.arrow.down.right"
         case .audio:
@@ -83,6 +84,6 @@ enum VideoPlayerActionButton: String, CaseIterable, Defaults.Serializable, Displ
         .subtitles,
         .playbackSpeed,
         .chapters,
-        .advanced,
+//        .advanced,
     ]
 }

--- a/Shared/ViewModels/MediaViewModel/MediaViewModel.swift
+++ b/Shared/ViewModels/MediaViewModel/MediaViewModel.swift
@@ -72,10 +72,14 @@ final class MediaViewModel: ViewModel, Stateful {
             mediaItems.removeAll()
         }
 
+        // TODO: atow, liveTV is removed because it wasn't fixed in time
+        //       after a giant refactor and to push an update
         let media: [MediaType] = try await getUserViews()
-            .map { userView in
+            .compactMap { userView in
                 if userView.collectionType == "livetv" {
-                    return .liveTV(userView)
+//                    return .liveTV(userView)
+
+                    return nil
                 }
 
                 return .collectionFolder(userView)

--- a/Swiftfin/Views/VideoPlayer/Overlays/Components/BarActionButtons.swift
+++ b/Swiftfin/Views/VideoPlayer/Overlays/Components/BarActionButtons.swift
@@ -139,8 +139,8 @@ extension VideoPlayer.Overlay {
             HStack(spacing: 0) {
                 ForEach(barActionButtons) { actionButton in
                     switch actionButton {
-                    case .advanced:
-                        advancedButton
+//                    case .advanced:
+//                        advancedButton
                     case .aspectFill:
                         aspectFillButton
                     case .audio:

--- a/Swiftfin/Views/VideoPlayer/Overlays/Components/OverlayMenu.swift
+++ b/Swiftfin/Views/VideoPlayer/Overlays/Components/OverlayMenu.swift
@@ -151,8 +151,8 @@ extension VideoPlayer.Overlay {
             Menu {
                 ForEach(menuActionButtons) { actionButton in
                     switch actionButton {
-                    case .advanced:
-                        advancedButton
+//                    case .advanced:
+//                        advancedButton
                     case .aspectFill:
                         aspectFillButton
                     case .audio:


### PR DESCRIPTION
Due to me wanting to finally push an update and since these aren't ready yet, just disable them for now.

I haven't gotten to reviewing #806 because I wanted to work on everything else and have made a lot of improvements that would require a lot of work in that PR to be redone.