### PR TITLE
[WIP] tvOS - Episode Item View Backdrop Substitute

### DIFF
--- a/Shared/Extensions/JellyfinAPI/BaseItemDto/BaseItemDto+Poster.swift
+++ b/Shared/Extensions/JellyfinAPI/BaseItemDto/BaseItemDto+Poster.swift
@@ -20,7 +20,12 @@ extension BaseItemDto: Poster {
         case .episode:
             seasonEpisodeLabel
         case .video:
-            extraType?.displayTitle
+            /// Don't show any subtitle if it's unknown
+            if let extraType, extraType != .unknown {
+                extraType.displayTitle
+            } else {
+                nil
+            }
         default:
             nil
         }

--- a/Swiftfin tvOS/Views/ItemView/EpisodeItemView/EpisodeItemContentView.swift
+++ b/Swiftfin tvOS/Views/ItemView/EpisodeItemView/EpisodeItemContentView.swift
@@ -89,60 +89,82 @@ extension EpisodeItemView.ContentView {
                     .focusable()
                     .focused($focusedLayer, equals: .top)
 
-                HStack(alignment: .bottom) {
+                VStack(alignment: .leading, spacing: 16) {
 
-                    VStack(alignment: .leading, spacing: 20) {
-
-                        if let seriesName = viewModel.item.seriesName {
-                            Text(seriesName)
-                                .font(.headline)
-                                .fontWeight(.semibold)
-                                .foregroundColor(.secondary)
-                        }
-
-                        Text(viewModel.item.displayTitle)
-                            .font(.title2)
+                    if let seriesName = viewModel.item.seriesName {
+                        Text(seriesName)
+                            .font(.headline)
                             .fontWeight(.semibold)
-                            .lineLimit(1)
-                            .multilineTextAlignment(.leading)
-                            .foregroundColor(.white)
+                            .foregroundColor(.secondary)
+                    }
 
-                        if let overview = viewModel.item.overview {
-                            Text(overview)
-                                .font(.subheadline)
-                                .lineLimit(3)
-                        } else {
-                            L10n.noOverviewAvailable.text
-                        }
+                    HStack(alignment: .bottom) {
 
-                        HStack {
-                            DotHStack {
-                                if let premiereYear = viewModel.item.premiereDateYear {
-                                    Text(premiereYear)
+                        HStack(alignment: .bottom, spacing: 16) {
+
+                            ImageView(viewModel.item.imageSource(
+                                .primary,
+                                maxHeight: 250
+                            ))
+                            .placeholder { _ in
+                                EmptyView()
+                            }
+                            .failure {
+                                EmptyView()
+                            }
+                            .aspectRatio(contentMode: .fit)
+                            .posterShadow()
+                            .frame(maxHeight: 250, alignment: .bottomLeading)
+                            .clipShape(RoundedRectangle(cornerRadius: 10, style: .continuous))
+
+                            VStack(alignment: .leading, spacing: 20) {
+
+                                Text(viewModel.item.displayTitle)
+                                    .font(.title2)
+                                    .fontWeight(.semibold)
+                                    .lineLimit(1)
+                                    .multilineTextAlignment(.leading)
+                                    .foregroundColor(.white)
+
+                                if let overview = viewModel.item.overview {
+                                    Text(overview)
+                                        .font(.subheadline)
+                                        .multilineTextAlignment(.leading)
+                                        .lineLimit(3)
+                                } else {
+                                    L10n.noOverviewAvailable.text
                                 }
 
-                                if let playButtonitem = viewModel.playButtonItem, let runtime = playButtonitem.runTimeLabel {
-                                    Text(runtime)
+                                HStack {
+                                    DotHStack {
+                                        if let premiereYear = viewModel.item.premiereDateYear {
+                                            Text(premiereYear)
+                                        }
+
+                                        if let playButtonitem = viewModel.playButtonItem, let runtime = playButtonitem.runTimeLabel {
+                                            Text(runtime)
+                                        }
+                                    }
+                                    .font(.caption)
+                                    .foregroundColor(Color(UIColor.lightGray))
+
+                                    ItemView.AttributesHStack(viewModel: viewModel)
                                 }
                             }
-                            .font(.caption)
-                            .foregroundColor(Color(UIColor.lightGray))
-
-                            ItemView.AttributesHStack(viewModel: viewModel)
                         }
+
+                        Spacer()
+
+                        VStack {
+                            ItemView.PlayButton(viewModel: viewModel)
+                                .focused($focusedLayer, equals: .playButton)
+
+                            ItemView.ActionButtonHStack(viewModel: viewModel)
+                                .frame(width: 400)
+                        }
+                        .frame(width: 450)
+                        .padding(.leading, 150)
                     }
-
-                    Spacer()
-
-                    VStack {
-                        ItemView.PlayButton(viewModel: viewModel)
-                            .focused($focusedLayer, equals: .playButton)
-
-                        ItemView.ActionButtonHStack(viewModel: viewModel)
-                            .frame(width: 400)
-                    }
-                    .frame(width: 450)
-                    .padding(.leading, 150)
                 }
             }
             .padding(.horizontal, 50)

--- a/Swiftfin tvOS/Views/ItemView/ScrollViews/CinematicScrollView.swift
+++ b/Swiftfin tvOS/Views/ItemView/ScrollViews/CinematicScrollView.swift
@@ -21,7 +21,7 @@ extension ItemView {
         var body: some View {
             ZStack {
                 if viewModel.item.type == .episode {
-                    ImageView(viewModel.item.imageSource(.primary, maxWidth: 1920))
+                    ImageView(viewModel.item.seriesImageSource(.backdrop, maxWidth: 1920))
                 } else {
                     ImageView(viewModel.item.imageSource(.backdrop, maxWidth: 1920))
                 }


### PR DESCRIPTION
### Summary

The issue I am experiencing is that Episode images tend to be lower quality than other images in Jellyfin. As a result, episode views get blown out when used as the backdrop:

![Simulator Screenshot - Apple TV 4K (3rd generation) - 2025-01-08 at 12 03 31](https://github.com/user-attachments/assets/2fe7ff92-27a1-4dc6-b54c-656df5afbff6)

My WIP solution is to use the Series Backdrop for Episodes but also include the Episode Primary image in a more standard size for it's resolution. Below is my current version of this. I don't love it since I feel like it cramps the description/title. I'd love some feedback on ideas for how we'd want this to look!

![Simulator Screenshot - Apple TV 4K (3rd generation) - 2025-01-08 at 16 56 29](https://github.com/user-attachments/assets/a5d3fc1b-1930-4abe-b66f-877dac7f1885)

<details>
<summary> Other Attempts </summary>

![Simulator Screenshot - Apple TV 4K (3rd generation) - 2025-01-08 at 11 43 57](https://github.com/user-attachments/assets/66e86a9b-5dbf-46a1-90fb-c4a19fd2cf12)

![Simulator Screenshot - Apple TV 4K (3rd generation) - 2025-01-08 at 12 48 29](https://github.com/user-attachments/assets/e44dff52-59dc-487d-9f11-a38a1a5a6017)

</details>