### PR TITLE
[tvOS] Fix Episode Description Size & Provide Episode Thumbnail Clarity

### DIFF
--- a/Swiftfin tvOS/Views/ItemView/Components/EpisodeSelector/Components/EpisodeCard.swift
+++ b/Swiftfin tvOS/Views/ItemView/Components/EpisodeSelector/Components/EpisodeCard.swift
@@ -12,26 +12,32 @@ import JellyfinAPI
 import SwiftUI
 
 extension SeriesEpisodeSelector {
-
     struct EpisodeCard: View {
-
         @EnvironmentObject
         private var router: ItemCoordinator.Router
 
         let episode: BaseItemDto
+
+        @FocusState
+        private var isFocused: Bool
 
         @ViewBuilder
         private var imageOverlay: some View {
             ZStack {
                 if episode.userData?.isPlayed ?? false {
                     WatchedIndicator(size: 45)
-                } else {
-                    if (episode.userData?.playbackPositionTicks ?? 0) > 0 {
-                        LandscapePosterProgressBar(
-                            title: episode.progressLabel ?? L10n.continue,
-                            progress: (episode.userData?.playedPercentage ?? 0) / 100
-                        )
-                    }
+                } else if (episode.userData?.playbackPositionTicks ?? 0) > 0 {
+                    LandscapePosterProgressBar(
+                        title: episode.progressLabel ?? L10n.continue,
+                        progress: (episode.userData?.playedPercentage ?? 0) / 100
+                    )
+                }
+
+                if isFocused {
+                    Image(systemName: "play.fill")
+                        .resizable()
+                        .frame(width: 50, height: 50)
+                        .foregroundColor(.white)
                 }
             }
         }
@@ -64,6 +70,7 @@ extension SeriesEpisodeSelector {
                 }
                 .buttonStyle(.card)
                 .posterShadow()
+                .focused($isFocused)
 
                 SeriesEpisodeSelector.EpisodeContent(
                     subHeader: episode.episodeLocator ?? .emptyDash,

--- a/Swiftfin tvOS/Views/ItemView/Components/EpisodeSelector/Components/EpisodeContent.swift
+++ b/Swiftfin tvOS/Views/ItemView/Components/EpisodeSelector/Components/EpisodeContent.swift
@@ -11,9 +11,7 @@ import JellyfinAPI
 import SwiftUI
 
 extension SeriesEpisodeSelector {
-
     struct EpisodeContent: View {
-
         @Default(.accentColor)
         private var accentColor
 
@@ -60,6 +58,8 @@ extension SeriesEpisodeSelector {
                     headerView
 
                     contentView
+                        // Removing the alignment below makes the text center
+                            .frame(maxWidth: .infinity, alignment: .leading)
 
                     L10n.seeMore.text
                         .font(.caption.weight(.light))
@@ -73,7 +73,6 @@ extension SeriesEpisodeSelector {
 }
 
 extension SeriesEpisodeSelector.EpisodeContent {
-
     init(
         subHeader: String,
         header: String,


### PR DESCRIPTION
### Ensures that the episode description matches the size of the thumbnail:
![Fix Description Spacing](https://github.com/user-attachments/assets/da885a2e-458d-4063-a570-2e53611c1867)

### Provides some additional clarity that selecting the episode thumbnail _plays_ the episode.
![Episode Play Clarity](https://github.com/user-attachments/assets/3cedf7cd-fc8f-40d6-b2af-81dcea42ca1a)
_This comes from an issue where I select the thumbnail thinking it will take me to the episode details. Focusing the thumbnail will now overlay the play icon to let the user know this will play the episode._

_Any extra formatting comes from the "Format File" option from SwiftFormat_ 