### PR TITLE
Fix the subtitle stream index calculation for multiple subtitles

### DIFF
--- a/Shared/Extensions/JellyfinAPI/MediaStream.swift
+++ b/Shared/Extensions/JellyfinAPI/MediaStream.swift
@@ -225,10 +225,10 @@ extension [MediaStream] {
 
         for (i, mediaStream) in mediaStreams.enumerated() {
             guard mediaStream.isExternal ?? false else { continue }
-            var _mediaStream = mediaStream
-            _mediaStream.index = 1 + embeddedSubtitleCount + audioStreamCount
+            var copy = mediaStream
+            copy.index = (copy.index ?? 0) + 1 + embeddedSubtitleCount + audioStreamCount
 
-            mediaStreams[i] = _mediaStream
+            mediaStreams[i] = copy
         }
 
         return mediaStreams


### PR DESCRIPTION
Fix #1207 

This patch make the subtitles map to a different indexes rather than the same index while doing the index recalculation in `adjustExternalSubtitleIndexes`.The original code will let us have only one subtile available in menu.

Minor, rename variable to `copy` to alight the code in the below (in `adjustAudioForExternalSubtitles`)

