### PR TITLE
Fix possible duplicate ids

### DIFF
--- a/Shared/ViewModels/LibraryViewModel/PagingLibraryViewModel.swift
+++ b/Shared/ViewModels/LibraryViewModel/PagingLibraryViewModel.swift
@@ -57,7 +57,7 @@ protocol LibraryIdentifiable: Identifiable {
        on remembering other filters.
  */
 
-class PagingLibraryViewModel<Element: Poster & LibraryIdentifiable>: ViewModel, Eventful, Stateful {
+class PagingLibraryViewModel<Element: Poster>: ViewModel, Eventful, Stateful {
 
     // MARK: Event
 
@@ -129,7 +129,7 @@ class PagingLibraryViewModel<Element: Poster & LibraryIdentifiable>: ViewModel, 
         parent: (any LibraryParent)? = nil
     ) {
         self.filterViewModel = nil
-        self.elements = IdentifiedArray(uniqueElements: data, id: \.unwrappedIDHashOrZero)
+        self.elements = IdentifiedArray(data, id: \.unwrappedIDHashOrZero, uniquingIDsWith: { x, _ in x })
         self.isStatic = true
         self.hasNextPage = false
         self.pageSize = DefaultPageSize
@@ -166,7 +166,7 @@ class PagingLibraryViewModel<Element: Poster & LibraryIdentifiable>: ViewModel, 
         filters: ItemFilterCollection? = nil,
         pageSize: Int = DefaultPageSize
     ) {
-        self.elements = IdentifiedArray(id: \.unwrappedIDHashOrZero)
+        self.elements = IdentifiedArray([], id: \.unwrappedIDHashOrZero, uniquingIDsWith: { x, _ in x })
         self.isStatic = false
         self.pageSize = pageSize
         self.parent = parent


### PR DESCRIPTION
Since we don't check the uniqueness of ids with `uniqueElements` we need to at least employ the uniqueness consolidation in `IdentifiedArray`. Just keep the first item in the event of collisions.