### PR TITLE
[Fix] NextUp Updates Require Restart

### DIFF
--- a/Shared/ViewModels/LibraryViewModel/NextUpLibraryViewModel.swift
+++ b/Shared/ViewModels/LibraryViewModel/NextUpLibraryViewModel.swift
@@ -13,11 +13,6 @@ import JellyfinAPI
 
 final class NextUpLibraryViewModel: PagingLibraryViewModel<BaseItemDto> {
 
-    @Default(.Customization.Home.maxNextUp)
-    var maxNextUp
-    @Default(.Customization.Home.resumeNextUp)
-    var resumeNextUp
-
     init() {
         super.init(parent: TitledLibraryParent(displayTitle: L10n.nextUp, id: "nextUp"))
     }
@@ -37,10 +32,10 @@ final class NextUpLibraryViewModel: PagingLibraryViewModel<BaseItemDto> {
         parameters.enableUserData = true
         parameters.fields = .MinimumFields
         parameters.limit = pageSize
-        if maxNextUp > 0 {
-            parameters.nextUpDateCutoff = Date.now.addingTimeInterval(-maxNextUp)
+        if Defaults[.Customization.Home.maxNextUp] > 0 {
+            parameters.nextUpDateCutoff = Date.now.addingTimeInterval(-Defaults[.Customization.Home.maxNextUp])
         }
-        parameters.enableRewatching = resumeNextUp
+        parameters.enableRewatching = Defaults[.Customization.Home.resumeNextUp]
         parameters.startIndex = page
         parameters.userID = userSession.user.id
 

--- a/Shared/ViewModels/LibraryViewModel/NextUpLibraryViewModel.swift
+++ b/Shared/ViewModels/LibraryViewModel/NextUpLibraryViewModel.swift
@@ -13,8 +13,10 @@ import JellyfinAPI
 
 final class NextUpLibraryViewModel: PagingLibraryViewModel<BaseItemDto> {
 
-    let maxNextUp = Defaults[.Customization.Home.maxNextUp]
-    let resumeNextUp = Defaults[.Customization.Home.resumeNextUp]
+    @Default(.Customization.Home.maxNextUp)
+    var maxNextUp
+    @Default(.Customization.Home.resumeNextUp)
+    var resumeNextUp
 
     init() {
         super.init(parent: TitledLibraryParent(displayTitle: L10n.nextUp, id: "nextUp"))

--- a/Shared/ViewModels/LibraryViewModel/NextUpLibraryViewModel.swift
+++ b/Shared/ViewModels/LibraryViewModel/NextUpLibraryViewModel.swift
@@ -28,12 +28,13 @@ final class NextUpLibraryViewModel: PagingLibraryViewModel<BaseItemDto> {
 
     private func parameters(for page: Int) -> Paths.GetNextUpParameters {
 
+        let maxNextUp = Defaults[.Customization.Home.maxNextUp]
         var parameters = Paths.GetNextUpParameters()
         parameters.enableUserData = true
         parameters.fields = .MinimumFields
         parameters.limit = pageSize
-        if Defaults[.Customization.Home.maxNextUp] > 0 {
-            parameters.nextUpDateCutoff = Date.now.addingTimeInterval(-Defaults[.Customization.Home.maxNextUp])
+        if maxNextUp > 0 {
+            parameters.nextUpDateCutoff = Date.now.addingTimeInterval(-maxNextUp)
         }
         parameters.enableRewatching = Defaults[.Customization.Home.resumeNextUp]
         parameters.startIndex = page


### PR DESCRIPTION
### Issue

Fixes #1279.

When I made this change: https://github.com/jellyfin/Swiftfin/pull/1258#discussion_r1789501879, I updated the maxNextUp and resumeNextUp settings to use let constants. However, this introduced an issue where you cannot update the values for maxNextUp or resumeNextUp without restarting Swiftfin. Changing them to var doesn’t fully resolve the problem either, as the values still don’t update dynamically.

### PR Fix

If I revert the change from #1258 (comment), the issue is resolved.

### Alternative Fix

I also explored another approach that allows these values to update dynamically without requiring a restart. The fix uses `Published` properties in combination with Defaults.publisher to observe changes and update the values in real-time.

```
@Published 
private(set) var maxNextUp: TimeInterval = Defaults[.Customization.Home.maxNextUp]
@Published 
private(set) var resumeNextUp: Bool = Defaults[.Customization.Home.resumeNextUp]

init() {
    Defaults.publisher(.Customization.Home.maxNextUp)
        .map { $0.newValue }
        .assign(to: &$maxNextUp)

    Defaults.publisher(.Customization.Home.resumeNextUp)
        .map { $0.newValue }
        .assign(to: &$resumeNextUp)

    // Other init code...
}
```

Let me know if we want to go the alternative route or if there is a better solution I haven't explored yet! For this PR, I chose to start with the 4 line change vs the 20 line change.