### PR TITLE
[iOS] Admin Dashboard - Hide Collections from Deletion Menu

### DIFF
--- a/Swiftfin/Views/AdminDashboardView/ServerUserAccessView/ServerUserAccessView.swift
+++ b/Swiftfin/Views/AdminDashboardView/ServerUserAccessView/ServerUserAccessView.swift
@@ -132,7 +132,10 @@ struct ServerUserAccessView: View {
 
         if tempPolicy.enableContentDeletion == false {
             Section {
-                ForEach(viewModel.libraries, id: \.id) { library in
+                ForEach(
+                    viewModel.libraries.filter { $0.collectionType != "boxsets" },
+                    id: \.id
+                ) { library in
                     Toggle(
                         library.displayTitle,
                         isOn: $tempPolicy.enableContentDeletionFromFolders


### PR DESCRIPTION
### Summary

This is going to look a little different than web but I have an issue opened for this: https://github.com/jellyfin/jellyfin-web/issues/6361. The issue is that Collections should be included in the Allow Access section, where it works in allowing or restricting access from Collections. For deletion, Collection Deletion is only accessible to Administrators. Adding / removing this from the 'Allow deletion from...' section doesn't impact anything. It doesn't allow Collection deletion for non-admins and it doesn't restrict Collection deletion from admins.

This PR just removes this confusing interaction while leaving Collection in the access section since that works correctly:

<details>
  <summary>Screenshot</summary>
  <img src="https://github.com/user-attachments/assets/643a6ede-d702-4ef1-865b-51fb562b89ae" alt="Simulator Screenshot - iPhone 16 Pro">
</details>