### PR TITLE
[iPadOS] Fixes #1368 Shrunken posters on iPad home screen

### DIFF
--- a/Swiftfin/Components/PosterHStack.swift
+++ b/Swiftfin/Components/PosterHStack.swift
@@ -26,7 +26,7 @@ struct PosterHStack<Element: Poster & Identifiable, Data: Collection>: View wher
     private var padHStack: some View {
         CollectionHStack(
             uniqueElements: data,
-            columns: type == .portrait ? 140 : 220
+            minWidth: type == .portrait ? 140 : 220
         ) { item in
             PosterButton(
                 item: item,


### PR DESCRIPTION
It looks like the iPad code got switched to use the wrong initializer. This commit reverts a change from commit `e856303`