### PR TITLE
Fix Recently Added View logo size

### DIFF
--- a/Swiftfin tvOS/Views/HomeView/Components/CinematicRecentlyAddedView.swift
+++ b/Swiftfin tvOS/Views/HomeView/Components/CinematicRecentlyAddedView.swift
@@ -48,6 +48,8 @@ extension HomeView {
                                 .fontWeight(.semibold)
                         }
                         .edgePadding(.leading)
+                        .aspectRatio(contentMode: .fit)
+                        .frame(height: 200, alignment: .bottomLeading)
                 }
                 .onSelect { item in
                     router.route(to: \.item, item)


### PR DESCRIPTION
Fixes logos on the "Recently Added" section from taking up the entire image view (as seen below). Copied logic from "Resume" view. 
![Simulator Screenshot - Apple TV 4K (3rd generation) (at 1080p) - 2024-05-15 at 13 40 56](https://github.com/jellyfin/Swiftfin/assets/8967127/052c6f43-2949-46a5-b528-23acf54ed21b)
