### PR TITLE
[Bug] [iOS] Item Editor Photo Upload - Coordinator Doesn't Dismiss

### DIFF
--- a/Shared/ViewModels/ItemAdministration/ItemImagesViewModel.swift
+++ b/Shared/ViewModels/ItemAdministration/ItemImagesViewModel.swift
@@ -149,6 +149,10 @@ class ItemImagesViewModel: ViewModel, Stateful, Eventful {
 
                     try await self.uploadPhoto(image, type: type)
                     try await self.getAllImages()
+
+                    await MainActor.run {
+                        self.eventSubject.send(.updated)
+                    }
                 } catch {
                     let apiError = JellyfinAPIError(error.localizedDescription)
                     await MainActor.run {


### PR DESCRIPTION
### Summary

On the TestFlight, I noticed that the Photo Crop View doesn't dismiss after a photo is selected. Just a missing even for that specific image edit.