### PR TITLE
iOS Hour/Minute Picker Initial Duration

### DIFF
--- a/Swiftfin/Components/HourMinutePicker.swift
+++ b/Swiftfin/Components/HourMinutePicker.swift
@@ -16,6 +16,7 @@ struct HourMinutePicker: UIViewRepresentable {
         let picker = UIDatePicker(frame: .zero)
         picker.translatesAutoresizingMaskIntoConstraints = false
         picker.datePickerMode = .countDownTimer
+        picker.countDownDuration = interval.wrappedValue
 
         context.coordinator.add(picker: picker)
         context.coordinator.interval = interval


### PR DESCRIPTION
Forgot to set the initial duration for the picker.