### PR TITLE
Fix Opus Playback Issues on Native Player

### DIFF
--- a/Shared/Objects/VideoPlayerType/VideoPlayerType+Native.swift
+++ b/Shared/Objects/VideoPlayerType/VideoPlayerType+Native.swift
@@ -21,7 +21,6 @@ extension VideoPlayerType {
             AudioCodec.alac
             AudioCodec.eac3
             AudioCodec.flac
-            AudioCodec.opus
         } videoCodecs: {
             VideoCodec.h261
             VideoCodec.hevc
@@ -110,7 +109,6 @@ extension VideoPlayerType {
             AudioCodec.alac
             AudioCodec.eac3
             AudioCodec.flac
-            AudioCodec.opus
         } videoCodecs: {
             VideoCodec.h264
             VideoCodec.hevc


### PR DESCRIPTION
### Resolves:
https://github.com/jellyfin/Swiftfin/issues/1170 & https://github.com/jellyfin/Swiftfin/issues/1150

### Issue:
Officially, Opus audio is not supported for Apple's AVKit. Technically, Opus **IS** supported on AVKit but only up to 2 channels. This means, people with more than 2 channels (5.1 being the most common) who use the Native Player are unable to play that content. Even if it's forced to transcode for other reasons, since Opus is in the Transcode profile, the problem audio gets carried forward.

The issue we run into is that there doesn't appear to be a good way to tell Jellyfin to DirectPlay Opus 2.0 and Transcode Opus 2.0+. @holow29 had a good idea with adding:

```
        let opusCodecConditions: [ProfileCondition] = [
            ProfileCondition(
                condition: .lessThanEqual,
                isRequired: true,
                property: .audioChannels,
                value: "2"
            ),
        ]

        profile.codecProfiles = [
            CodecProfile(
                applyConditions: opusCodecConditions,
                codec: "opus",
                type: .videoAudio
            ),
        ]
```
For the CodecProfiles but in testing it is either bugged or we aren't using it correctly.

For now, I am I pitching that we just force transcode Opus for Native Player and, if the user wants to Direct Play 2.0, they can enable Opus using the changes in: https://github.com/jellyfin/Swiftfin/pull/1169

Alternatively, if we can find a way to differentiate between 2.0 and other channels I think that would be ideal but I think #1169 gives us some additional leniency to be a little over-zealous in favor of compatibility.