### PR TITLE
Add ability to hide "Recently Added" section at home screen

### DIFF
--- a/Shared/Services/SwiftfinDefaults.swift
+++ b/Shared/Services/SwiftfinDefaults.swift
@@ -112,6 +112,7 @@ extension Defaults.Keys {
         static let showPosterLabels: Key<Bool> = UserKey("showPosterLabels", default: true)
         static let nextUpPosterType: Key<PosterDisplayType> = UserKey("nextUpPosterType", default: .portrait)
         static let recentlyAddedPosterType: Key<PosterDisplayType> = UserKey("recentlyAddedPosterType", default: .portrait)
+        static let showRecentlyAdded: Key<Bool> = UserKey("showRecentlyAdded", default: true)
         static let latestInLibraryPosterType: Key<PosterDisplayType> = UserKey("latestInLibraryPosterType", default: .portrait)
         static let shouldShowMissingSeasons: Key<Bool> = UserKey("shouldShowMissingSeasons", default: true)
         static let shouldShowMissingEpisodes: Key<Bool> = UserKey("shouldShowMissingEpisodes", default: true)

--- a/Swiftfin tvOS/Views/HomeView/HomeView.swift
+++ b/Swiftfin tvOS/Views/HomeView/HomeView.swift
@@ -19,6 +19,9 @@ struct HomeView: View {
     @StateObject
     private var viewModel = HomeViewModel()
 
+    @Default(.Customization.showRecentlyAdded)
+    private var showRecentlyAdded
+
     @ViewBuilder
     private var contentView: some View {
         ScrollView {
@@ -29,10 +32,13 @@ struct HomeView: View {
 
                     NextUpView(viewModel: viewModel.nextUpViewModel)
 
-                    RecentlyAddedView(viewModel: viewModel.recentlyAddedViewModel)
+                    if showRecentlyAdded {
+                        RecentlyAddedView(viewModel: viewModel.recentlyAddedViewModel)
+                    }
                 } else {
-                    CinematicRecentlyAddedView(viewModel: viewModel.recentlyAddedViewModel)
-
+                    if showRecentlyAdded {
+                        CinematicRecentlyAddedView(viewModel: viewModel.recentlyAddedViewModel)
+                    }
                     NextUpView(viewModel: viewModel.nextUpViewModel)
                 }
 

--- a/Swiftfin tvOS/Views/SettingsView/CustomizeViewsSettings.swift
+++ b/Swiftfin tvOS/Views/SettingsView/CustomizeViewsSettings.swift
@@ -37,6 +37,8 @@ struct CustomizeViewsSettings: View {
     private var libraryRandomImage
     @Default(.Customization.Library.showFavorites)
     private var showFavorites
+    @Default(.Customization.showRecentlyAdded)
+    private var showRecentlyAdded
 
     @EnvironmentObject
     private var router: SettingsCoordinator.Router
@@ -92,6 +94,9 @@ struct CustomizeViewsSettings: View {
                     Toggle("Random Image", isOn: $libraryRandomImage)
 
                     Toggle("Show Favorites", isOn: $showFavorites)
+                    
+                    Toggle("Show Recently Added", isOn: $showRecentlyAdded)
+                    
                 } header: {
                     L10n.library.text
                 }

--- a/Swiftfin tvOS/Views/SettingsView/CustomizeViewsSettings.swift
+++ b/Swiftfin tvOS/Views/SettingsView/CustomizeViewsSettings.swift
@@ -94,9 +94,9 @@ struct CustomizeViewsSettings: View {
                     Toggle("Random Image", isOn: $libraryRandomImage)
 
                     Toggle("Show Favorites", isOn: $showFavorites)
-                    
+
                     Toggle("Show Recently Added", isOn: $showRecentlyAdded)
-                    
+
                 } header: {
                     L10n.library.text
                 }

--- a/Swiftfin/Views/HomeView/HomeView.swift
+++ b/Swiftfin/Views/HomeView/HomeView.swift
@@ -18,6 +18,8 @@ struct HomeView: View {
 
     @Default(.Customization.nextUpPosterType)
     private var nextUpPosterType
+    @Default(.Customization.showRecentlyAdded)
+    private var showRecentlyAdded
     @Default(.Customization.recentlyAddedPosterType)
     private var recentlyAddedPosterType
 
@@ -38,7 +40,9 @@ struct HomeView: View {
 
                 NextUpView(homeViewModel: viewModel)
 
-                RecentlyAddedView(viewModel: viewModel.recentlyAddedViewModel)
+                if showRecentlyAdded {
+                    RecentlyAddedView(viewModel: viewModel.recentlyAddedViewModel)
+                }
 
                 ForEach(viewModel.libraries) { viewModel in
                     LatestInLibraryView(viewModel: viewModel)

--- a/Swiftfin/Views/SettingsView/CustomizeViewsSettings.swift
+++ b/Swiftfin/Views/SettingsView/CustomizeViewsSettings.swift
@@ -38,6 +38,8 @@ struct CustomizeViewsSettings: View {
     private var nextUpPosterType
     @Default(.Customization.recentlyAddedPosterType)
     private var recentlyAddedPosterType
+    @Default(.Customization.showRecentlyAdded)
+    private var showRecentlyAdded
     @Default(.Customization.latestInLibraryPosterType)
     private var latestInLibraryPosterType
     @Default(.Customization.similarPosterType)
@@ -158,6 +160,10 @@ struct CustomizeViewsSettings: View {
                         step: 1
                     )
                 }
+            }
+
+            Section("Home") {
+                Toggle("Show recently added", isOn: $showRecentlyAdded)
             }
 
             Section {


### PR DESCRIPTION
Requested here: https://github.com/jellyfin/Swiftfin/issues/1019

Add a customization default for recently added
Add a show recently added toggle in settings for both iOS and tvOS Conditionally show the recently added section based on toggle