### PR TITLE
[iOS] LetterPicker - Dynamic Scaling

### DIFF
--- a/Swiftfin/Components/LetterPickerBar/Components/LetterPickerButton.swift
+++ b/Swiftfin/Components/LetterPickerBar/Components/LetterPickerButton.swift
@@ -20,10 +20,12 @@ extension LetterPickerBar {
         private var isSelected
 
         private let letter: ItemLetter
+        private let size: CGFloat
         private let viewModel: FilterViewModel
 
-        init(letter: ItemLetter, viewModel: FilterViewModel) {
+        init(letter: ItemLetter, size: CGFloat, viewModel: FilterViewModel) {
             self.letter = letter
+            self.size = size
             self.viewModel = viewModel
         }
 
@@ -37,15 +39,15 @@ extension LetterPickerBar {
             } label: {
                 ZStack {
                     RoundedRectangle(cornerRadius: 5)
+                        .frame(width: size, height: size)
                         .foregroundStyle(isSelected ? accentColor : Color.clear)
 
                     Text(letter.value)
                         .font(.headline)
                         .foregroundStyle(isSelected ? accentColor.overlayColor : accentColor)
+                        .frame(width: size, height: size, alignment: .center)
                 }
-                .frame(width: 20, height: 20)
             }
-            .frame(width: 50, height: 20)
         }
     }
 }

--- a/Swiftfin/Components/LetterPickerBar/LetterPickerBar.swift
+++ b/Swiftfin/Components/LetterPickerBar/LetterPickerBar.swift
@@ -24,7 +24,7 @@ struct LetterPickerBar: View {
             ForEach(ItemLetter.allCases, id: \.hashValue) { filterLetter in
                 LetterPickerButton(
                     letter: filterLetter,
-                    size: size,
+                    size: LetterPickerBar.size,
                     viewModel: viewModel
                 )
                 .environment(\.isSelected, viewModel.currentFilters.letter.contains(filterLetter))
@@ -33,12 +33,12 @@ struct LetterPickerBar: View {
             Spacer()
         }
         .scrollIfLargerThanContainer()
-        .frame(width: size, alignment: .center)
+        .frame(width: LetterPickerBar.size, alignment: .center)
     }
 
     // MARK: - Letter Button Size
 
-    private var size: CGFloat {
+    static var size: CGFloat {
         String().height(
             withConstrainedWidth: CGFloat.greatestFiniteMagnitude,
             font: UIFont.preferredFont(

--- a/Swiftfin/Components/LetterPickerBar/LetterPickerBar.swift
+++ b/Swiftfin/Components/LetterPickerBar/LetterPickerBar.swift
@@ -14,6 +14,8 @@ struct LetterPickerBar: View {
     @ObservedObject
     var viewModel: FilterViewModel
 
+    // MARK: - Body
+
     @ViewBuilder
     var body: some View {
         VStack(spacing: 0) {
@@ -22,6 +24,7 @@ struct LetterPickerBar: View {
             ForEach(ItemLetter.allCases, id: \.hashValue) { filterLetter in
                 LetterPickerButton(
                     letter: filterLetter,
+                    size: size,
                     viewModel: viewModel
                 )
                 .environment(\.isSelected, viewModel.currentFilters.letter.contains(filterLetter))
@@ -30,6 +33,17 @@ struct LetterPickerBar: View {
             Spacer()
         }
         .scrollIfLargerThanContainer()
-        .frame(width: 30, alignment: .center)
+        .frame(width: size, alignment: .center)
+    }
+
+    // MARK: - Letter Button Size
+
+    private var size: CGFloat {
+        String().height(
+            withConstrainedWidth: CGFloat.greatestFiniteMagnitude,
+            font: UIFont.preferredFont(
+                forTextStyle: .headline
+            )
+        )
     }
 }

--- a/Swiftfin/Views/PagingLibraryView/PagingLibraryView.swift
+++ b/Swiftfin/Views/PagingLibraryView/PagingLibraryView.swift
@@ -284,7 +284,7 @@ struct PagingLibraryView<Element: Poster>: View {
         if letterPickerEnabled, let filterViewModel = viewModel.filterViewModel {
             ZStack(alignment: letterPickerOrientation.alignment) {
                 innerContent
-                    .padding(letterPickerOrientation.edge, 35)
+                    .padding(letterPickerOrientation.edge, LetterPickerBar.size + 10)
                     .frame(maxWidth: .infinity)
 
                 LetterPickerBar(viewModel: filterViewModel)


### PR DESCRIPTION
### Summary
I noticed some LetterPickers looked wrong. I realized it was because he was using the Accessibility > Font Size to increase his font to the maximum allowed font. Since the LetterPicker was build using static padding and frame numbers, this resulted in a weird look:

<img width="51" alt="Screenshot 2024-11-23 at 21 45 27" src="https://github.com/user-attachments/assets/b1add216-8d25-401e-89e8-bb41d38f177b">

Coming back at this with some additional experience, I just changed each letter to accept it's size as an input. Then, from the LetterPickerBar, I use the `String().height()` to create a static `size` for the Headline font that we are using for the LetterPicker. So, all letters get that size passed in for it's from the LetterPickerBar and the LetterPickerBar frame is always appropriately sized to ensure no letters get cut off.

Finally, I am calling `LetterPickerBar.size` on the `PagingLibraryView` and using that to get the padding when the LetterPickerBar is present. I am adding 10 to this value since the LetterPickerBar is padded 10 away from the edge, centering it between the edge of the screen and the content.

I've tested this from iOS and iPad from the smallest to the largest letters and this looks to be working a lot better. An unintended side effect is this is turning into a scroll more often but that seems ideal over cramming everything in.

<img width="841" alt="Screenshot 2024-11-23 at 21 57 56" src="https://github.com/user-attachments/assets/806999da-c6df-4d8d-af86-b2c1236404db">
