### PR TITLE
Refresh Server Info

### DIFF
--- a/Shared/SwiftfinStore/SwiftfinStore+ServerState.swift
+++ b/Shared/SwiftfinStore/SwiftfinStore+ServerState.swift
@@ -78,4 +78,21 @@ extension ServerState {
         let request = Paths.getSplashscreen()
         return ImageSource(url: client.fullURL(with: request))
     }
+
+    func updateServerInfo() async throws {
+        guard let server = try? SwiftfinStore.dataStack.fetchOne(
+            From<ServerModel>()
+        ) else { return }
+
+        let publicInfo = try await getPublicSystemInfo()
+
+        try SwiftfinStore.dataStack.perform { transaction in
+            guard let newServer = transaction.edit(server) else { return }
+
+            newServer.name = publicInfo.serverName ?? newServer.name
+            newServer.id = publicInfo.id ?? newServer.id
+        }
+
+        StoredValues[.Server.publicInfo(id: server.id)] = publicInfo
+    }
 }

--- a/Shared/ViewModels/ServerCheckViewModel.swift
+++ b/Shared/ViewModels/ServerCheckViewModel.swift
@@ -36,6 +36,8 @@ class ServerCheckViewModel: ViewModel, Stateful {
             // TODO: also server stuff
             connectCancellable = Task {
                 do {
+                    try await userSession.server.updateServerInfo()
+
                     let request = Paths.getCurrentUser
                     let response = try await userSession.client.send(request)
 

--- a/Shared/ViewModels/ServerCheckViewModel.swift
+++ b/Shared/ViewModels/ServerCheckViewModel.swift
@@ -7,6 +7,7 @@
 //
 
 import Combine
+import Factory
 import Foundation
 import JellyfinAPI
 
@@ -44,6 +45,7 @@ class ServerCheckViewModel: ViewModel, Stateful {
                     await MainActor.run {
                         userSession.user.data = response.value
                         self.state = .connected
+                        Container.shared.currentUserSession.reset()
                     }
                 } catch {
                     await MainActor.run {


### PR DESCRIPTION
Working to resolve #1389, looking through where server information is set this is the partial solution I came up with. It's not ideal as the user won't see the name change until after relaunching the app so pointers on where to put this would be appreciated!

There is also a `TODO` in ServerCheckViewModel that says "Also server stuff", what needs to be done to resolve the todo? I can fill it out since I'm already touching that file.