### PR TITLE
Fix Collection/Episode Item Empty Image and Cleanup

### DIFF
--- a/Swiftfin/Views/ChannelLibraryView/ChannelLibraryView.swift
+++ b/Swiftfin/Views/ChannelLibraryView/ChannelLibraryView.swift
@@ -73,7 +73,7 @@ struct ChannelLibraryView: View {
 
     // MARK: item view
 
-    private func narrowChannelView(channel: ChannelProgram) -> some View {
+    private func compactChannelView(channel: ChannelProgram) -> some View {
         CompactChannelView(channel: channel.channel)
             .onSelect {
                 guard let mediaSource = channel.channel.mediaSources?.first else { return }
@@ -84,7 +84,7 @@ struct ChannelLibraryView: View {
             }
     }
 
-    private func wideChannelView(channel: ChannelProgram) -> some View {
+    private func detailedChannelView(channel: ChannelProgram) -> some View {
         DetailedChannelView(channel: channel)
             .onSelect {
                 guard let mediaSource = channel.channel.mediaSources?.first else { return }
@@ -102,9 +102,9 @@ struct ChannelLibraryView: View {
         ) { channel in
             switch channelDisplayType {
             case .grid:
-                narrowChannelView(channel: channel)
+                compactChannelView(channel: channel)
             case .list:
-                wideChannelView(channel: channel)
+                detailedChannelView(channel: channel)
             }
         }
         .onReachedBottomEdge(offset: .offset(300)) {

--- a/Swiftfin/Views/ChannelLibraryView/Components/DetailedChannelView.swift
+++ b/Swiftfin/Views/ChannelLibraryView/Components/DetailedChannelView.swift
@@ -68,7 +68,7 @@ extension ChannelLibraryView {
         private func programLabel(for program: BaseItemDto) -> some View {
             HStack(alignment: .top) {
                 AlternateLayoutView(alignment: .leading) {
-                    Text(Date(timeIntervalSince1970: 0), style: .time)
+                    Text("00:00 AAA")
                         .monospacedDigit()
                 } content: {
                     if let startDate = program.startDate {

--- a/Swiftfin/Views/ItemView/iOS/CollectionItemView/CollectionItemContentView.swift
+++ b/Swiftfin/Views/ItemView/iOS/CollectionItemView/CollectionItemContentView.swift
@@ -6,6 +6,7 @@
 // Copyright (c) 2024 Jellyfin & Jellyfin Contributors
 //
 
+import BlurHashKit
 import JellyfinAPI
 import SwiftUI
 
@@ -24,6 +25,17 @@ extension CollectionItemView {
 
                 VStack(alignment: .center) {
                     ImageView(viewModel.item.imageSource(.backdrop, maxWidth: 600))
+                        .placeholder { source in
+                            if let blurHash = source.blurHash {
+                                BlurHashView(blurHash: blurHash, size: .Square(length: 8))
+                            } else {
+                                Color.secondarySystemFill
+                                    .opacity(0.75)
+                            }
+                        }
+                        .failure {
+                            SystemImageContentView(systemName: viewModel.item.systemImage)
+                        }
                         .posterStyle(.landscape, contentMode: .fill)
                         .frame(maxHeight: 300)
                         .posterShadow()

--- a/Swiftfin/Views/ItemView/iOS/EpisodeItemView/EpisodeItemContentView.swift
+++ b/Swiftfin/Views/ItemView/iOS/EpisodeItemView/EpisodeItemContentView.swift
@@ -6,6 +6,7 @@
 // Copyright (c) 2024 Jellyfin & Jellyfin Contributors
 //
 
+import BlurHashKit
 import JellyfinAPI
 import SwiftUI
 
@@ -24,6 +25,17 @@ extension EpisodeItemView {
 
                 VStack(alignment: .center) {
                     ImageView(viewModel.item.imageSource(.primary, maxWidth: 600))
+                        .placeholder { source in
+                            if let blurHash = source.blurHash {
+                                BlurHashView(blurHash: blurHash, size: .Square(length: 8))
+                            } else {
+                                Color.secondarySystemFill
+                                    .opacity(0.75)
+                            }
+                        }
+                        .failure {
+                            SystemImageContentView(systemName: viewModel.item.systemImage)
+                        }
                         .frame(maxHeight: 300)
                         .posterStyle(.landscape)
                         .posterShadow()


### PR DESCRIPTION
- since I changed the placeholder/failure views for `ImageView` to `EmptyView`, now have to manually add for collection/episode item header image
	- there are other spacing issues that I know I'll get to later
- program time would sometimes truncate with large text like `12:30 PM`, make the layout wider