### PR TITLE
Fix Trailing Slash Server URL

### DIFF
--- a/Shared/ViewModels/ConnectToServerViewModel.swift
+++ b/Shared/ViewModels/ConnectToServerViewModel.swift
@@ -140,6 +140,7 @@ final class ConnectToServerViewModel: ViewModel, Eventful, Stateful {
 
         let formattedURL = url.trimmingCharacters(in: .whitespacesAndNewlines)
             .trimmingCharacters(in: .objectReplacement)
+            .trimmingCharacters(in: ["/"])
             .prepending("http://", if: !url.contains("://"))
 
         guard let url = URL(string: formattedURL) else { throw JellyfinAPIError("Invalid URL") }
@@ -199,6 +200,9 @@ final class ConnectToServerViewModel: ViewModel, Eventful, Stateful {
     }
 
     private func save(server: ServerState) async throws {
+
+        let publicInfo = try await server.getPublicSystemInfo()
+
         try dataStack.perform { transaction in
             let newServer = transaction.create(Into<ServerModel>())
 
@@ -208,8 +212,6 @@ final class ConnectToServerViewModel: ViewModel, Eventful, Stateful {
             newServer.id = server.id
             newServer.users = []
         }
-
-        let publicInfo = try await server.getPublicSystemInfo()
 
         StoredValues[.Server.publicInfo(id: server.id)] = publicInfo
     }


### PR DESCRIPTION
- Since we don't use the raw connection URL and everything uses some path, we can just strip out a trailing slash
- Don't save the server locally if public info fails
- Closes #1144