### PR TITLE
Default Playback Rate to `max`

### DIFF
--- a/Shared/Services/SwiftfinDefaults.swift
+++ b/Shared/Services/SwiftfinDefaults.swift
@@ -171,7 +171,7 @@ extension Defaults.Keys {
 
     enum VideoPlayer {
 
-        static let appMaximumBitrate: Key<PlaybackBitrate> = UserKey("appMaximumBitrate", default: .auto)
+        static let appMaximumBitrate: Key<PlaybackBitrate> = UserKey("appMaximumBitrate", default: .max)
         static let appMaximumBitrateTest: Key<PlaybackBitrateTestSize> = UserKey("appMaximumBitrateTest", default: .regular)
         static let autoPlayEnabled: Key<Bool> = UserKey("autoPlayEnabled", default: true)
         static let barActionButtons: Key<[VideoPlayerActionButton]> = UserKey(


### PR DESCRIPTION
Currently, I would prefer if the behavior didn't change before next release where video player launches would have a new delay. This overall behavior will become better when video quality can be changed in-progress or we can change the default later.