### PR TITLE
[iOS] Select all Users When Editing

### DIFF
--- a/Shared/Extensions/Set.swift
+++ b/Shared/Extensions/Set.swift
@@ -17,4 +17,10 @@ extension Set {
             insert(value)
         }
     }
+
+    mutating func insert(contentsOf elements: [Element]) {
+        for element in elements {
+            insert(element)
+        }
+    }
 }

--- a/Swiftfin/Views/SelectUserView/SelectUserView.swift
+++ b/Swiftfin/Views/SelectUserView/SelectUserView.swift
@@ -20,6 +20,9 @@ import SwiftUI
 // TODO: user ordering
 //       - name
 //       - last signed in date
+// TODO: between the server selection menu and delete toolbar,
+//       figure out a way to make the grid/list and splash screen
+//       not jump when size is changed
 
 struct SelectUserView: View {
 
@@ -84,6 +87,17 @@ struct SelectUserView: View {
 
     @State
     private var error: Error? = nil
+
+    private var users: [UserState] {
+        gridItems.compactMap { item in
+            switch item {
+            case let .user(user, _):
+                return user
+            default:
+                return nil
+            }
+        }
+    }
 
     // MARK: - Select Server
 
@@ -514,20 +528,21 @@ struct SelectUserView: View {
 
             ToolbarItem(placement: .topBarLeading) {
                 if isEditingUsers {
-                    Button(L10n.selectAll) {
-                        for gridItem in gridItems {
-                            switch gridItem {
-                            case let .user(user, server: _):
-                                selectedUsers.insert(user)
-                            default:
-                                break
-                            }
+                    if selectedUsers.count == users.count {
+                        Button(L10n.removeAll) {
+                            selectedUsers.removeAll()
                         }
+                        .buttonStyle(.toolbarPill)
+                    } else {
+                        Button(L10n.selectAll) {
+                            selectedUsers.insert(contentsOf: users)
+                        }
+                        .buttonStyle(.toolbarPill)
                     }
-                    .buttonStyle(.toolbarPill)
                 }
             }
-            ToolbarItem(placement: .topBarTrailing) {
+
+            ToolbarItemGroup(placement: .topBarTrailing) {
                 if isEditingUsers {
                     Button(isEditingUsers ? L10n.cancel : L10n.edit) {
                         isEditingUsers.toggle()
@@ -539,8 +554,11 @@ struct SelectUserView: View {
                         }
                     }
                     .buttonStyle(.toolbarPill)
+                } else {
+                    advancedMenu
                 }
             }
+
             ToolbarItem(placement: .bottomBar) {
                 if isEditingUsers {
                     Button(L10n.delete) {
@@ -550,11 +568,6 @@ struct SelectUserView: View {
                     .disabled(selectedUsers.isEmpty)
                     .frame(maxWidth: .infinity, alignment: .trailing)
                 }
-            }
-        }
-        .topBarTrailing {
-            if !isEditingUsers {
-                advancedMenu
             }
         }
         .onAppear {

--- a/Swiftfin/Views/SelectUserView/SelectUserView.swift
+++ b/Swiftfin/Views/SelectUserView/SelectUserView.swift
@@ -453,25 +453,6 @@ struct SelectUserView: View {
                 )
                 .edgePadding([.bottom, .horizontal])
             }
-
-            if isEditingUsers {
-                VStack {
-                    PrimaryButton(title: L10n.selectAll).onSelect {
-                        for gridItem in gridItems {
-                            switch gridItem {
-                            case let .user(user, server: server):
-                                selectedUsers.insert(user)
-                            default:
-                                break
-                            }
-                        }
-                    }
-                    .edgePadding([.bottom, .horizontal])
-
-                    deleteUsersButton
-                        .edgePadding([.bottom, .horizontal])
-                }
-            }
         }
         .background {
             if selectUserUseSplashscreen, splashScreenImageSources.isNotEmpty {
@@ -530,27 +511,49 @@ struct SelectUserView: View {
                     .aspectRatio(contentMode: .fit)
                     .frame(width: 30)
             }
-        }
-        .topBarTrailing {
-            if isEditingUsers {
-                Button {
-                    isEditingUsers = false
-                } label: {
-                    L10n.cancel.text
-                        .font(.headline)
-                        .padding(.vertical, 5)
-                        .padding(.horizontal, 10)
-                        .background {
-                            if colorScheme == .light {
-                                Color.secondarySystemFill
-                            } else {
-                                Color.tertiarySystemBackground
+
+            ToolbarItem(placement: .topBarLeading) {
+                if isEditingUsers {
+                    Button(L10n.selectAll) {
+                        for gridItem in gridItems {
+                            switch gridItem {
+                            case let .user(user, server: _):
+                                selectedUsers.insert(user)
+                            default:
+                                break
                             }
                         }
-                        .clipShape(RoundedRectangle(cornerRadius: 10))
+                    }
+                    .buttonStyle(.toolbarPill)
                 }
-                .buttonStyle(.plain)
-            } else {
+            }
+            ToolbarItem(placement: .topBarTrailing) {
+                if isEditingUsers {
+                    Button(isEditingUsers ? L10n.cancel : L10n.edit) {
+                        isEditingUsers.toggle()
+
+                        UIDevice.impact(.light)
+
+                        if !isEditingUsers {
+                            selectedUsers.removeAll()
+                        }
+                    }
+                    .buttonStyle(.toolbarPill)
+                }
+            }
+            ToolbarItem(placement: .bottomBar) {
+                if isEditingUsers {
+                    Button(L10n.delete) {
+                        isPresentingConfirmDeleteUsers = true
+                    }
+                    .buttonStyle(.toolbarPill(.red))
+                    .disabled(selectedUsers.isEmpty)
+                    .frame(maxWidth: .infinity, alignment: .trailing)
+                }
+            }
+        }
+        .topBarTrailing {
+            if !isEditingUsers {
                 advancedMenu
             }
         }

--- a/Swiftfin/Views/SelectUserView/SelectUserView.swift
+++ b/Swiftfin/Views/SelectUserView/SelectUserView.swift
@@ -455,8 +455,22 @@ struct SelectUserView: View {
             }
 
             if isEditingUsers {
-                deleteUsersButton
+                VStack {
+                    PrimaryButton(title: L10n.selectAll).onSelect {
+                        for gridItem in gridItems {
+                            switch gridItem {
+                            case let .user(user, server: server):
+                                selectedUsers.insert(user)
+                            default:
+                                break
+                            }
+                        }
+                    }
                     .edgePadding([.bottom, .horizontal])
+
+                    deleteUsersButton
+                        .edgePadding([.bottom, .horizontal])
+                }
             }
         }
         .background {

--- a/Swiftfin/Views/SelectUserView/SelectUserView.swift
+++ b/Swiftfin/Views/SelectUserView/SelectUserView.swift
@@ -394,33 +394,6 @@ struct SelectUserView: View {
         }
     }
 
-    // MARK: - Delete Users Button
-
-    @ViewBuilder
-    private var deleteUsersButton: some View {
-        Button {
-            isPresentingConfirmDeleteUsers = true
-        } label: {
-            ZStack {
-                Color.red
-
-                Text(L10n.delete)
-                    .font(.body.weight(.semibold))
-                    .foregroundStyle(selectedUsers.isNotEmpty ? .primary : .secondary)
-
-                if selectedUsers.isEmpty {
-                    Color.black
-                        .opacity(0.5)
-                }
-            }
-            .clipShape(RoundedRectangle(cornerRadius: 10))
-            .frame(height: 50)
-            .frame(maxWidth: 400)
-        }
-        .disabled(selectedUsers.isEmpty)
-        .buttonStyle(.plain)
-    }
-
     // MARK: - User View
 
     @ViewBuilder


### PR DESCRIPTION
Simple change, adds a button when editing users to select all users for faster management and moves the buttons to the toolbars.

<img src="https://github.com/user-attachments/assets/adcab4b5-7ed5-4e5b-b12d-a915d2907810" width=40%>
