### PR TITLE
[Meta] Video Player Documentation - Move AV1 from Video to Container Section

### DIFF
--- a/Documentation/players.md
+++ b/Documentation/players.md
@@ -93,7 +93,7 @@ Swiftfin offers two player options: Swiftfin (VLCKit) and Native (AVKit). The Sw
 | **VP8**     | ✅                | ❌             |
 | **VP9**     | ✅                | ❌             |
 
-- AV1 is disabled by default but can be enabled for Native (AVKit) using Custom Device Profiles. Enabling AV1 may result in a [poor experience for non-A17 SOCs and higher](https://en.wikipedia.org/wiki/Apple_A17).
+- AV1 is disabled by default but can be enabled for Native (AVKit) using Custom Device Profiles. Enabling AV1 may result in a [poor experience for SOCs prior to A17](https://en.wikipedia.org/wiki/Apple_A17).
 
 ---
 

--- a/Documentation/players.md
+++ b/Documentation/players.md
@@ -46,7 +46,6 @@ Swiftfin offers two player options: Swiftfin (VLCKit) and Native (AVKit). The Sw
 **Notes**
 
 - Unsupported containers will require transcoding or remuxing to play.
-- AV1 is disabled by default but can be enabled for Native (AVKit) using Custom Device Profiles.
 
 ---
 
@@ -86,13 +85,15 @@ Swiftfin offers two player options: Swiftfin (VLCKit) and Native (AVKit). The Sw
 
 | Video Codec | Swiftfin (VLCKit) | Native (AVKit) |
 |-------------|-------------------|----------------|
-| **AV1**     | ✅                | ❌             |
+| **AV1**     | ✅                | 🟡 Limited support |
 | **H.264**   | ✅                | ✅             |
 | **H.265**   | ✅                | ✅             |
 | **MPEG-2**  | ✅                | ❌             |
 | **MPEG-4**  | ✅                | ✅             |
 | **VP8**     | ✅                | ❌             |
 | **VP9**     | ✅                | ❌             |
+
+- AV1 is disabled by default but can be enabled for Native (AVKit) using Custom Device Profiles. Enabling AV1 may result in a [poor experience for non-A17 SOCs and higher](https://en.wikipedia.org/wiki/Apple_A17).
 
 ---
 


### PR DESCRIPTION
This should be under containers not video. Confusing since AV**i** vs AV**1**. Added a note for the Apple SOC that first added HWA AV1 decoding as this should correspond with AVKit's ability to use it.

Pre-AV1 Decoders, I tested, and AV1 works but is VERY choppy so defaulting this to disabled is still the right move!

Resolves: https://github.com/jellyfin/Swiftfin/issues/1415