### PR TITLE
Start work on offline download support

### DIFF
--- a/Shared/Coordinators/MainCoordinator/iOSMainCoordinator.swift
+++ b/Shared/Coordinators/MainCoordinator/iOSMainCoordinator.swift
@@ -31,6 +31,8 @@ final class MainCoordinator: NavigationCoordinatable {
     @Root
     var mainTab = makeMainTab
     @Root
+    var offlineTab = makeOfflineTab
+    @Root
     var selectUser = makeSelectUser
     @Root
     var serverCheck = makeServerCheck
@@ -136,6 +138,10 @@ final class MainCoordinator: NavigationCoordinatable {
 
     func makeMainTab() -> MainTabCoordinator {
         MainTabCoordinator()
+    }
+
+    func makeOfflineTab() -> OfflineTabCoordinator {
+        OfflineTabCoordinator()
     }
 
     func makeSelectUser() -> NavigationViewCoordinator<SelectUserCoordinator> {

--- a/Shared/Coordinators/MainCoordinator/iOSMainTabCoordinator.swift
+++ b/Shared/Coordinators/MainCoordinator/iOSMainTabCoordinator.swift
@@ -6,20 +6,35 @@
 // Copyright (c) 2024 Jellyfin & Jellyfin Contributors
 //
 
+import Defaults
 import Foundation
 import Stinsen
 import SwiftUI
 
 final class MainTabCoordinator: TabCoordinatable {
 
-    var child = TabChild(startingItems: [
-        \MainTabCoordinator.home,
-        \MainTabCoordinator.search,
-        \MainTabCoordinator.media,
-    ])
+    var child: TabChild
+
+    init() {
+        self.child = TabChild(startingItems: [
+            \MainTabCoordinator.home,
+            \MainTabCoordinator.search,
+            \MainTabCoordinator.media,
+        ])
+        if Defaults[.Experimental.downloads] {
+            self.child = TabChild(startingItems: [
+                \MainTabCoordinator.home,
+                \MainTabCoordinator.search,
+                \MainTabCoordinator.media,
+                \MainTabCoordinator.downloads,
+            ])
+        }
+    }
 
     @Route(tabItem: makeHomeTab, onTapped: onHomeTapped)
     var home = makeHome
+    @Route(tabItem: makeDownloadsTab, onTapped: onDownloadsTapped)
+    var downloads = makeDownloads
     @Route(tabItem: makeSearchTab, onTapped: onSearchTapped)
     var search = makeSearch
     @Route(tabItem: makeMediaTab, onTapped: onMediaTapped)
@@ -39,6 +54,22 @@ final class MainTabCoordinator: TabCoordinatable {
     func makeHomeTab(isActive: Bool) -> some View {
         Image(systemName: "house")
         L10n.home.text
+    }
+
+    @ViewBuilder
+    func makeDownloadsTab(isActive: Bool) -> some View {
+        Image(systemName: "square.and.arrow.down.fill")
+        L10n.downloads.text
+    }
+
+    func makeDownloads() -> NavigationViewCoordinator<DownloadListCoordinator> {
+        NavigationViewCoordinator(DownloadListCoordinator())
+    }
+
+    func onDownloadsTapped(isRepeat: Bool, coordinator: NavigationViewCoordinator<DownloadListCoordinator>) {
+        if isRepeat {
+            coordinator.child.popToRoot()
+        }
     }
 
     func makeSearch() -> NavigationViewCoordinator<SearchCoordinator> {

--- a/Shared/Coordinators/MainCoordinator/iOSOfflineTabCoordinator.swift
+++ b/Shared/Coordinators/MainCoordinator/iOSOfflineTabCoordinator.swift
@@ -1,0 +1,46 @@
+//
+// Swiftfin is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, you can obtain one at https://mozilla.org/MPL/2.0/.
+//
+// Copyright (c) 2024 Jellyfin & Jellyfin Contributors
+//
+
+import Foundation
+import Stinsen
+import SwiftUI
+
+final class OfflineTabCoordinator: TabCoordinatable {
+
+    var child = TabChild(startingItems: [\OfflineTabCoordinator.downloads])
+
+    @Route(tabItem: makeDownloadsTab, onTapped: onDownloadsTapped)
+    var downloads = makeDownloads
+
+    func makeDownloads() -> NavigationViewCoordinator<DownloadListCoordinator> {
+        NavigationViewCoordinator(DownloadListCoordinator())
+    }
+
+    func onDownloadsTapped(isRepeat: Bool, coordinator: NavigationViewCoordinator<DownloadListCoordinator>) {
+        if isRepeat {
+            coordinator.child.popToRoot()
+        }
+    }
+
+    @ViewBuilder
+    func makeDownloadsTab(isActive: Bool) -> some View {
+        Image(systemName: "rectangle.stack.fill")
+        L10n.downloads.text
+    }
+
+    @ViewBuilder
+    func customize(_ view: AnyView) -> some View {
+        view.onAppear {
+            AppURLHandler.shared.appURLState = .allowed
+            // TODO: todo
+            DispatchQueue.main.asyncAfter(deadline: .now() + 0.25) {
+                AppURLHandler.shared.processLaunchedURLIfNeeded()
+            }
+        }
+    }
+}

--- a/Shared/Extensions/Int.swift
+++ b/Shared/Extensions/Int.swift
@@ -24,6 +24,13 @@ extension FixedWidthInteger {
             .appending(minutesText)
             .appending(secondsText)
     }
+
+    var sizeLable: String {
+        let bcf = ByteCountFormatter()
+        bcf.allowedUnits = [.useMB, .useGB]
+        bcf.countStyle = .file
+        return bcf.string(fromByteCount: Int64(self))
+    }
 }
 
 extension Int {

--- a/Shared/Services/DownloadManager.swift
+++ b/Shared/Services/DownloadManager.swift
@@ -80,6 +80,13 @@ class DownloadManager: ObservableObject {
     }
 
     func remove(task: DownloadTask) {
+        do {
+            try FileManager.default.removeItem(at: task.item.downloadFolder!)
+        } catch {
+            logger.error("Error deleting item: \(error.localizedDescription)")
+            return
+        }
+        task.state = .ready
         downloads.removeAll(where: { $0.item == task.item })
     }
 
@@ -108,6 +115,7 @@ class DownloadManager: ObservableObject {
         guard let offlineItem = try? jsonDecoder.decode(BaseItemDto.self, from: itemMetadataData) else { return nil }
 
         let task = DownloadTask(item: offlineItem)
+        task.expectedSize = Int64(offlineItem.mediaSources!.first!.size!)
         task.state = .complete
         return task
     }

--- a/Shared/Services/DownloadTask.swift
+++ b/Shared/Services/DownloadTask.swift
@@ -43,6 +43,8 @@ class DownloadTask: NSObject, ObservableObject {
     @Injected(UserSession.current)
     private var userSession: UserSession!
 
+    public var expectedSize: Int64 = -1
+
     @Published
     var state: State = .ready
 
@@ -119,6 +121,8 @@ class DownloadTask: NSObject, ObservableObject {
         guard let downloadFolder = item.downloadFolder else { return }
 
         let request = Paths.getDownload(itemID: item.id!)
+        self.expectedSize = Int64(item.mediaSources!.first!.size!)
+
         let response = try await userSession.client.download(for: request, delegate: self)
 
         let subtype = response.response.mimeSubtype
@@ -269,7 +273,7 @@ extension DownloadTask: URLSessionDownloadDelegate {
         totalBytesWritten: Int64,
         totalBytesExpectedToWrite: Int64
     ) {
-        let progress = Double(totalBytesWritten) / Double(totalBytesExpectedToWrite)
+        let progress = Double(totalBytesWritten) / Double(expectedSize)
 
         DispatchQueue.main.async {
             self.state = .downloading(progress)

--- a/Shared/ViewModels/DownloadListViewModel.swift
+++ b/Shared/ViewModels/DownloadListViewModel.swift
@@ -22,4 +22,9 @@ class DownloadListViewModel: ViewModel {
 
         items = downloadManager.downloadedItems()
     }
+
+    func remove(task: DownloadTask) {
+        downloadManager.remove(task: task)
+        items.removeAll(where: { $0.item == task.item })
+    }
 }

--- a/Shared/ViewModels/MediaViewModel/MediaViewModel.swift
+++ b/Shared/ViewModels/MediaViewModel/MediaViewModel.swift
@@ -81,6 +81,7 @@ final class MediaViewModel: ViewModel, Stateful {
                 return .collectionFolder(userView)
             }
             .prepending(.favorites, if: Defaults[.Customization.Library.showFavorites])
+            .prepending(.downloads)
 
         await MainActor.run {
             mediaItems.elements = media

--- a/Shared/ViewModels/ServerCheckViewModel.swift
+++ b/Shared/ViewModels/ServerCheckViewModel.swift
@@ -18,6 +18,7 @@ class ServerCheckViewModel: ViewModel, Stateful {
 
     enum State: Hashable {
         case connecting
+        case offline
         case connected
         case error(JellyfinAPIError)
         case initial
@@ -45,7 +46,11 @@ class ServerCheckViewModel: ViewModel, Stateful {
                     }
                 } catch {
                     await MainActor.run {
-                        self.state = .error(.init(error.localizedDescription))
+                        if (error as NSError).code == NSURLErrorNotConnectedToInternet {
+                            self.state = .offline
+                        } else {
+                            self.state = .error(.init(error.localizedDescription))
+                        }
                     }
                 }
             }

--- a/Swiftfin.xcodeproj/project.pbxproj
+++ b/Swiftfin.xcodeproj/project.pbxproj
@@ -141,6 +141,8 @@
 		62ECA01826FA685A00E8EBB7 /* DeepLink.swift in Sources */ = {isa = PBXBuildFile; fileRef = 62ECA01726FA685A00E8EBB7 /* DeepLink.swift */; };
 		6334175B287DDFB9000603CE /* QuickConnectAuthorizeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6334175A287DDFB9000603CE /* QuickConnectAuthorizeView.swift */; };
 		6334175D287DE0D0000603CE /* QuickConnectAuthorizeViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6334175C287DE0D0000603CE /* QuickConnectAuthorizeViewModel.swift */; };
+		9A4E01AC2BFF69F4003B4D25 /* iOSOfflineTabCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A4E01AB2BFF69F4003B4D25 /* iOSOfflineTabCoordinator.swift */; };
+		9A4E01AD2BFF69F4003B4D25 /* iOSOfflineTabCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A4E01AB2BFF69F4003B4D25 /* iOSOfflineTabCoordinator.swift */; };
 		AE8C3159265D6F90008AA076 /* bitrates.json in Resources */ = {isa = PBXBuildFile; fileRef = AE8C3158265D6F90008AA076 /* bitrates.json */; };
 		BD0BA22B2AD6503B00306A8D /* OnlineVideoPlayerManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD0BA22A2AD6503B00306A8D /* OnlineVideoPlayerManager.swift */; };
 		BD0BA22C2AD6503B00306A8D /* OnlineVideoPlayerManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD0BA22A2AD6503B00306A8D /* OnlineVideoPlayerManager.swift */; };
@@ -1034,6 +1036,7 @@
 		6334175A287DDFB9000603CE /* QuickConnectAuthorizeView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QuickConnectAuthorizeView.swift; sourceTree = "<group>"; };
 		6334175C287DE0D0000603CE /* QuickConnectAuthorizeViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QuickConnectAuthorizeViewModel.swift; sourceTree = "<group>"; };
 		637FCAF3287B5B2600C0A353 /* UDPBroadcast.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = UDPBroadcast.xcframework; path = Carthage/Build/UDPBroadcast.xcframework; sourceTree = "<group>"; };
+		9A4E01AB2BFF69F4003B4D25 /* iOSOfflineTabCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = iOSOfflineTabCoordinator.swift; sourceTree = "<group>"; };
 		AE8C3158265D6F90008AA076 /* bitrates.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = bitrates.json; sourceTree = "<group>"; };
 		BD0BA22A2AD6503B00306A8D /* OnlineVideoPlayerManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnlineVideoPlayerManager.swift; sourceTree = "<group>"; };
 		BD0BA22D2AD6508C00306A8D /* DownloadVideoPlayerManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DownloadVideoPlayerManager.swift; sourceTree = "<group>"; };
@@ -3084,6 +3087,7 @@
 			children = (
 				62C29E9E26D1016600C1D2E7 /* iOSMainCoordinator.swift */,
 				62C29EA026D102A500C1D2E7 /* iOSMainTabCoordinator.swift */,
+				9A4E01AB2BFF69F4003B4D25 /* iOSOfflineTabCoordinator.swift */,
 				E193D5422719407E00900D82 /* tvOSMainCoordinator.swift */,
 				E193D552271943D500900D82 /* tvOSMainTabCoordinator.swift */,
 			);
@@ -4130,6 +4134,7 @@
 				E187A60329AB28F0008387E6 /* RotateContentView.swift in Sources */,
 				E1D37F4F2B9CEDC400343D2B /* DeviceProfile.swift in Sources */,
 				E1575E94293E7B1E001665B1 /* VerticalAlignment.swift in Sources */,
+				9A4E01AD2BFF69F4003B4D25 /* iOSOfflineTabCoordinator.swift in Sources */,
 				E1575EA3293E7B1E001665B1 /* UIDevice.swift in Sources */,
 				E193D547271941C500900D82 /* SelectUserView.swift in Sources */,
 				E1BDF2E62951475300CC0294 /* VideoPlayerActionButton.swift in Sources */,
@@ -4288,6 +4293,7 @@
 				E129429B28F4A5E300796AC6 /* PlaybackSettingsView.swift in Sources */,
 				E1E9017B28DAAE4D001B1594 /* RoundedCorner.swift in Sources */,
 				E18E01F2288747230022598C /* ActionButtonHStack.swift in Sources */,
+				9A4E01AC2BFF69F4003B4D25 /* iOSOfflineTabCoordinator.swift in Sources */,
 				E1EA09692BED78BB004CDE76 /* UserAccessPolicy.swift in Sources */,
 				E18E0204288749200022598C /* RowDivider.swift in Sources */,
 				E18E01DA288747230022598C /* iPadOSEpisodeContentView.swift in Sources */,

--- a/Swiftfin/Views/DownloadTaskView/DownloadTaskContentView.swift
+++ b/Swiftfin/Views/DownloadTaskView/DownloadTaskContentView.swift
@@ -98,13 +98,18 @@ extension DownloadTaskView {
                             }
                             .frame(maxWidth: 300)
                             .frame(height: 50)
+                        Text("Size: \(downloadTask.expectedSize.sizeLable)")
+                            .font(.subheadline)
+                            .fontWeight(.regular)
+                            .padding(.horizontal)
+                        PrimaryButton(title: "Delete")
+                            .onSelect {
+                                downloadManager.remove(task: downloadTask)
+                            }
+                            .frame(maxWidth: 200)
+                            .frame(height: 50)
                     }
                 }
-
-//                Text("Media Info")
-//                    .font(.title2)
-//                    .fontWeight(.semibold)
-//                    .padding(.horizontal)
             }
             .alert(
                 L10n.error,

--- a/Swiftfin/Views/MediaView/MediaView.swift
+++ b/Swiftfin/Views/MediaView/MediaView.swift
@@ -64,6 +64,18 @@ struct MediaView: View {
         }
     }
 
