### PR TITLE
Update PosterButton.swift | Adding accessibility support to media posters in media section of TVOS app

### DIFF
--- a/Swiftfin tvOS/Components/PosterButton.swift
+++ b/Swiftfin tvOS/Components/PosterButton.swift
@@ -77,7 +77,7 @@ struct PosterButton<Item: Poster>: View {
                     }
             }
             .accessibilityLabel(item.displayTitle)
-            
+
             content()
                 .eraseToAnyView()
                 .zIndex(-1)

--- a/Swiftfin tvOS/Components/PosterButton.swift
+++ b/Swiftfin tvOS/Components/PosterButton.swift
@@ -76,7 +76,8 @@ struct PosterButton<Item: Poster>: View {
                         onFocusChanged(newValue)
                     }
             }
-
+            .accessibilityLabel(item.displayTitle)
+            
             content()
                 .eraseToAnyView()
                 .zIndex(-1)
@@ -142,6 +143,7 @@ extension PosterButton {
             Text(item.displayTitle)
                 .font(.footnote.weight(.regular))
                 .foregroundColor(.primary)
+                .accessibilityLabel(item.displayTitle)
         }
     }
 


### PR DESCRIPTION
Added accessibility labels to enable voiceover on TVOS to read film titles on posters in media. I am not overly familiar with Swift as I do not develop for the Apple ecosystem, so apologies if this fix does not work as intended as I have no means to test the fix on hardware. 

This is in response to issue #963.

I would appreciate this fix (given it works) being pushed to the TVOS App as soon as possible. 