### PR TITLE
Fix optional ID case for libraries

### DIFF
--- a/Shared/Extensions/JellyfinAPI/BaseItemDto/BaseItemDto.swift
+++ b/Shared/Extensions/JellyfinAPI/BaseItemDto/BaseItemDto.swift
@@ -27,6 +27,13 @@ extension BaseItemDto: LibraryParent {
     }
 }
 
+extension BaseItemDto: LibraryIdentifiable {
+
+    var unwrappedIDHashOrZero: Int {
+        id?.hashValue ?? 0
+    }
+}
+
 extension BaseItemDto {
 
     var episodeLocator: String? {

--- a/Shared/Extensions/JellyfinAPI/BaseItemPerson/BaseItemPerson+Poster.swift
+++ b/Shared/Extensions/JellyfinAPI/BaseItemPerson/BaseItemPerson+Poster.swift
@@ -13,6 +13,10 @@ import UIKit
 
 extension BaseItemPerson: Poster {
 
+    var unwrappedIDHashOrZero: Int {
+        id?.hashValue ?? 0
+    }
+
     var subtitle: String? {
         firstRole
     }

--- a/Shared/Extensions/JellyfinAPI/ChapterInfo.swift
+++ b/Shared/Extensions/JellyfinAPI/ChapterInfo.swift
@@ -45,6 +45,10 @@ extension ChapterInfo {
             chapterInfo.displayTitle
         }
 
+        var unwrappedIDHashOrZero: Int {
+            id
+        }
+
         let systemImage: String = "film"
         var subtitle: String?
         var showTitle: Bool = true

--- a/Shared/Objects/ChannelProgram.swift
+++ b/Shared/Objects/ChannelProgram.swift
@@ -42,6 +42,10 @@ struct ChannelProgram: Hashable, Identifiable {
 
 extension ChannelProgram: Poster {
 
+    var unwrappedIDHashOrZero: Int {
+        channel.id?.hashValue ?? 0
+    }
+
     var displayTitle: String {
         channel.displayTitle
     }

--- a/Shared/Objects/Poster.swift
+++ b/Shared/Objects/Poster.swift
@@ -9,7 +9,7 @@
 import Foundation
 
 /// A type that is displayed as a poster
-protocol Poster: Displayable, Hashable, Identifiable, SystemImageable {
+protocol Poster: Displayable, Hashable, LibraryIdentifiable, SystemImageable {
 
     /// Optional subtitle when used as a poster
     var subtitle: String? { get }

--- a/Swiftfin/Views/PagingLibraryView/PagingLibraryView.swift
+++ b/Swiftfin/Views/PagingLibraryView/PagingLibraryView.swift
@@ -36,7 +36,7 @@ import SwiftUI
        should be applied.
  */
 
-struct PagingLibraryView<Element: Poster & Identifiable>: View {
+struct PagingLibraryView<Element: Poster>: View {
 
     @Default(.Customization.Library.enabledDrawerFilters)
     private var enabledDrawerFilters
@@ -240,6 +240,7 @@ struct PagingLibraryView<Element: Poster & Identifiable>: View {
     private var gridView: some View {
         CollectionVGrid(
             uniqueElements: viewModel.elements,
+            id: \.unwrappedIDHashOrZero,
             layout: layout
         ) { item in
 


### PR DESCRIPTION
I noticed that items weren't being deleted from libraries. I tracked this down due to the following behavior:

```swift
let fooA = "Foo".hashValue // String.hashValue
let fooB = Optional("Foo").hashValue // Optional.hashValue
let fooC = Optional("Foo")?.hashValue

print(fooA)
print(fooB)
print(fooC)

// 7631599267132626175
// -2986088522783645984
// Optional(7631599267132626175) 
```

Many of the objects like `BaseItemDto` have `id: String?`, which would mean that when we receive the item ID `String` it will be comparing something like `fooA == fooB` from above, which will never be true. I have had to make a new protocol for items that may be in libraries and must return the intended `.hashValue` target or 0 otherwise. When using `Optional`, this would be `Wrapped.hashValue`. I don't see us running into an issue with the 0 case, but something to be mindful of.

This would be better fixed if there were parameterized generics so I could extend `Identifiable` or provide the default implementation. Or, I could've compared `Optional(id).hashValue` if the first failed, but I would rather be statically safe than try to remember typing issues.