### PR TITLE
Default ResumeNextUp to False

### DIFF
--- a/Shared/Services/SwiftfinDefaults.swift
+++ b/Shared/Services/SwiftfinDefaults.swift
@@ -166,7 +166,7 @@ extension Defaults.Keys {
 
         enum Home {
             static let showRecentlyAdded: Key<Bool> = UserKey("showRecentlyAdded", default: true)
-            static let resumeNextUp: Key<Bool> = UserKey("homeResumeNextUp", default: true)
+            static let resumeNextUp: Key<Bool> = UserKey("homeResumeNextUp", default: false)
             static let maxNextUp: Key<TimeInterval> = UserKey(
                 "homeMaxNextUp",
                 default: 366 * 86400


### PR DESCRIPTION
When I made https://github.com/jellyfin/Swiftfin/pull/1258 I defaulted this to true. Reviewing Jellyfin-Web and seeing feedback this should be defaulted to false.