### PR TITLE
Update watched indicator color

### DIFF
--- a/Shared/Components/PosterIndicators/WatchedIndicator.swift
+++ b/Shared/Components/PosterIndicators/WatchedIndicator.swift
@@ -6,9 +6,13 @@
 // Copyright (c) 2024 Jellyfin & Jellyfin Contributors
 //
 
+import Defaults
 import SwiftUI
 
 struct WatchedIndicator: View {
+
+    @Default(.accentColor)
+    private var accentColor
 
     let size: CGFloat
 
@@ -20,7 +24,7 @@ struct WatchedIndicator: View {
                 .resizable()
                 .frame(width: size, height: size)
                 .symbolRenderingMode(.palette)
-                .foregroundStyle(.white, Color.jellyfinPurple)
+                .foregroundStyle(.white, accentColor)
                 .padding(3)
         }
     }

--- a/Swiftfin/Views/ItemView/Components/ActionButtonHStack.swift
+++ b/Swiftfin/Views/ItemView/Components/ActionButtonHStack.swift
@@ -15,6 +15,9 @@ extension ItemView {
 
     struct ActionButtonHStack: View {
 
+        @Default(.accentColor)
+        private var accentColor
+
         @Injected(Container.downloadManager)
         private var downloadManager: DownloadManager
 
@@ -42,7 +45,7 @@ extension ItemView {
                             .symbolRenderingMode(.palette)
                             .foregroundStyle(
                                 .primary,
-                                Color.jellyfinPurple
+                                accentColor
                             )
                     } else {
                         Image(systemName: "checkmark.circle")


### PR DESCRIPTION
## Changes made

Updated the watched indicator color to use the users accent color


## Before

<img src="https://github.com/jellyfin/Swiftfin/assets/70828596/3c9e375f-126d-43b3-9cbf-9e4a4f208f70" height="400px" style="width:45%; display:inline-block;" />
<img src="https://github.com/jellyfin/Swiftfin/assets/70828596/cdaeb920-f558-44bd-b5db-50cb5ac67121" height="400px" style="width:45%; display:inline-block;" />

## After

<img src="https://github.com/jellyfin/Swiftfin/assets/70828596/7d25ade1-a40c-493f-b282-cd28ee7fe912" height="400px" style="width:45%; display:inline-block;" />
<img src="https://github.com/jellyfin/Swiftfin/assets/70828596/c3de59c0-7145-487d-93ba-c7d0844f29e9" height="400px" style="width:45%; display:inline-block;" />

## Alternative Option

Instead of using the users accent color just make the indicator color white

<img src="https://github.com/jellyfin/Swiftfin/assets/70828596/20b33f17-b2ba-443f-a65e-502474776aa5" height="400px" style="width:45%; display:inline-block;" />
<img src="https://github.com/jellyfin/Swiftfin/assets/70828596/cdaeb920-f558-44bd-b5db-50cb5ac67121" height="400px" style="width:45%; display:inline-block;" />

## Feedback

Let me know which one is best and what you think.