+    private var offlineView: some View {
+        CollectionVGrid(
+            $viewModel.mediaItems,
+            layout: UIDevice.isPhone ? phoneLayout : padLayout
+        ) { mediaType in
+            MediaItem(viewModel: viewModel, type: mediaType)
+                .onSelect {
+                    router.route(to: \.downloads)
+                }
+        }
+    }
+
     private func errorView(with error: some Error) -> some View {
         ErrorView(error: error)
             .onRetry {

--- a/Swiftfin/Views/ServerCheckView.swift
+++ b/Swiftfin/Views/ServerCheckView.swift
@@ -43,7 +43,7 @@ struct ServerCheckView: View {
     var body: some View {
         ZStack {
             switch viewModel.state {
-            case .initial, .connecting, .connected:
+            case .initial, .connecting, .connected, .offline:
                 ZStack {
                     Color.clear
 
@@ -61,6 +61,11 @@ struct ServerCheckView: View {
             if newState == .connected {
                 withAnimation(.linear(duration: 0.1)) {
                     let _ = router.root(\.mainTab)
+                }
+            }
+            if newState == .offline {
+                withAnimation(.linear(duration: 0.1)) {
+                    let _ = router.root(\.offlineTab)
                 }
             }
         }

--- a/Swiftfin/Views/SettingsView/ExperimentalSettingsView.swift
+++ b/Swiftfin/Views/SettingsView/ExperimentalSettingsView.swift
@@ -11,6 +11,8 @@ import SwiftUI
 
 struct ExperimentalSettingsView: View {
 
+    @Default(.Experimental.downloads)
+    private var enableDownloads
     @Default(.Experimental.forceDirectPlay)
     private var forceDirectPlay
     @Default(.Experimental.liveTVForceDirectPlay)
@@ -18,6 +20,13 @@ struct ExperimentalSettingsView: View {
 
     var body: some View {
         Form {
+            Section {
+
+                Toggle("Enable Downloads", isOn: $enableDownloads)
+
+            } header: {
+                Text("General")
+            }
             Section {
 
                 Toggle("Force Direct Play", isOn: $forceDirectPlay)


### PR DESCRIPTION
This PR was inspired by @JacobKingDev. It improves upon the current framework for media downloading provided by @LePips. It is far from finished, and I intended to improve on it in the coming weeks. I would love any feedback, as this is the first time I'm working with Swift, so my code is probably riddled with nonsensical rubbish. That being said here is a list of the changes I've implemented.

- Fixed negative percentage with progress text while downloading (the way I get the excepted size is kind of hacky, I would love pointers on how to improve it)
- Improved design of download list view
- Added size label to download item view (added extension to the FixedWidthInteger extension)
- Added temporary OfflineTabCoordinator for testing I'll try to integrate it with the MainTabCoordinator ASAP
- Changed the default behaviour when a NSURLErrorNotConnectedToInternet to showing a view using the OffileTabCoordinator.
- Added the ability to remove downloaded media