### PR TITLE
[iOS] LetterPickerButtons are Hard to Tap

### DIFF
--- a/Swiftfin/Components/LetterPickerBar/Components/LetterPickerButton.swift
+++ b/Swiftfin/Components/LetterPickerBar/Components/LetterPickerButton.swift
@@ -45,6 +45,7 @@ extension LetterPickerBar {
                 }
                 .frame(width: 20, height: 20)
             }
+            .frame(width: 50, height: 20)
         }
     }
 }


### PR DESCRIPTION
Just an oversight on my end... The buttons are only selection from the Alignment side of the letter. It's kind of hard to show via screenshots but I roughly found the line where it was selectable. See the screenshot below. The clickable area is everything from the side of the screen up until that line. What that means is that ~50% of the letter is not selectable. The result was several people who I showed this to thought it was broken/unselectable.

I also included a before and after for the Left Side alignment as well just to show that the actual alignment of the buttons isn't changing. It's just the 'hitbox' of the letters itself.

<details>
<summary>Current TestFlight (Left) vs this PR (Right)</summary>
<img width="620" alt="Screenshot 2024-09-02 at 01 29 14" src="https://github.com/user-attachments/assets/98396be1-3e6b-49a1-b788-90738eaad24c">
</details>

The solution was to keep the letter and the overlay square the same size but increase the size of the button itself to better fill/exceed the container. I did this with a single:

`.frame(width: 50, height: 20)`

This makes the buttons fully selectable from both sides (see the red line) and a much better user experience.