### PR TITLE
Fix App Icon picker Xcode16/iOS 18

### DIFF
--- a/Shared/AppIcons/AppIcons.swift
+++ b/Shared/AppIcons/AppIcons.swift
@@ -28,7 +28,7 @@ extension AppIcon where ID == String, RawValue == String {
 
     static func createCase(iconName: String) -> Self? {
         let split = iconName.split(separator: "-")
-        guard split.count == 3, split[1] == Self.tag else { return nil }
+        guard split.count == 3, split[1] == tag else { return nil }
 
         return Self(rawValue: String(split[2]))
     }

--- a/Shared/AppIcons/AppIcons.swift
+++ b/Shared/AppIcons/AppIcons.swift
@@ -11,7 +11,6 @@ import UIKit
 
 protocol AppIcon: CaseIterable, Identifiable, Displayable, RawRepresentable {
     var iconName: String { get }
-    var iconPreview: UIImage { get }
     static var tag: String { get }
 
     static func createCase(iconName: String) -> Self?
@@ -21,10 +20,6 @@ extension AppIcon where ID == String, RawValue == String {
 
     var iconName: String {
         "AppIcon-\(Self.tag)-\(rawValue)"
-    }
-
-    var iconPreview: UIImage {
-        UIImage(named: iconName) ?? UIImage()
     }
 
     var id: String {

--- a/Swiftfin/Resources/Assets.xcassets/AppIcon-dark-blue.imageset/AppIcon-dark-blue.svg
+++ b/Swiftfin/Resources/Assets.xcassets/AppIcon-dark-blue.imageset/AppIcon-dark-blue.svg
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg width="1024px" height="1024px" viewBox="0 0 1024 1024" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    <title>AppIcon-dark-blue</title>
+    <defs>
+        <linearGradient x1="19.2532352%" y1="40.8257212%" x2="100.658798%" y2="88.6971024%" id="linearGradient-1">
+            <stop stop-color="#1F4EA7" offset="0%"></stop>
+            <stop stop-color="#00DDFF" offset="100%"></stop>
+        </linearGradient>
+    </defs>
+    <g id="Dark" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
+        <g id="AppIcon-dark-blue" fill-rule="nonzero">
+            <rect id="solid-background" fill="#000000" x="0" y="0" width="1024" height="1024"></rect>
+            <path d="M511.582082,136 C609.711866,136 924.91518,714.816848 877.299462,811.251498 C829.683744,907.686149 194.101496,908.81122 145.960253,811.251498 C97.8190104,713.691777 413.547848,136 511.582082,136 Z M511.677632,288.155769 C447.420301,288.155769 240.55469,666.677846 272.102093,730.597947 C303.649497,794.518049 720.072042,793.810861 751.269096,730.597947 C782.46615,667.368961 575.934964,288.155769 511.677632,288.155769 Z M511.109544,425.091384 C543.724099,425.107443 648.323295,617.009305 632.517902,648.998301 C616.71251,680.987298 405.681839,681.34059 389.701185,648.998301 C373.720531,616.656013 478.542787,425.091384 511.109544,425.091384 Z" id="Combined-Shape" fill="url(#linearGradient-1)"></path>
+        </g>
+    </g>
+</svg>

--- a/Swiftfin/Resources/Assets.xcassets/AppIcon-dark-blue.imageset/Contents.json
+++ b/Swiftfin/Resources/Assets.xcassets/AppIcon-dark-blue.imageset/Contents.json
@@ -1,0 +1,12 @@
+{
+  "images" : [
+    {
+      "filename" : "AppIcon-dark-blue.svg",
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Swiftfin/Resources/Assets.xcassets/AppIcon-dark-green.imageset/AppIcon-dark-green.svg
+++ b/Swiftfin/Resources/Assets.xcassets/AppIcon-dark-green.imageset/AppIcon-dark-green.svg
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg width="1024px" height="1024px" viewBox="0 0 1024 1024" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    <title>AppIcon-dark-green</title>
+    <defs>
+        <linearGradient x1="19.2532352%" y1="40.8257212%" x2="100.658798%" y2="88.6971024%" id="linearGradient-1">
+            <stop stop-color="#316D0C" offset="0%"></stop>
+            <stop stop-color="#7CD841" offset="100%"></stop>
+        </linearGradient>
+    </defs>
+    <g id="Dark" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
+        <g id="AppIcon-dark-green" fill-rule="nonzero">
+            <rect id="solid-background" fill="#000000" x="0" y="0" width="1024" height="1024"></rect>
+            <path d="M511.582082,136 C609.711866,136 924.91518,714.816848 877.299462,811.251498 C829.683744,907.686149 194.101496,908.81122 145.960253,811.251498 C97.8190104,713.691777 413.547848,136 511.582082,136 Z M511.677632,288.155769 C447.420301,288.155769 240.55469,666.677846 272.102093,730.597947 C303.649497,794.518049 720.072042,793.810861 751.269096,730.597947 C782.46615,667.368961 575.934964,288.155769 511.677632,288.155769 Z M511.109544,425.091384 C543.724099,425.107443 648.323295,617.009305 632.517902,648.998301 C616.71251,680.987298 405.681839,681.34059 389.701185,648.998301 C373.720531,616.656013 478.542787,425.091384 511.109544,425.091384 Z" id="Combined-Shape" fill="url(#linearGradient-1)"></path>
+        </g>
+    </g>
+</svg>

--- a/Swiftfin/Resources/Assets.xcassets/AppIcon-dark-green.imageset/Contents.json
+++ b/Swiftfin/Resources/Assets.xcassets/AppIcon-dark-green.imageset/Contents.json
@@ -1,0 +1,12 @@
+{
+  "images" : [
+    {
+      "filename" : "AppIcon-dark-green.svg",
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Swiftfin/Resources/Assets.xcassets/AppIcon-dark-jellyfin.imageset/AppIcon-dark-jellyfin.svg
+++ b/Swiftfin/Resources/Assets.xcassets/AppIcon-dark-jellyfin.imageset/AppIcon-dark-jellyfin.svg
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg width="1024px" height="1024px" viewBox="0 0 1024 1024" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    <title>AppIcon-dark-jellyfin</title>
+    <defs>
+        <linearGradient x1="19.8247286%" y1="41.1617938%" x2="100.658798%" y2="88.6971024%" id="linearGradient-1">
+            <stop stop-color="#AA5CC3" offset="0%"></stop>
+            <stop stop-color="#00A4DC" offset="100%"></stop>
+        </linearGradient>
+    </defs>
+    <g id="Dark" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
+        <g id="AppIcon-dark-jellyfin" fill-rule="nonzero">
+            <rect id="solid-background" fill="#000000" x="0" y="0" width="1024" height="1024"></rect>
+            <path d="M511.582082,136 C609.711866,136 924.91518,714.816848 877.299462,811.251498 C829.683744,907.686149 194.101496,908.81122 145.960253,811.251498 C97.8190104,713.691777 413.547848,136 511.582082,136 Z M511.677632,288.155769 C447.420301,288.155769 240.55469,666.677846 272.102093,730.597947 C303.649497,794.518049 720.072042,793.810861 751.269096,730.597947 C782.46615,667.368961 575.934964,288.155769 511.677632,288.155769 Z M511.109544,425.091384 C543.724099,425.107443 648.323295,617.009305 632.517902,648.998301 C616.71251,680.987298 405.681839,681.34059 389.701185,648.998301 C373.720531,616.656013 478.542787,425.091384 511.109544,425.091384 Z" id="Combined-Shape" fill="url(#linearGradient-1)"></path>
+        </g>
+    </g>
+</svg>

--- a/Swiftfin/Resources/Assets.xcassets/AppIcon-dark-jellyfin.imageset/Contents.json
+++ b/Swiftfin/Resources/Assets.xcassets/AppIcon-dark-jellyfin.imageset/Contents.json
@@ -1,0 +1,12 @@
+{
+  "images" : [
+    {
+      "filename" : "AppIcon-dark-jellyfin.svg",
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Swiftfin/Resources/Assets.xcassets/AppIcon-dark-orange.imageset/AppIcon-dark-orange.svg
+++ b/Swiftfin/Resources/Assets.xcassets/AppIcon-dark-orange.imageset/AppIcon-dark-orange.svg
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg width="1024px" height="1024px" viewBox="0 0 1024 1024" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    <title>AppIcon-dark-orange</title>
+    <defs>
+        <linearGradient x1="19.2532352%" y1="40.8257212%" x2="100.658798%" y2="88.6971024%" id="linearGradient-1">
+            <stop stop-color="#D64800" offset="0%"></stop>
+            <stop stop-color="#FFB657" offset="100%"></stop>
+        </linearGradient>
+    </defs>
+    <g id="Dark" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
+        <g id="AppIcon-dark-orange" fill-rule="nonzero">
+            <rect id="solid-background" fill="#000000" x="0" y="0" width="1024" height="1024"></rect>
+            <path d="M511.582082,136 C609.711866,136 924.91518,714.816848 877.299462,811.251498 C829.683744,907.686149 194.101496,908.81122 145.960253,811.251498 C97.8190104,713.691777 413.547848,136 511.582082,136 Z M511.677632,288.155769 C447.420301,288.155769 240.55469,666.677846 272.102093,730.597947 C303.649497,794.518049 720.072042,793.810861 751.269096,730.597947 C782.46615,667.368961 575.934964,288.155769 511.677632,288.155769 Z M511.109544,425.091384 C543.724099,425.107443 648.323295,617.009305 632.517902,648.998301 C616.71251,680.987298 405.681839,681.34059 389.701185,648.998301 C373.720531,616.656013 478.542787,425.091384 511.109544,425.091384 Z" id="Combined-Shape" fill="url(#linearGradient-1)"></path>
+        </g>
+    </g>
+</svg>

--- a/Swiftfin/Resources/Assets.xcassets/AppIcon-dark-orange.imageset/Contents.json
+++ b/Swiftfin/Resources/Assets.xcassets/AppIcon-dark-orange.imageset/Contents.json
@@ -1,0 +1,12 @@
+{
+  "images" : [
+    {
+      "filename" : "AppIcon-dark-orange.svg",
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Swiftfin/Resources/Assets.xcassets/AppIcon-dark-red.imageset/AppIcon-dark-red.svg
+++ b/Swiftfin/Resources/Assets.xcassets/AppIcon-dark-red.imageset/AppIcon-dark-red.svg
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg width="1024px" height="1024px" viewBox="0 0 1024 1024" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    <title>AppIcon-dark-red</title>
+    <defs>
+        <linearGradient x1="19.2532352%" y1="40.8257212%" x2="100.658798%" y2="88.6971024%" id="linearGradient-1">
+            <stop stop-color="#B42222" offset="0%"></stop>
+            <stop stop-color="#FF8383" offset="100%"></stop>
+        </linearGradient>
+    </defs>
+    <g id="Dark" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
+        <g id="AppIcon-dark-red" fill-rule="nonzero">
+            <rect id="solid-background" fill="#000000" x="0" y="0" width="1024" height="1024"></rect>
+            <path d="M511.582082,136 C609.711866,136 924.91518,714.816848 877.299462,811.251498 C829.683744,907.686149 194.101496,908.81122 145.960253,811.251498 C97.8190104,713.691777 413.547848,136 511.582082,136 Z M511.677632,288.155769 C447.420301,288.155769 240.55469,666.677846 272.102093,730.597947 C303.649497,794.518049 720.072042,793.810861 751.269096,730.597947 C782.46615,667.368961 575.934964,288.155769 511.677632,288.155769 Z M511.109544,425.091384 C543.724099,425.107443 648.323295,617.009305 632.517902,648.998301 C616.71251,680.987298 405.681839,681.34059 389.701185,648.998301 C373.720531,616.656013 478.542787,425.091384 511.109544,425.091384 Z" id="Combined-Shape" fill="url(#linearGradient-1)"></path>
+        </g>
+    </g>
+</svg>

--- a/Swiftfin/Resources/Assets.xcassets/AppIcon-dark-red.imageset/Contents.json
+++ b/Swiftfin/Resources/Assets.xcassets/AppIcon-dark-red.imageset/Contents.json
@@ -1,0 +1,12 @@
+{
+  "images" : [
+    {
+      "filename" : "AppIcon-dark-red.svg",
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Swiftfin/Resources/Assets.xcassets/AppIcon-dark-yellow.imageset/AppIcon-dark-yellow.svg
+++ b/Swiftfin/Resources/Assets.xcassets/AppIcon-dark-yellow.imageset/AppIcon-dark-yellow.svg
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg width="1024px" height="1024px" viewBox="0 0 1024 1024" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    <title>AppIcon-dark-yellow</title>
+    <defs>
+        <linearGradient x1="19.8247286%" y1="41.1617938%" x2="100.658798%" y2="88.6971024%" id="linearGradient-1">
+            <stop stop-color="#988E0D" offset="0%"></stop>
+            <stop stop-color="#FFEE00" offset="100%"></stop>
+        </linearGradient>
+    </defs>
+    <g id="Dark" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
+        <g id="AppIcon-dark-yellow" fill-rule="nonzero">
+            <rect id="solid-background" fill="#000000" x="0" y="0" width="1024" height="1024"></rect>
+            <path d="M511.582082,136 C609.711866,136 924.91518,714.816848 877.299462,811.251498 C829.683744,907.686149 194.101496,908.81122 145.960253,811.251498 C97.8190104,713.691777 413.547848,136 511.582082,136 Z M511.677632,288.155769 C447.420301,288.155769 240.55469,666.677846 272.102093,730.597947 C303.649497,794.518049 720.072042,793.810861 751.269096,730.597947 C782.46615,667.368961 575.934964,288.155769 511.677632,288.155769 Z M511.109544,425.091384 C543.724099,425.107443 648.323295,617.009305 632.517902,648.998301 C616.71251,680.987298 405.681839,681.34059 389.701185,648.998301 C373.720531,616.656013 478.542787,425.091384 511.109544,425.091384 Z" id="Combined-Shape" fill="url(#linearGradient-1)"></path>
+        </g>
+    </g>
+</svg>

--- a/Swiftfin/Resources/Assets.xcassets/AppIcon-dark-yellow.imageset/Contents.json
+++ b/Swiftfin/Resources/Assets.xcassets/AppIcon-dark-yellow.imageset/Contents.json
@@ -1,0 +1,12 @@
+{
+  "images" : [
+    {
+      "filename" : "AppIcon-dark-yellow.svg",
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Swiftfin/Resources/Assets.xcassets/AppIcon-invertedDark-blue.imageset/AppIcon-invertedDark-blue.svg
+++ b/Swiftfin/Resources/Assets.xcassets/AppIcon-invertedDark-blue.imageset/AppIcon-invertedDark-blue.svg
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg width="1024px" height="1024px" viewBox="0 0 1024 1024" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    <title>AppIcon-invertedDark-blue</title>
+    <defs>
+        <linearGradient x1="18.6834859%" y1="40.8257212%" x2="101.597525%" y2="88.6971024%" id="linearGradient-1">
+            <stop stop-color="#1F4EA7" offset="0%"></stop>
+            <stop stop-color="#00DDFF" offset="100%"></stop>
+        </linearGradient>
+    </defs>
+    <g id="Inverted-Dark" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
+        <g id="AppIcon-invertedDark-blue" fill-rule="nonzero">
+            <rect id="solid-background" fill="url(#linearGradient-1)" x="0" y="0" width="1024" height="1024"></rect>
+            <path d="M511.582082,136 C609.711866,136 924.91518,714.816848 877.299462,811.251498 C829.683744,907.686149 194.101496,908.81122 145.960253,811.251498 C97.8190104,713.691777 413.547848,136 511.582082,136 Z M511.677632,288.155769 C447.420301,288.155769 240.55469,666.677846 272.102093,730.597947 C303.649497,794.518049 720.072042,793.810861 751.269096,730.597947 C782.46615,667.368961 575.934964,288.155769 511.677632,288.155769 Z M511.109544,425.091384 C543.724099,425.107443 648.323295,617.009305 632.517902,648.998301 C616.71251,680.987298 405.681839,681.34059 389.701185,648.998301 C373.720531,616.656013 478.542787,425.091384 511.109544,425.091384 Z" id="Combined-Shape" fill="#000000"></path>
+        </g>
+    </g>
+</svg>

--- a/Swiftfin/Resources/Assets.xcassets/AppIcon-invertedDark-blue.imageset/Contents.json
+++ b/Swiftfin/Resources/Assets.xcassets/AppIcon-invertedDark-blue.imageset/Contents.json
@@ -1,0 +1,12 @@
+{
+  "images" : [
+    {
+      "filename" : "AppIcon-invertedDark-blue.svg",
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Swiftfin/Resources/Assets.xcassets/AppIcon-invertedDark-green.imageset/AppIcon-invertedDark-green.svg
+++ b/Swiftfin/Resources/Assets.xcassets/AppIcon-invertedDark-green.imageset/AppIcon-invertedDark-green.svg
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg width="1024px" height="1024px" viewBox="0 0 1024 1024" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    <title>AppIcon-invertedDark-green</title>
+    <defs>
+        <linearGradient x1="18.6834859%" y1="40.8257212%" x2="101.597525%" y2="88.6971024%" id="linearGradient-1">
+            <stop stop-color="#316D0C" offset="0%"></stop>
+            <stop stop-color="#7CD841" offset="100%"></stop>
+        </linearGradient>
+    </defs>
+    <g id="Inverted-Dark" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
+        <g id="AppIcon-invertedDark-green" fill-rule="nonzero">
+            <rect id="solid-background" fill="url(#linearGradient-1)" x="0" y="0" width="1024" height="1024"></rect>
+            <path d="M511.582082,136 C609.711866,136 924.91518,714.816848 877.299462,811.251498 C829.683744,907.686149 194.101496,908.81122 145.960253,811.251498 C97.8190104,713.691777 413.547848,136 511.582082,136 Z M511.677632,288.155769 C447.420301,288.155769 240.55469,666.677846 272.102093,730.597947 C303.649497,794.518049 720.072042,793.810861 751.269096,730.597947 C782.46615,667.368961 575.934964,288.155769 511.677632,288.155769 Z M511.109544,425.091384 C543.724099,425.107443 648.323295,617.009305 632.517902,648.998301 C616.71251,680.987298 405.681839,681.34059 389.701185,648.998301 C373.720531,616.656013 478.542787,425.091384 511.109544,425.091384 Z" id="Combined-Shape" fill="#000000"></path>
+        </g>
+    </g>
+</svg>

--- a/Swiftfin/Resources/Assets.xcassets/AppIcon-invertedDark-green.imageset/Contents.json
+++ b/Swiftfin/Resources/Assets.xcassets/AppIcon-invertedDark-green.imageset/Contents.json
@@ -1,0 +1,12 @@
+{
+  "images" : [
+    {
+      "filename" : "AppIcon-invertedDark-green.svg",
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Swiftfin/Resources/Assets.xcassets/AppIcon-invertedDark-jellyfin.imageset/AppIcon-invertedDark-jellyfin.svg
+++ b/Swiftfin/Resources/Assets.xcassets/AppIcon-invertedDark-jellyfin.imageset/AppIcon-invertedDark-jellyfin.svg
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg width="1024px" height="1024px" viewBox="0 0 1024 1024" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    <title>AppIcon-invertedDark-jellyfin</title>
+    <defs>
+        <linearGradient x1="19.2655693%" y1="41.1617938%" x2="101.597525%" y2="88.6971024%" id="linearGradient-1">
+            <stop stop-color="#AA5CC3" offset="0%"></stop>
+            <stop stop-color="#00A4DC" offset="100%"></stop>
+        </linearGradient>
+    </defs>
+    <g id="Inverted-Dark" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
+        <g id="AppIcon-invertedDark-jellyfin" fill-rule="nonzero">
+            <rect id="solid-background" fill="url(#linearGradient-1)" x="0" y="0" width="1024" height="1024"></rect>
+            <path d="M511.582082,136 C609.711866,136 924.91518,714.816848 877.299462,811.251498 C829.683744,907.686149 194.101496,908.81122 145.960253,811.251498 C97.8190104,713.691777 413.547848,136 511.582082,136 Z M511.677632,288.155769 C447.420301,288.155769 240.55469,666.677846 272.102093,730.597947 C303.649497,794.518049 720.072042,793.810861 751.269096,730.597947 C782.46615,667.368961 575.934964,288.155769 511.677632,288.155769 Z M511.109544,425.091384 C543.724099,425.107443 648.323295,617.009305 632.517902,648.998301 C616.71251,680.987298 405.681839,681.34059 389.701185,648.998301 C373.720531,616.656013 478.542787,425.091384 511.109544,425.091384 Z" id="Combined-Shape" fill="#000000"></path>
+        </g>
+    </g>
+</svg>

--- a/Swiftfin/Resources/Assets.xcassets/AppIcon-invertedDark-jellyfin.imageset/Contents.json
+++ b/Swiftfin/Resources/Assets.xcassets/AppIcon-invertedDark-jellyfin.imageset/Contents.json
@@ -1,0 +1,12 @@
+{
+  "images" : [
+    {
+      "filename" : "AppIcon-invertedDark-jellyfin.svg",
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Swiftfin/Resources/Assets.xcassets/AppIcon-invertedDark-orange.imageset/AppIcon-invertedDark-orange.svg
+++ b/Swiftfin/Resources/Assets.xcassets/AppIcon-invertedDark-orange.imageset/AppIcon-invertedDark-orange.svg
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg width="1024px" height="1024px" viewBox="0 0 1024 1024" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    <title>AppIcon-invertedDark-orange</title>
+    <defs>
+        <linearGradient x1="18.6834859%" y1="40.8257212%" x2="101.597525%" y2="88.6971024%" id="linearGradient-1">
+            <stop stop-color="#D64800" offset="0%"></stop>
+            <stop stop-color="#FFB657" offset="100%"></stop>
+        </linearGradient>
+    </defs>
+    <g id="Inverted-Dark" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
+        <g id="AppIcon-invertedDark-orange" fill-rule="nonzero">
+            <rect id="solid-background" fill="url(#linearGradient-1)" x="0" y="0" width="1024" height="1024"></rect>
+            <path d="M511.582082,136 C609.711866,136 924.91518,714.816848 877.299462,811.251498 C829.683744,907.686149 194.101496,908.81122 145.960253,811.251498 C97.8190104,713.691777 413.547848,136 511.582082,136 Z M511.677632,288.155769 C447.420301,288.155769 240.55469,666.677846 272.102093,730.597947 C303.649497,794.518049 720.072042,793.810861 751.269096,730.597947 C782.46615,667.368961 575.934964,288.155769 511.677632,288.155769 Z M511.109544,425.091384 C543.724099,425.107443 648.323295,617.009305 632.517902,648.998301 C616.71251,680.987298 405.681839,681.34059 389.701185,648.998301 C373.720531,616.656013 478.542787,425.091384 511.109544,425.091384 Z" id="Combined-Shape" fill="#000000"></path>
+        </g>
+    </g>
+</svg>

--- a/Swiftfin/Resources/Assets.xcassets/AppIcon-invertedDark-orange.imageset/Contents.json
+++ b/Swiftfin/Resources/Assets.xcassets/AppIcon-invertedDark-orange.imageset/Contents.json
@@ -1,0 +1,12 @@
+{
+  "images" : [
+    {
+      "filename" : "AppIcon-invertedDark-orange.svg",
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Swiftfin/Resources/Assets.xcassets/AppIcon-invertedDark-red.imageset/AppIcon-invertedDark-red.svg
+++ b/Swiftfin/Resources/Assets.xcassets/AppIcon-invertedDark-red.imageset/AppIcon-invertedDark-red.svg
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg width="1024px" height="1024px" viewBox="0 0 1024 1024" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    <title>AppIcon-invertedDark-red</title>
+    <defs>
+        <linearGradient x1="18.6834859%" y1="40.8257212%" x2="101.597525%" y2="88.6971024%" id="linearGradient-1">
+            <stop stop-color="#B42222" offset="0%"></stop>
+            <stop stop-color="#FF8383" offset="100%"></stop>
+        </linearGradient>
+    </defs>
+    <g id="Inverted-Dark" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
+        <g id="AppIcon-invertedDark-red" fill-rule="nonzero">
+            <rect id="solid-background" fill="url(#linearGradient-1)" x="0" y="0" width="1024" height="1024"></rect>
+            <path d="M511.582082,136 C609.711866,136 924.91518,714.816848 877.299462,811.251498 C829.683744,907.686149 194.101496,908.81122 145.960253,811.251498 C97.8190104,713.691777 413.547848,136 511.582082,136 Z M511.677632,288.155769 C447.420301,288.155769 240.55469,666.677846 272.102093,730.597947 C303.649497,794.518049 720.072042,793.810861 751.269096,730.597947 C782.46615,667.368961 575.934964,288.155769 511.677632,288.155769 Z M511.109544,425.091384 C543.724099,425.107443 648.323295,617.009305 632.517902,648.998301 C616.71251,680.987298 405.681839,681.34059 389.701185,648.998301 C373.720531,616.656013 478.542787,425.091384 511.109544,425.091384 Z" id="Combined-Shape" fill="#000000"></path>
+        </g>
+    </g>
+</svg>

--- a/Swiftfin/Resources/Assets.xcassets/AppIcon-invertedDark-red.imageset/Contents.json
+++ b/Swiftfin/Resources/Assets.xcassets/AppIcon-invertedDark-red.imageset/Contents.json
@@ -1,0 +1,12 @@
+{
+  "images" : [
+    {
+      "filename" : "AppIcon-invertedDark-red.svg",
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Swiftfin/Resources/Assets.xcassets/AppIcon-invertedDark-yellow.imageset/AppIcon-invertedDark-yellow.svg
+++ b/Swiftfin/Resources/Assets.xcassets/AppIcon-invertedDark-yellow.imageset/AppIcon-invertedDark-yellow.svg
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg width="1024px" height="1024px" viewBox="0 0 1024 1024" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    <title>AppIcon-invertedDark-yellow</title>
+    <defs>
+        <linearGradient x1="19.2655693%" y1="41.1617938%" x2="101.597525%" y2="88.6971024%" id="linearGradient-1">
+            <stop stop-color="#988E0D" offset="0%"></stop>
+            <stop stop-color="#FFEE00" offset="100%"></stop>
+        </linearGradient>
+    </defs>
+    <g id="Inverted-Dark" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
+        <g id="AppIcon-invertedDark-yellow" fill-rule="nonzero">
+            <rect id="solid-background" fill="url(#linearGradient-1)" x="0" y="0" width="1024" height="1024"></rect>
+            <path d="M511.582082,136 C609.711866,136 924.91518,714.816848 877.299462,811.251498 C829.683744,907.686149 194.101496,908.81122 145.960253,811.251498 C97.8190104,713.691777 413.547848,136 511.582082,136 Z M511.677632,288.155769 C447.420301,288.155769 240.55469,666.677846 272.102093,730.597947 C303.649497,794.518049 720.072042,793.810861 751.269096,730.597947 C782.46615,667.368961 575.934964,288.155769 511.677632,288.155769 Z M511.109544,425.091384 C543.724099,425.107443 648.323295,617.009305 632.517902,648.998301 C616.71251,680.987298 405.681839,681.34059 389.701185,648.998301 C373.720531,616.656013 478.542787,425.091384 511.109544,425.091384 Z" id="Combined-Shape" fill="#000000"></path>
+        </g>
+    </g>
+</svg>

--- a/Swiftfin/Resources/Assets.xcassets/AppIcon-invertedDark-yellow.imageset/Contents.json
+++ b/Swiftfin/Resources/Assets.xcassets/AppIcon-invertedDark-yellow.imageset/Contents.json
@@ -1,0 +1,12 @@
+{
+  "images" : [
+    {
+      "filename" : "AppIcon-invertedDark-yellow.svg",
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Swiftfin/Resources/Assets.xcassets/AppIcon-invertedLight-blue.imageset/AppIcon-invertedLight-blue.svg
+++ b/Swiftfin/Resources/Assets.xcassets/AppIcon-invertedLight-blue.imageset/AppIcon-invertedLight-blue.svg
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg width="1024px" height="1024px" viewBox="0 0 1024 1024" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    <title>AppIcon-invertedLight-blue</title>
+    <defs>
+        <linearGradient x1="18.6834859%" y1="40.8257212%" x2="101.597525%" y2="88.6971024%" id="linearGradient-1">
+            <stop stop-color="#1F4EA7" offset="0%"></stop>
+            <stop stop-color="#00DDFF" offset="100%"></stop>
+        </linearGradient>
+    </defs>
+    <g id="Inverted-Light" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
+        <g id="AppIcon-invertedLight-blue" fill-rule="nonzero">
+            <rect id="solid-background" fill="url(#linearGradient-1)" x="0" y="0" width="1024" height="1024"></rect>
+            <path d="M511.582082,136 C609.711866,136 924.91518,714.816848 877.299462,811.251498 C829.683744,907.686149 194.101496,908.81122 145.960253,811.251498 C97.8190104,713.691777 413.547848,136 511.582082,136 Z M511.677632,288.155769 C447.420301,288.155769 240.55469,666.677846 272.102093,730.597947 C303.649497,794.518049 720.072042,793.810861 751.269096,730.597947 C782.46615,667.368961 575.934964,288.155769 511.677632,288.155769 Z M511.109544,425.091384 C543.724099,425.107443 648.323295,617.009305 632.517902,648.998301 C616.71251,680.987298 405.681839,681.34059 389.701185,648.998301 C373.720531,616.656013 478.542787,425.091384 511.109544,425.091384 Z" id="Combined-Shape" fill="#FFFFFF"></path>
+        </g>
+    </g>
+</svg>

--- a/Swiftfin/Resources/Assets.xcassets/AppIcon-invertedLight-blue.imageset/Contents.json
+++ b/Swiftfin/Resources/Assets.xcassets/AppIcon-invertedLight-blue.imageset/Contents.json
@@ -1,0 +1,12 @@
+{
+  "images" : [
+    {
+      "filename" : "AppIcon-invertedLight-blue.svg",
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Swiftfin/Resources/Assets.xcassets/AppIcon-invertedLight-green.imageset/AppIcon-invertedLight-green.svg
+++ b/Swiftfin/Resources/Assets.xcassets/AppIcon-invertedLight-green.imageset/AppIcon-invertedLight-green.svg
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg width="1024px" height="1024px" viewBox="0 0 1024 1024" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    <title>AppIcon-invertedLight-green</title>
+    <defs>
+        <linearGradient x1="18.6834859%" y1="40.8257212%" x2="101.597525%" y2="88.6971024%" id="linearGradient-1">
+            <stop stop-color="#316D0C" offset="0%"></stop>
+            <stop stop-color="#7CD841" offset="100%"></stop>
+        </linearGradient>
+    </defs>
+    <g id="Inverted-Light" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
+        <g id="AppIcon-invertedLight-green" fill-rule="nonzero">
+            <rect id="solid-background" fill="url(#linearGradient-1)" x="0" y="0" width="1024" height="1024"></rect>
+            <path d="M511.582082,136 C609.711866,136 924.91518,714.816848 877.299462,811.251498 C829.683744,907.686149 194.101496,908.81122 145.960253,811.251498 C97.8190104,713.691777 413.547848,136 511.582082,136 Z M511.677632,288.155769 C447.420301,288.155769 240.55469,666.677846 272.102093,730.597947 C303.649497,794.518049 720.072042,793.810861 751.269096,730.597947 C782.46615,667.368961 575.934964,288.155769 511.677632,288.155769 Z M511.109544,425.091384 C543.724099,425.107443 648.323295,617.009305 632.517902,648.998301 C616.71251,680.987298 405.681839,681.34059 389.701185,648.998301 C373.720531,616.656013 478.542787,425.091384 511.109544,425.091384 Z" id="Combined-Shape" fill="#FFFFFF"></path>
+        </g>
+    </g>
+</svg>

--- a/Swiftfin/Resources/Assets.xcassets/AppIcon-invertedLight-green.imageset/Contents.json
+++ b/Swiftfin/Resources/Assets.xcassets/AppIcon-invertedLight-green.imageset/Contents.json
@@ -1,0 +1,12 @@
+{
+  "images" : [
+    {
+      "filename" : "AppIcon-invertedLight-green.svg",
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Swiftfin/Resources/Assets.xcassets/AppIcon-invertedLight-jellyfin.imageset/AppIcon-invertedLight-jellyfin.svg
+++ b/Swiftfin/Resources/Assets.xcassets/AppIcon-invertedLight-jellyfin.imageset/AppIcon-invertedLight-jellyfin.svg
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg width="1024px" height="1024px" viewBox="0 0 1024 1024" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    <title>AppIcon-invertedLight-jellyfin</title>
+    <defs>
+        <linearGradient x1="19.2655693%" y1="41.1617938%" x2="101.597525%" y2="88.6971024%" id="linearGradient-1">
+            <stop stop-color="#AA5CC3" offset="0%"></stop>
+            <stop stop-color="#00A4DC" offset="100%"></stop>
+        </linearGradient>
+    </defs>
+    <g id="Inverted-Light" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
+        <g id="AppIcon-invertedLight-jellyfin" fill-rule="nonzero">
+            <rect id="solid-background" fill="url(#linearGradient-1)" x="0" y="0" width="1024" height="1024"></rect>
+            <path d="M511.582082,136 C609.711866,136 924.91518,714.816848 877.299462,811.251498 C829.683744,907.686149 194.101496,908.81122 145.960253,811.251498 C97.8190104,713.691777 413.547848,136 511.582082,136 Z M511.677632,288.155769 C447.420301,288.155769 240.55469,666.677846 272.102093,730.597947 C303.649497,794.518049 720.072042,793.810861 751.269096,730.597947 C782.46615,667.368961 575.934964,288.155769 511.677632,288.155769 Z M511.109544,425.091384 C543.724099,425.107443 648.323295,617.009305 632.517902,648.998301 C616.71251,680.987298 405.681839,681.34059 389.701185,648.998301 C373.720531,616.656013 478.542787,425.091384 511.109544,425.091384 Z" id="Combined-Shape" fill="#FFFFFF"></path>
+        </g>
+    </g>
+</svg>

--- a/Swiftfin/Resources/Assets.xcassets/AppIcon-invertedLight-jellyfin.imageset/Contents.json
+++ b/Swiftfin/Resources/Assets.xcassets/AppIcon-invertedLight-jellyfin.imageset/Contents.json
@@ -1,0 +1,12 @@
+{
+  "images" : [
+    {
+      "filename" : "AppIcon-invertedLight-jellyfin.svg",
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Swiftfin/Resources/Assets.xcassets/AppIcon-invertedLight-orange.imageset/AppIcon-invertedLight-orange.svg
+++ b/Swiftfin/Resources/Assets.xcassets/AppIcon-invertedLight-orange.imageset/AppIcon-invertedLight-orange.svg
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg width="1024px" height="1024px" viewBox="0 0 1024 1024" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    <title>AppIcon-invertedLight-orange</title>
+    <defs>
+        <linearGradient x1="18.6834859%" y1="40.8257212%" x2="101.597525%" y2="88.6971024%" id="linearGradient-1">
+            <stop stop-color="#D64800" offset="0%"></stop>
+            <stop stop-color="#FFB657" offset="100%"></stop>
+        </linearGradient>
+    </defs>
+    <g id="Inverted-Light" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
+        <g id="AppIcon-invertedLight-orange" fill-rule="nonzero">
+            <rect id="solid-background" fill="url(#linearGradient-1)" x="0" y="0" width="1024" height="1024"></rect>
+            <path d="M511.582082,136 C609.711866,136 924.91518,714.816848 877.299462,811.251498 C829.683744,907.686149 194.101496,908.81122 145.960253,811.251498 C97.8190104,713.691777 413.547848,136 511.582082,136 Z M511.677632,288.155769 C447.420301,288.155769 240.55469,666.677846 272.102093,730.597947 C303.649497,794.518049 720.072042,793.810861 751.269096,730.597947 C782.46615,667.368961 575.934964,288.155769 511.677632,288.155769 Z M511.109544,425.091384 C543.724099,425.107443 648.323295,617.009305 632.517902,648.998301 C616.71251,680.987298 405.681839,681.34059 389.701185,648.998301 C373.720531,616.656013 478.542787,425.091384 511.109544,425.091384 Z" id="Combined-Shape" fill="#FFFFFF"></path>
+        </g>
+    </g>
+</svg>

--- a/Swiftfin/Resources/Assets.xcassets/AppIcon-invertedLight-orange.imageset/Contents.json
+++ b/Swiftfin/Resources/Assets.xcassets/AppIcon-invertedLight-orange.imageset/Contents.json
@@ -1,0 +1,12 @@
+{
+  "images" : [
+    {
+      "filename" : "AppIcon-invertedLight-orange.svg",
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Swiftfin/Resources/Assets.xcassets/AppIcon-invertedLight-red.imageset/AppIcon-invertedLight-red.svg
+++ b/Swiftfin/Resources/Assets.xcassets/AppIcon-invertedLight-red.imageset/AppIcon-invertedLight-red.svg
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg width="1024px" height="1024px" viewBox="0 0 1024 1024" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    <title>AppIcon-invertedLight-red</title>
+    <defs>
+        <linearGradient x1="18.6834859%" y1="40.8257212%" x2="101.597525%" y2="88.6971024%" id="linearGradient-1">
+            <stop stop-color="#B42222" offset="0%"></stop>
+            <stop stop-color="#FF8383" offset="100%"></stop>
+        </linearGradient>
+    </defs>
+    <g id="Inverted-Light" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
+        <g id="AppIcon-invertedLight-red" fill-rule="nonzero">
+            <rect id="solid-background" fill="url(#linearGradient-1)" x="0" y="0" width="1024" height="1024"></rect>
+            <path d="M511.582082,136 C609.711866,136 924.91518,714.816848 877.299462,811.251498 C829.683744,907.686149 194.101496,908.81122 145.960253,811.251498 C97.8190104,713.691777 413.547848,136 511.582082,136 Z M511.677632,288.155769 C447.420301,288.155769 240.55469,666.677846 272.102093,730.597947 C303.649497,794.518049 720.072042,793.810861 751.269096,730.597947 C782.46615,667.368961 575.934964,288.155769 511.677632,288.155769 Z M511.109544,425.091384 C543.724099,425.107443 648.323295,617.009305 632.517902,648.998301 C616.71251,680.987298 405.681839,681.34059 389.701185,648.998301 C373.720531,616.656013 478.542787,425.091384 511.109544,425.091384 Z" id="Combined-Shape" fill="#FFFFFF"></path>
+        </g>
+    </g>
+</svg>

--- a/Swiftfin/Resources/Assets.xcassets/AppIcon-invertedLight-red.imageset/Contents.json
+++ b/Swiftfin/Resources/Assets.xcassets/AppIcon-invertedLight-red.imageset/Contents.json
@@ -1,0 +1,12 @@
+{
+  "images" : [
+    {
+      "filename" : "AppIcon-invertedLight-red.svg",
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Swiftfin/Resources/Assets.xcassets/AppIcon-invertedLight-yellow.imageset/AppIcon-invertedLight-yellow.svg
+++ b/Swiftfin/Resources/Assets.xcassets/AppIcon-invertedLight-yellow.imageset/AppIcon-invertedLight-yellow.svg
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg width="1024px" height="1024px" viewBox="0 0 1024 1024" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    <title>AppIcon-invertedLight-yellow</title>
+    <defs>
+        <linearGradient x1="19.2655693%" y1="41.1617938%" x2="101.597525%" y2="88.6971024%" id="linearGradient-1">
+            <stop stop-color="#988E0D" offset="0%"></stop>
+            <stop stop-color="#FFEE00" offset="100%"></stop>
+        </linearGradient>
+    </defs>
+    <g id="Inverted-Light" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
+        <g id="AppIcon-invertedLight-yellow" fill-rule="nonzero">
+            <rect id="solid-background" fill="url(#linearGradient-1)" x="0" y="0" width="1024" height="1024"></rect>
+            <path d="M511.582082,136 C609.711866,136 924.91518,714.816848 877.299462,811.251498 C829.683744,907.686149 194.101496,908.81122 145.960253,811.251498 C97.8190104,713.691777 413.547848,136 511.582082,136 Z M511.677632,288.155769 C447.420301,288.155769 240.55469,666.677846 272.102093,730.597947 C303.649497,794.518049 720.072042,793.810861 751.269096,730.597947 C782.46615,667.368961 575.934964,288.155769 511.677632,288.155769 Z M511.109544,425.091384 C543.724099,425.107443 648.323295,617.009305 632.517902,648.998301 C616.71251,680.987298 405.681839,681.34059 389.701185,648.998301 C373.720531,616.656013 478.542787,425.091384 511.109544,425.091384 Z" id="Combined-Shape" fill="#FFFFFF"></path>
+        </g>
+    </g>
+</svg>

--- a/Swiftfin/Resources/Assets.xcassets/AppIcon-invertedLight-yellow.imageset/Contents.json
+++ b/Swiftfin/Resources/Assets.xcassets/AppIcon-invertedLight-yellow.imageset/Contents.json
@@ -1,0 +1,12 @@
+{
+  "images" : [
+    {
+      "filename" : "AppIcon-invertedLight-yellow.svg",
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Swiftfin/Resources/Assets.xcassets/AppIcon-light-blue.imageset/AppIcon-light-blue.svg
+++ b/Swiftfin/Resources/Assets.xcassets/AppIcon-light-blue.imageset/AppIcon-light-blue.svg
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg width="1024px" height="1024px" viewBox="0 0 1024 1024" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    <title>AppIcon-light-blue</title>
+    <defs>
+        <linearGradient x1="19.2532352%" y1="40.8257212%" x2="100.658798%" y2="88.6971024%" id="linearGradient-1">
+            <stop stop-color="#1F4EA7" offset="0%"></stop>
+            <stop stop-color="#00DDFF" offset="100%"></stop>
+        </linearGradient>
+    </defs>
+    <g id="Light" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
+        <g id="AppIcon-light-blue" fill-rule="nonzero">
+            <rect id="solid-background" fill="#FFFFFF" x="0" y="0" width="1024" height="1024"></rect>
+            <path d="M511.582082,136 C609.711866,136 924.91518,714.816848 877.299462,811.251498 C829.683744,907.686149 194.101496,908.81122 145.960253,811.251498 C97.8190104,713.691777 413.547848,136 511.582082,136 Z M511.677632,288.155769 C447.420301,288.155769 240.55469,666.677846 272.102093,730.597947 C303.649497,794.518049 720.072042,793.810861 751.269096,730.597947 C782.46615,667.368961 575.934964,288.155769 511.677632,288.155769 Z M511.109544,425.091384 C543.724099,425.107443 648.323295,617.009305 632.517902,648.998301 C616.71251,680.987298 405.681839,681.34059 389.701185,648.998301 C373.720531,616.656013 478.542787,425.091384 511.109544,425.091384 Z" id="Combined-Shape" fill="url(#linearGradient-1)"></path>
+        </g>
+    </g>
+</svg>

--- a/Swiftfin/Resources/Assets.xcassets/AppIcon-light-blue.imageset/Contents.json
+++ b/Swiftfin/Resources/Assets.xcassets/AppIcon-light-blue.imageset/Contents.json
@@ -1,0 +1,12 @@
+{
+  "images" : [
+    {
+      "filename" : "AppIcon-light-blue.svg",
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Swiftfin/Resources/Assets.xcassets/AppIcon-light-green.imageset/AppIcon-light-green.svg
+++ b/Swiftfin/Resources/Assets.xcassets/AppIcon-light-green.imageset/AppIcon-light-green.svg
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg width="1024px" height="1024px" viewBox="0 0 1024 1024" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    <title>AppIcon-light-green</title>
+    <defs>
+        <linearGradient x1="19.2532352%" y1="40.8257212%" x2="100.658798%" y2="88.6971024%" id="linearGradient-1">
+            <stop stop-color="#316D0C" offset="0%"></stop>
+            <stop stop-color="#7CD841" offset="100%"></stop>
+        </linearGradient>
+    </defs>
+    <g id="Light" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
+        <g id="AppIcon-light-green" fill-rule="nonzero">
+            <rect id="solid-background" fill="#FFFFFF" x="0" y="0" width="1024" height="1024"></rect>
+            <path d="M511.582082,136 C609.711866,136 924.91518,714.816848 877.299462,811.251498 C829.683744,907.686149 194.101496,908.81122 145.960253,811.251498 C97.8190104,713.691777 413.547848,136 511.582082,136 Z M511.677632,288.155769 C447.420301,288.155769 240.55469,666.677846 272.102093,730.597947 C303.649497,794.518049 720.072042,793.810861 751.269096,730.597947 C782.46615,667.368961 575.934964,288.155769 511.677632,288.155769 Z M511.109544,425.091384 C543.724099,425.107443 648.323295,617.009305 632.517902,648.998301 C616.71251,680.987298 405.681839,681.34059 389.701185,648.998301 C373.720531,616.656013 478.542787,425.091384 511.109544,425.091384 Z" id="Combined-Shape" fill="url(#linearGradient-1)"></path>
+        </g>
+    </g>
+</svg>

--- a/Swiftfin/Resources/Assets.xcassets/AppIcon-light-green.imageset/Contents.json
+++ b/Swiftfin/Resources/Assets.xcassets/AppIcon-light-green.imageset/Contents.json
@@ -1,0 +1,12 @@
+{
+  "images" : [
+    {
+      "filename" : "AppIcon-light-green.svg",
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Swiftfin/Resources/Assets.xcassets/AppIcon-light-jellyfin.imageset/AppIcon-light-jellyfin.svg
+++ b/Swiftfin/Resources/Assets.xcassets/AppIcon-light-jellyfin.imageset/AppIcon-light-jellyfin.svg
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg width="1024px" height="1024px" viewBox="0 0 1024 1024" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    <title>AppIcon-light-jellyfin</title>
+    <defs>
+        <linearGradient x1="19.8247286%" y1="41.1617938%" x2="100.658798%" y2="88.6971024%" id="linearGradient-1">
+            <stop stop-color="#AA5CC3" offset="0%"></stop>
+            <stop stop-color="#00A4DC" offset="100%"></stop>
+        </linearGradient>
+    </defs>
+    <g id="Light" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
+        <g id="AppIcon-light-jellyfin" fill-rule="nonzero">
+            <rect id="solid-background" fill="#FFFFFF" x="0" y="0" width="1024" height="1024"></rect>
+            <path d="M511.582082,136 C609.711866,136 924.91518,714.816848 877.299462,811.251498 C829.683744,907.686149 194.101496,908.81122 145.960253,811.251498 C97.8190104,713.691777 413.547848,136 511.582082,136 Z M511.677632,288.155769 C447.420301,288.155769 240.55469,666.677846 272.102093,730.597947 C303.649497,794.518049 720.072042,793.810861 751.269096,730.597947 C782.46615,667.368961 575.934964,288.155769 511.677632,288.155769 Z M511.109544,425.091384 C543.724099,425.107443 648.323295,617.009305 632.517902,648.998301 C616.71251,680.987298 405.681839,681.34059 389.701185,648.998301 C373.720531,616.656013 478.542787,425.091384 511.109544,425.091384 Z" id="Combined-Shape" fill="url(#linearGradient-1)"></path>
+        </g>
+    </g>
+</svg>

--- a/Swiftfin/Resources/Assets.xcassets/AppIcon-light-jellyfin.imageset/Contents.json
+++ b/Swiftfin/Resources/Assets.xcassets/AppIcon-light-jellyfin.imageset/Contents.json
@@ -1,0 +1,12 @@
+{
+  "images" : [
+    {
+      "filename" : "AppIcon-light-jellyfin.svg",
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Swiftfin/Resources/Assets.xcassets/AppIcon-light-orange.imageset/AppIcon-light-orange.svg
+++ b/Swiftfin/Resources/Assets.xcassets/AppIcon-light-orange.imageset/AppIcon-light-orange.svg
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg width="1024px" height="1024px" viewBox="0 0 1024 1024" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    <title>AppIcon-light-orange</title>
+    <defs>
+        <linearGradient x1="19.2532352%" y1="40.8257212%" x2="100.658798%" y2="88.6971024%" id="linearGradient-1">
+            <stop stop-color="#D64800" offset="0%"></stop>
+            <stop stop-color="#FFB657" offset="100%"></stop>
+        </linearGradient>
+    </defs>
+    <g id="Light" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
+        <g id="AppIcon-light-orange" fill-rule="nonzero">
+            <rect id="solid-background" fill="#FFFFFF" x="0" y="0" width="1024" height="1024"></rect>
+            <path d="M511.582082,136 C609.711866,136 924.91518,714.816848 877.299462,811.251498 C829.683744,907.686149 194.101496,908.81122 145.960253,811.251498 C97.8190104,713.691777 413.547848,136 511.582082,136 Z M511.677632,288.155769 C447.420301,288.155769 240.55469,666.677846 272.102093,730.597947 C303.649497,794.518049 720.072042,793.810861 751.269096,730.597947 C782.46615,667.368961 575.934964,288.155769 511.677632,288.155769 Z M511.109544,425.091384 C543.724099,425.107443 648.323295,617.009305 632.517902,648.998301 C616.71251,680.987298 405.681839,681.34059 389.701185,648.998301 C373.720531,616.656013 478.542787,425.091384 511.109544,425.091384 Z" id="Combined-Shape" fill="url(#linearGradient-1)"></path>
+        </g>
+    </g>
+</svg>

--- a/Swiftfin/Resources/Assets.xcassets/AppIcon-light-orange.imageset/Contents.json
+++ b/Swiftfin/Resources/Assets.xcassets/AppIcon-light-orange.imageset/Contents.json
@@ -1,0 +1,12 @@
+{
+  "images" : [
+    {
+      "filename" : "AppIcon-light-orange.svg",
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Swiftfin/Resources/Assets.xcassets/AppIcon-light-red.imageset/AppIcon-light-red.svg
+++ b/Swiftfin/Resources/Assets.xcassets/AppIcon-light-red.imageset/AppIcon-light-red.svg
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg width="1024px" height="1024px" viewBox="0 0 1024 1024" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    <title>AppIcon-light-red</title>
+    <defs>
+        <linearGradient x1="19.2532352%" y1="40.8257212%" x2="100.658798%" y2="88.6971024%" id="linearGradient-1">
+            <stop stop-color="#B42222" offset="0%"></stop>
+            <stop stop-color="#FF8383" offset="100%"></stop>
+        </linearGradient>
+    </defs>
+    <g id="Light" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
+        <g id="AppIcon-light-red" fill-rule="nonzero">
+            <rect id="solid-background" fill="#FFFFFF" x="0" y="0" width="1024" height="1024"></rect>
+            <path d="M511.582082,136 C609.711866,136 924.91518,714.816848 877.299462,811.251498 C829.683744,907.686149 194.101496,908.81122 145.960253,811.251498 C97.8190104,713.691777 413.547848,136 511.582082,136 Z M511.677632,288.155769 C447.420301,288.155769 240.55469,666.677846 272.102093,730.597947 C303.649497,794.518049 720.072042,793.810861 751.269096,730.597947 C782.46615,667.368961 575.934964,288.155769 511.677632,288.155769 Z M511.109544,425.091384 C543.724099,425.107443 648.323295,617.009305 632.517902,648.998301 C616.71251,680.987298 405.681839,681.34059 389.701185,648.998301 C373.720531,616.656013 478.542787,425.091384 511.109544,425.091384 Z" id="Combined-Shape" fill="url(#linearGradient-1)"></path>
+        </g>
+    </g>
+</svg>

--- a/Swiftfin/Resources/Assets.xcassets/AppIcon-light-red.imageset/Contents.json
+++ b/Swiftfin/Resources/Assets.xcassets/AppIcon-light-red.imageset/Contents.json
@@ -1,0 +1,12 @@
+{
+  "images" : [
+    {
+      "filename" : "AppIcon-light-red.svg",
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Swiftfin/Resources/Assets.xcassets/AppIcon-light-yellow.imageset/AppIcon-light-yellow.svg
+++ b/Swiftfin/Resources/Assets.xcassets/AppIcon-light-yellow.imageset/AppIcon-light-yellow.svg
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg width="1024px" height="1024px" viewBox="0 0 1024 1024" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    <title>AppIcon-light-yellow</title>
+    <defs>
+        <linearGradient x1="19.8247286%" y1="41.1617938%" x2="100.658798%" y2="88.6971024%" id="linearGradient-1">
+            <stop stop-color="#988E0D" offset="0%"></stop>
+            <stop stop-color="#FFEE00" offset="100%"></stop>
+        </linearGradient>
+    </defs>
+    <g id="Light" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
+        <g id="AppIcon-light-yellow" fill-rule="nonzero">
+            <rect id="solid-background" fill="#FFFFFF" x="0" y="0" width="1024" height="1024"></rect>
+            <path d="M511.582082,136 C609.711866,136 924.91518,714.816848 877.299462,811.251498 C829.683744,907.686149 194.101496,908.81122 145.960253,811.251498 C97.8190104,713.691777 413.547848,136 511.582082,136 Z M511.677632,288.155769 C447.420301,288.155769 240.55469,666.677846 272.102093,730.597947 C303.649497,794.518049 720.072042,793.810861 751.269096,730.597947 C782.46615,667.368961 575.934964,288.155769 511.677632,288.155769 Z M511.109544,425.091384 C543.724099,425.107443 648.323295,617.009305 632.517902,648.998301 C616.71251,680.987298 405.681839,681.34059 389.701185,648.998301 C373.720531,616.656013 478.542787,425.091384 511.109544,425.091384 Z" id="Combined-Shape" fill="url(#linearGradient-1)"></path>
+        </g>
+    </g>
+</svg>

--- a/Swiftfin/Resources/Assets.xcassets/AppIcon-light-yellow.imageset/Contents.json
+++ b/Swiftfin/Resources/Assets.xcassets/AppIcon-light-yellow.imageset/Contents.json
@@ -1,0 +1,12 @@
+{
+  "images" : [
+    {
+      "filename" : "AppIcon-light-yellow.svg",
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Swiftfin/Resources/Assets.xcassets/AppIcon-primary-primary.imageset/AppIcon-primary-primary.svg
+++ b/Swiftfin/Resources/Assets.xcassets/AppIcon-primary-primary.imageset/AppIcon-primary-primary.svg
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg width="1024px" height="1024px" viewBox="0 0 1024 1024" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    <title>primary</title>
+    <defs>
+        <linearGradient x1="19.2532352%" y1="40.8257212%" x2="100.658798%" y2="88.6971024%" id="linearGradient-1">
+            <stop stop-color="#1F4EA7" offset="0%"></stop>
+            <stop stop-color="#00DDFF" offset="100%"></stop>
+        </linearGradient>
+    </defs>
+    <g id="Primary" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
+        <g id="primary" fill-rule="nonzero">
+            <rect id="solid-background" fill="#020B23" x="0" y="0" width="1024" height="1024"></rect>
+            <path d="M511.582082,136 C609.711866,136 924.91518,714.816848 877.299462,811.251498 C829.683744,907.686149 194.101496,908.81122 145.960253,811.251498 C97.8190104,713.691777 413.547848,136 511.582082,136 Z M511.677632,288.155769 C447.420301,288.155769 240.55469,666.677846 272.102093,730.597947 C303.649497,794.518049 720.072042,793.810861 751.269096,730.597947 C782.46615,667.368961 575.934964,288.155769 511.677632,288.155769 Z M511.109544,425.091384 C543.724099,425.107443 648.323295,617.009305 632.517902,648.998301 C616.71251,680.987298 405.681839,681.34059 389.701185,648.998301 C373.720531,616.656013 478.542787,425.091384 511.109544,425.091384 Z" id="Combined-Shape" fill="url(#linearGradient-1)"></path>
+        </g>
+    </g>
+</svg>

--- a/Swiftfin/Resources/Assets.xcassets/AppIcon-primary-primary.imageset/Contents.json
+++ b/Swiftfin/Resources/Assets.xcassets/AppIcon-primary-primary.imageset/Contents.json
@@ -1,0 +1,12 @@
+{
+  "images" : [
+    {
+      "filename" : "AppIcon-primary-primary.svg",
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Swiftfin/Views/AppIconSelectorView.swift
+++ b/Swiftfin/Views/AppIconSelectorView.swift
@@ -69,7 +69,7 @@ extension AppIconSelectorView {
             } label: {
                 HStack {
 
-                    Image(uiImage: icon.iconPreview)
+                    Image(icon.iconName)
                         .resizable()
                         .aspectRatio(contentMode: .fit)
                         .frame(width: 60, height: 60)


### PR DESCRIPTION
Something changed with iOS 18/Xcode 16 and the app icons are no longer showing up in the picker.

<img src="https://github.com/user-attachments/assets/5445b303-b788-480c-a723-aa40a8c34ab7" width=25% height=25%>

Apparently, this change was in [Xcode 16 beta 5](https://forums.developer.apple.com/forums/thread/757162) but I'm not finding the entry in the final release notes. So all I did was add them to the assets catalog as image sets.

