### PR TITLE
Media Item HD Attribute Source

### DIFF
--- a/Swiftfin/Views/ItemView/Components/AttributeHStack.swift
+++ b/Swiftfin/Views/ItemView/Components/AttributeHStack.swift
@@ -23,7 +23,8 @@ extension ItemView {
                 }
 
                 if let mediaStreams = viewModel.selectedMediaSource?.mediaStreams {
-                    if mediaStreams.hasHDVideo || viewModel.item.isHD ?? false {
+
+                    if mediaStreams.hasHDVideo {
                         Text("HD")
                             .asAttributeStyle(.fill)
                     }

--- a/Swiftfin/Views/ItemView/Components/AttributeHStack.swift
+++ b/Swiftfin/Views/ItemView/Components/AttributeHStack.swift
@@ -22,13 +22,11 @@ extension ItemView {
                         .asAttributeStyle(.outline)
                 }
 
-                // TODO: Have stream indicate this instead?
-                if viewModel.item.isHD ?? false {
-                    Text("HD")
-                        .asAttributeStyle(.fill)
-                }
-
                 if let mediaStreams = viewModel.selectedMediaSource?.mediaStreams {
+                    if mediaStreams.hasHDVideo || viewModel.item.isHD ?? false {
+                        Text("HD")
+                            .asAttributeStyle(.fill)
+                    }
 
                     if mediaStreams.has4KVideo {
                         Text("4K")


### PR DESCRIPTION
Clearing the TODO that suggests using the stream to determine if content supports HD. As a fallback I made the conditional an OR statement just to be safe.