### PR TITLE
[tvOS] TV Shows Icon Doesn't Highlight

### DIFF
--- a/Shared/Coordinators/MainCoordinator/tvOSMainTabCoordinator.swift
+++ b/Shared/Coordinators/MainCoordinator/tvOSMainTabCoordinator.swift
@@ -56,8 +56,8 @@ final class MainTabCoordinator: TabCoordinatable {
     func makeTvTab(isActive: Bool) -> some View {
         HStack {
             Image(systemName: "tv")
-                // Fixes the TV Show Icon not shifting from White to Black when Active
-                .symbolRenderingMode(.monochrome)
+            // Fixes the TV Show Icon not shifting from White to Black when Active
+            .symbolRenderingMode(.monochrome)
             L10n.tvShows.text
         }
     }

--- a/Shared/Coordinators/MainCoordinator/tvOSMainTabCoordinator.swift
+++ b/Shared/Coordinators/MainCoordinator/tvOSMainTabCoordinator.swift
@@ -56,7 +56,6 @@ final class MainTabCoordinator: TabCoordinatable {
     func makeTvTab(isActive: Bool) -> some View {
         HStack {
             Image(systemName: "tv")
-                // Fixes the TV Show Icon not shifting from White to Black when Active
                 .symbolRenderingMode(.monochrome)
             L10n.tvShows.text
         }

--- a/Shared/Coordinators/MainCoordinator/tvOSMainTabCoordinator.swift
+++ b/Shared/Coordinators/MainCoordinator/tvOSMainTabCoordinator.swift
@@ -56,6 +56,8 @@ final class MainTabCoordinator: TabCoordinatable {
     func makeTvTab(isActive: Bool) -> some View {
         HStack {
             Image(systemName: "tv")
+                // Fixes the TV Show Icon not shifting from White to Black when Active
+                .symbolRenderingMode(.monochrome)
             L10n.tvShows.text
         }
     }

--- a/Shared/Coordinators/MainCoordinator/tvOSMainTabCoordinator.swift
+++ b/Shared/Coordinators/MainCoordinator/tvOSMainTabCoordinator.swift
@@ -56,8 +56,8 @@ final class MainTabCoordinator: TabCoordinatable {
     func makeTvTab(isActive: Bool) -> some View {
         HStack {
             Image(systemName: "tv")
-            // Fixes the TV Show Icon not shifting from White to Black when Active
-            .symbolRenderingMode(.monochrome)
+                // Fixes the TV Show Icon not shifting from White to Black when Active
+                .symbolRenderingMode(.monochrome)
             L10n.tvShows.text
         }
     }


### PR DESCRIPTION
See: https://github.com/jellyfin/Swiftfin/issues/1073

Force TV Show Icon to render in Monochrome to fix active highlighting weirdness. The other alternative I considered when setting all Icons for the Tabs to be .fill that resolves this too. The issue seems to only exist in the tv icon. Could be a tvOS version issue? 

Might be worth leaving a todo to look at this as we start targeting a newer tvOS version?

<details>
<summary>TV Shows (Current)</summary>

**Unselected:**
![Screenshot 2024-05-26 at 5 39 36 PM](https://github.com/jellyfin/Swiftfin/assets/37599297/4f663b41-2db0-4f52-b03e-d01713b85646)

**Selected:**
![Screenshot 2024-05-26 at 5 39 48 PM](https://github.com/jellyfin/Swiftfin/assets/37599297/d418a5b0-e610-478f-9eac-46863c4f7263)

</details>

<details>
<summary>TV Shows (This PR)</summary>

**Unselected:**
![Screenshot 2024-05-26 at 5 29 23 PM](https://github.com/jellyfin/Swiftfin/assets/37599297/c964e4f9-29ef-4d98-9033-46fb5902a15d)

**Selected:
![Screenshot 2024-05-26 at 5 29 11 PM](https://github.com/jellyfin/Swiftfin/assets/37599297/76eccab4-f2d0-4c2d-86f5-883a93114c22)

</details>