### PR TITLE
Resolve Prolonged Type Checking

### DIFF
--- a/Shared/SwiftfinStore/StoredValue/StoredValue.swift
+++ b/Shared/SwiftfinStore/StoredValue/StoredValue.swift
@@ -94,8 +94,12 @@ extension StoredValue {
 
             let domain = key.domain ?? "none"
 
+            let ownerFilter: Where<AnyStoredData> = Where(\.$ownerID == key.ownerID)
+            let keyFilter: Where<AnyStoredData> = Where(\.$key == key.name)
+            let domainFilter: Where<AnyStoredData> = Where(\.$domain == domain)
+
             let clause = From<AnyStoredData>()
-                .where(\.$ownerID == key.ownerID && \.$key == key.name && \.$domain == domain)
+                .where(ownerFilter && keyFilter && domainFilter)
 
             if let values = try? SwiftfinStore.dataStack.fetchAll(clause), let first = values.first {
                 let publisher = first.asPublisher(in: SwiftfinStore.dataStack)

--- a/Shared/SwiftfinStore/V2Schema/V2AnyData.swift
+++ b/Shared/SwiftfinStore/V2Schema/V2AnyData.swift
@@ -56,8 +56,12 @@ extension AnyStoredData {
 
         let domain = domain ?? "none"
 
+        let ownerFilter: Where<AnyStoredData> = Where(\.$ownerID == ownerID)
+        let keyFilter: Where<AnyStoredData> = Where(\.$key == key)
+        let domainFilter: Where<AnyStoredData> = Where(\.$domain == domain)
+
         let clause = From<AnyStoredData>()
-            .where(\.$ownerID == ownerID && \.$key == key && \.$domain == domain)
+            .where(ownerFilter && keyFilter && domainFilter)
 
         let values = try SwiftfinStore.dataStack
             .fetchAll(
@@ -78,8 +82,12 @@ extension AnyStoredData {
 
         let domain = domain ?? "none"
 
+        let ownerFilter: Where<AnyStoredData> = Where(\.$ownerID == ownerID)
+        let keyFilter: Where<AnyStoredData> = Where(\.$key == key)
+        let domainFilter: Where<AnyStoredData> = Where(\.$domain == domain)
+
         let clause = From<AnyStoredData>()
-            .where(\.$ownerID == ownerID && \.$key == key && \.$domain == domain)
+            .where(ownerFilter && keyFilter && domainFilter)
 
         try SwiftfinStore.dataStack.perform { transaction in
             let existing = try transaction.fetchAll(clause)
@@ -124,8 +132,12 @@ extension AnyStoredData {
     static func fetchClause(key: String, ownerID: String, domain: String? = nil) throws -> FetchChainBuilder<AnyStoredData> {
         let domain = domain ?? "none"
 
+        let ownerFilter: Where<AnyStoredData> = Where(\.$ownerID == ownerID)
+        let keyFilter: Where<AnyStoredData> = Where(\.$key == key)
+        let domainFilter: Where<AnyStoredData> = Where(\.$domain == domain)
+
         return From<AnyStoredData>()
-            .where(\.$ownerID == ownerID && \.$key == key && \.$domain == domain)
+            .where(ownerFilter && keyFilter && domainFilter)
     }
 
     /// Delete all data with the given `ownerID`


### PR DESCRIPTION
The use of keypaths in the where clauses were causing type check warnings due to being in excess of 200ms after the compiler flag I turned on. Prior to these changes the type checking took roughly 2000-3000ms but with these changes the warnings are resolved, meaning it now takes <200ms.