### PR TITLE
Add existing localizations to Xcode project

### DIFF
--- a/Swiftfin.xcodeproj/project.pbxproj
+++ b/Swiftfin.xcodeproj/project.pbxproj
@@ -313,6 +313,64 @@
 		53ABFDEB2679753200886593 /* ConnectToServerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 53ABFDEA2679753200886593 /* ConnectToServerView.swift */; };
 		53CD2A40268A49C2002ABD4E /* ItemView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 53CD2A3F268A49C2002ABD4E /* ItemView.swift */; };
 		53EE24E6265060780068F029 /* SearchView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 53EE24E5265060780068F029 /* SearchView.swift */; };
+		5E5236C82D4C1C2400D80C2C /* Localizable.strings in Resources */ = {isa = PBXBuildFile; fileRef = 5E5236842D4C1C2400D80C2C /* Localizable.strings */; };
+		5E5236C92D4C1C2400D80C2C /* Localizable.strings in Resources */ = {isa = PBXBuildFile; fileRef = 5E52368D2D4C1C2400D80C2C /* Localizable.strings */; };
+		5E5236CA2D4C1C2400D80C2C /* Localizable.strings in Resources */ = {isa = PBXBuildFile; fileRef = 5E5236B72D4C1C2400D80C2C /* Localizable.strings */; };
+		5E5236CB2D4C1C2400D80C2C /* Localizable.strings in Resources */ = {isa = PBXBuildFile; fileRef = 5E5236BA2D4C1C2400D80C2C /* Localizable.strings */; };
+		5E5236CC2D4C1C2400D80C2C /* Localizable.strings in Resources */ = {isa = PBXBuildFile; fileRef = 5E5236A52D4C1C2400D80C2C /* Localizable.strings */; };
+		5E5236CD2D4C1C2400D80C2C /* Localizable.strings in Resources */ = {isa = PBXBuildFile; fileRef = 5E52369F2D4C1C2400D80C2C /* Localizable.strings */; };
+		5E5236CE2D4C1C2400D80C2C /* Localizable.strings in Resources */ = {isa = PBXBuildFile; fileRef = 5E5236BD2D4C1C2400D80C2C /* Localizable.strings */; };
+		5E5236CF2D4C1C2400D80C2C /* Localizable.strings in Resources */ = {isa = PBXBuildFile; fileRef = 5E5236C62D4C1C2400D80C2C /* Localizable.strings */; };
+		5E5236D02D4C1C2400D80C2C /* Localizable.strings in Resources */ = {isa = PBXBuildFile; fileRef = 5E5236A22D4C1C2400D80C2C /* Localizable.strings */; };
+		5E5236D12D4C1C2400D80C2C /* Localizable.strings in Resources */ = {isa = PBXBuildFile; fileRef = 5E5236812D4C1C2400D80C2C /* Localizable.strings */; };
+		5E5236D22D4C1C2400D80C2C /* Localizable.strings in Resources */ = {isa = PBXBuildFile; fileRef = 5E5236A82D4C1C2400D80C2C /* Localizable.strings */; };
+		5E5236D32D4C1C2400D80C2C /* Localizable.strings in Resources */ = {isa = PBXBuildFile; fileRef = 5E5236B12D4C1C2400D80C2C /* Localizable.strings */; };
+		5E5236D42D4C1C2400D80C2C /* Localizable.strings in Resources */ = {isa = PBXBuildFile; fileRef = 5E5236B42D4C1C2400D80C2C /* Localizable.strings */; };
+		5E5236D52D4C1C2400D80C2C /* Localizable.strings in Resources */ = {isa = PBXBuildFile; fileRef = 5E5236962D4C1C2400D80C2C /* Localizable.strings */; };
+		5E5236D62D4C1C2400D80C2C /* Localizable.strings in Resources */ = {isa = PBXBuildFile; fileRef = 5E5236992D4C1C2400D80C2C /* Localizable.strings */; };
+		5E5236D72D4C1C2400D80C2C /* Localizable.strings in Resources */ = {isa = PBXBuildFile; fileRef = 5E5236782D4C1C2400D80C2C /* Localizable.strings */; };
+		5E5236D82D4C1C2400D80C2C /* Localizable.strings in Resources */ = {isa = PBXBuildFile; fileRef = 5E52367B2D4C1C2400D80C2C /* Localizable.strings */; };
+		5E5236D92D4C1C2400D80C2C /* Localizable.strings in Resources */ = {isa = PBXBuildFile; fileRef = 5E52369C2D4C1C2400D80C2C /* Localizable.strings */; };
+		5E5236DA2D4C1C2400D80C2C /* Localizable.strings in Resources */ = {isa = PBXBuildFile; fileRef = 5E5236932D4C1C2400D80C2C /* Localizable.strings */; };
+		5E5236DB2D4C1C2400D80C2C /* Localizable.strings in Resources */ = {isa = PBXBuildFile; fileRef = 5E5236C32D4C1C2400D80C2C /* Localizable.strings */; };
+		5E5236DC2D4C1C2400D80C2C /* Localizable.strings in Resources */ = {isa = PBXBuildFile; fileRef = 5E5236872D4C1C2400D80C2C /* Localizable.strings */; };
+		5E5236DD2D4C1C2400D80C2C /* Localizable.strings in Resources */ = {isa = PBXBuildFile; fileRef = 5E5236752D4C1C2400D80C2C /* Localizable.strings */; };
+		5E5236DE2D4C1C2400D80C2C /* Localizable.strings in Resources */ = {isa = PBXBuildFile; fileRef = 5E5236722D4C1C2400D80C2C /* Localizable.strings */; };
+		5E5236DF2D4C1C2400D80C2C /* Localizable.strings in Resources */ = {isa = PBXBuildFile; fileRef = 5E52368A2D4C1C2400D80C2C /* Localizable.strings */; };
+		5E5236E02D4C1C2400D80C2C /* Localizable.strings in Resources */ = {isa = PBXBuildFile; fileRef = 5E5236C02D4C1C2400D80C2C /* Localizable.strings */; };
+		5E5236E12D4C1C2400D80C2C /* Localizable.strings in Resources */ = {isa = PBXBuildFile; fileRef = 5E5236AB2D4C1C2400D80C2C /* Localizable.strings */; };
+		5E5236E22D4C1C2400D80C2C /* Localizable.strings in Resources */ = {isa = PBXBuildFile; fileRef = 5E52367E2D4C1C2400D80C2C /* Localizable.strings */; };
+		5E5236E32D4C1C2400D80C2C /* Localizable.strings in Resources */ = {isa = PBXBuildFile; fileRef = 5E5236902D4C1C2400D80C2C /* Localizable.strings */; };
+		5E5236E42D4C1C2400D80C2C /* Localizable.strings in Resources */ = {isa = PBXBuildFile; fileRef = 5E5236AE2D4C1C2400D80C2C /* Localizable.strings */; };
+		5E5236E52D4C1C2400D80C2C /* Localizable.strings in Resources */ = {isa = PBXBuildFile; fileRef = 5E5236842D4C1C2400D80C2C /* Localizable.strings */; };
+		5E5236E62D4C1C2400D80C2C /* Localizable.strings in Resources */ = {isa = PBXBuildFile; fileRef = 5E52368D2D4C1C2400D80C2C /* Localizable.strings */; };
+		5E5236E72D4C1C2400D80C2C /* Localizable.strings in Resources */ = {isa = PBXBuildFile; fileRef = 5E5236B72D4C1C2400D80C2C /* Localizable.strings */; };
+		5E5236E82D4C1C2400D80C2C /* Localizable.strings in Resources */ = {isa = PBXBuildFile; fileRef = 5E5236BA2D4C1C2400D80C2C /* Localizable.strings */; };
+		5E5236E92D4C1C2400D80C2C /* Localizable.strings in Resources */ = {isa = PBXBuildFile; fileRef = 5E5236A52D4C1C2400D80C2C /* Localizable.strings */; };
+		5E5236EA2D4C1C2400D80C2C /* Localizable.strings in Resources */ = {isa = PBXBuildFile; fileRef = 5E52369F2D4C1C2400D80C2C /* Localizable.strings */; };
+		5E5236EB2D4C1C2400D80C2C /* Localizable.strings in Resources */ = {isa = PBXBuildFile; fileRef = 5E5236BD2D4C1C2400D80C2C /* Localizable.strings */; };
+		5E5236EC2D4C1C2400D80C2C /* Localizable.strings in Resources */ = {isa = PBXBuildFile; fileRef = 5E5236C62D4C1C2400D80C2C /* Localizable.strings */; };
+		5E5236ED2D4C1C2400D80C2C /* Localizable.strings in Resources */ = {isa = PBXBuildFile; fileRef = 5E5236A22D4C1C2400D80C2C /* Localizable.strings */; };
+		5E5236EE2D4C1C2400D80C2C /* Localizable.strings in Resources */ = {isa = PBXBuildFile; fileRef = 5E5236812D4C1C2400D80C2C /* Localizable.strings */; };
+		5E5236EF2D4C1C2400D80C2C /* Localizable.strings in Resources */ = {isa = PBXBuildFile; fileRef = 5E5236A82D4C1C2400D80C2C /* Localizable.strings */; };
+		5E5236F02D4C1C2400D80C2C /* Localizable.strings in Resources */ = {isa = PBXBuildFile; fileRef = 5E5236B12D4C1C2400D80C2C /* Localizable.strings */; };
+		5E5236F12D4C1C2400D80C2C /* Localizable.strings in Resources */ = {isa = PBXBuildFile; fileRef = 5E5236B42D4C1C2400D80C2C /* Localizable.strings */; };
+		5E5236F22D4C1C2400D80C2C /* Localizable.strings in Resources */ = {isa = PBXBuildFile; fileRef = 5E5236962D4C1C2400D80C2C /* Localizable.strings */; };
+		5E5236F32D4C1C2400D80C2C /* Localizable.strings in Resources */ = {isa = PBXBuildFile; fileRef = 5E5236992D4C1C2400D80C2C /* Localizable.strings */; };
+		5E5236F42D4C1C2400D80C2C /* Localizable.strings in Resources */ = {isa = PBXBuildFile; fileRef = 5E5236782D4C1C2400D80C2C /* Localizable.strings */; };
+		5E5236F52D4C1C2400D80C2C /* Localizable.strings in Resources */ = {isa = PBXBuildFile; fileRef = 5E52367B2D4C1C2400D80C2C /* Localizable.strings */; };
+		5E5236F62D4C1C2400D80C2C /* Localizable.strings in Resources */ = {isa = PBXBuildFile; fileRef = 5E52369C2D4C1C2400D80C2C /* Localizable.strings */; };
+		5E5236F72D4C1C2400D80C2C /* Localizable.strings in Resources */ = {isa = PBXBuildFile; fileRef = 5E5236932D4C1C2400D80C2C /* Localizable.strings */; };
+		5E5236F82D4C1C2400D80C2C /* Localizable.strings in Resources */ = {isa = PBXBuildFile; fileRef = 5E5236C32D4C1C2400D80C2C /* Localizable.strings */; };
+		5E5236F92D4C1C2400D80C2C /* Localizable.strings in Resources */ = {isa = PBXBuildFile; fileRef = 5E5236872D4C1C2400D80C2C /* Localizable.strings */; };
+		5E5236FA2D4C1C2400D80C2C /* Localizable.strings in Resources */ = {isa = PBXBuildFile; fileRef = 5E5236752D4C1C2400D80C2C /* Localizable.strings */; };
+		5E5236FB2D4C1C2400D80C2C /* Localizable.strings in Resources */ = {isa = PBXBuildFile; fileRef = 5E5236722D4C1C2400D80C2C /* Localizable.strings */; };
+		5E5236FC2D4C1C2400D80C2C /* Localizable.strings in Resources */ = {isa = PBXBuildFile; fileRef = 5E52368A2D4C1C2400D80C2C /* Localizable.strings */; };
+		5E5236FD2D4C1C2400D80C2C /* Localizable.strings in Resources */ = {isa = PBXBuildFile; fileRef = 5E5236C02D4C1C2400D80C2C /* Localizable.strings */; };
+		5E5236FE2D4C1C2400D80C2C /* Localizable.strings in Resources */ = {isa = PBXBuildFile; fileRef = 5E5236AB2D4C1C2400D80C2C /* Localizable.strings */; };
+		5E5236FF2D4C1C2400D80C2C /* Localizable.strings in Resources */ = {isa = PBXBuildFile; fileRef = 5E52367E2D4C1C2400D80C2C /* Localizable.strings */; };
+		5E5237002D4C1C2400D80C2C /* Localizable.strings in Resources */ = {isa = PBXBuildFile; fileRef = 5E5236902D4C1C2400D80C2C /* Localizable.strings */; };
+		5E5237012D4C1C2400D80C2C /* Localizable.strings in Resources */ = {isa = PBXBuildFile; fileRef = 5E5236AE2D4C1C2400D80C2C /* Localizable.strings */; };
 		62133890265F83A900A81A2A /* MediaView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6213388F265F83A900A81A2A /* MediaView.swift */; };
 		621338932660107500A81A2A /* String.swift in Sources */ = {isa = PBXBuildFile; fileRef = 621338922660107500A81A2A /* String.swift */; };
 		6220D0AD26D5EABB00B8E046 /* ViewExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6220D0AC26D5EABB00B8E046 /* ViewExtensions.swift */; };
@@ -1465,6 +1523,35 @@
 		53CD2A3F268A49C2002ABD4E /* ItemView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ItemView.swift; sourceTree = "<group>"; };
 		53D5E3DC264B47EE00BADDC8 /* MobileVLCKit.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = MobileVLCKit.xcframework; path = Carthage/Build/MobileVLCKit.xcframework; sourceTree = "<group>"; };
 		53EE24E5265060780068F029 /* SearchView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchView.swift; sourceTree = "<group>"; };
+		5E5236712D4C1C2400D80C2C /* ar */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ar; path = Localizable.strings; sourceTree = "<group>"; };
+		5E5236742D4C1C2400D80C2C /* bg */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = bg; path = Localizable.strings; sourceTree = "<group>"; };
+		5E5236772D4C1C2400D80C2C /* ca */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ca; path = Localizable.strings; sourceTree = "<group>"; };
+		5E52367A2D4C1C2400D80C2C /* cs */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = cs; path = Localizable.strings; sourceTree = "<group>"; };
+		5E52367D2D4C1C2400D80C2C /* da */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = da; path = Localizable.strings; sourceTree = "<group>"; };
+		5E5236802D4C1C2400D80C2C /* eo */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = eo; path = Localizable.strings; sourceTree = "<group>"; };
+		5E5236832D4C1C2400D80C2C /* eu */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = eu; path = Localizable.strings; sourceTree = "<group>"; };
+		5E5236862D4C1C2400D80C2C /* fi */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = fi; path = Localizable.strings; sourceTree = "<group>"; };
+		5E5236892D4C1C2400D80C2C /* hi */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = hi; path = Localizable.strings; sourceTree = "<group>"; };
+		5E52368C2D4C1C2400D80C2C /* hr */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = hr; path = Localizable.strings; sourceTree = "<group>"; };
+		5E52368F2D4C1C2400D80C2C /* hu */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = hu; path = Localizable.strings; sourceTree = "<group>"; };
+		5E5236922D4C1C2400D80C2C /* id */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = id; path = Localizable.strings; sourceTree = "<group>"; };
+		5E5236952D4C1C2400D80C2C /* ja */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ja; path = Localizable.strings; sourceTree = "<group>"; };
+		5E5236982D4C1C2400D80C2C /* lb */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = lb; path = Localizable.strings; sourceTree = "<group>"; };
+		5E52369B2D4C1C2400D80C2C /* lt */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = lt; path = Localizable.strings; sourceTree = "<group>"; };
+		5E52369E2D4C1C2400D80C2C /* mk */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = mk; path = Localizable.strings; sourceTree = "<group>"; };
+		5E5236A12D4C1C2400D80C2C /* nb-NO */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "nb-NO"; path = Localizable.strings; sourceTree = "<group>"; };
+		5E5236A42D4C1C2400D80C2C /* nl */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = nl; path = Localizable.strings; sourceTree = "<group>"; };
+		5E5236A72D4C1C2400D80C2C /* nn */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = nn; path = Localizable.strings; sourceTree = "<group>"; };
+		5E5236AA2D4C1C2400D80C2C /* pl */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = pl; path = Localizable.strings; sourceTree = "<group>"; };
+		5E5236AD2D4C1C2400D80C2C /* ps */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ps; path = Localizable.strings; sourceTree = "<group>"; };
+		5E5236B02D4C1C2400D80C2C /* pt */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = pt; path = Localizable.strings; sourceTree = "<group>"; };
+		5E5236B32D4C1C2400D80C2C /* pt-BR */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "pt-BR"; path = Localizable.strings; sourceTree = "<group>"; };
+		5E5236B62D4C1C2400D80C2C /* ro */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ro; path = Localizable.strings; sourceTree = "<group>"; };
+		5E5236B92D4C1C2400D80C2C /* sq */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = sq; path = Localizable.strings; sourceTree = "<group>"; };
+		5E5236BC2D4C1C2400D80C2C /* th */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = th; path = Localizable.strings; sourceTree = "<group>"; };
+		5E5236BF2D4C1C2400D80C2C /* tr */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = tr; path = Localizable.strings; sourceTree = "<group>"; };
+		5E5236C22D4C1C2400D80C2C /* uk */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = uk; path = Localizable.strings; sourceTree = "<group>"; };
+		5E5236C52D4C1C2400D80C2C /* zh-Hant */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "zh-Hant"; path = Localizable.strings; sourceTree = "<group>"; };
 		6213388F265F83A900A81A2A /* MediaView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MediaView.swift; sourceTree = "<group>"; };
 		621338922660107500A81A2A /* String.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = String.swift; sourceTree = "<group>"; };
 		6220D0AC26D5EABB00B8E046 /* ViewExtensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ViewExtensions.swift; sourceTree = "<group>"; };
@@ -3103,22 +3190,51 @@
 		534D4FE126A7D7CC000A7A48 /* Translations */ = {
 			isa = PBXGroup;
 			children = (
+				5E5236732D4C1C2400D80C2C /* ar.lproj */,
+				5E5236762D4C1C2400D80C2C /* bg.lproj */,
+				5E5236792D4C1C2400D80C2C /* ca.lproj */,
+				5E52367C2D4C1C2400D80C2C /* cs.lproj */,
+				5E52367F2D4C1C2400D80C2C /* da.lproj */,
 				53913BDA26D323FE00EB3286 /* de.lproj */,
 				53913BE326D323FE00EB3286 /* el.lproj */,
 				534D4FE626A7D7CC000A7A48 /* en.lproj */,
+				5E5236822D4C1C2400D80C2C /* eo.lproj */,
 				53913BE026D323FE00EB3286 /* es.lproj */,
+				5E5236852D4C1C2400D80C2C /* eu.lproj */,
+				5E5236882D4C1C2400D80C2C /* fi.lproj */,
 				53913BC826D323FE00EB3286 /* fr.lproj */,
 				53913BE626D323FE00EB3286 /* he.lproj */,
+				5E52368B2D4C1C2400D80C2C /* hi.lproj */,
+				5E52368E2D4C1C2400D80C2C /* hr.lproj */,
+				5E5236912D4C1C2400D80C2C /* hu.lproj */,
+				5E5236942D4C1C2400D80C2C /* id.lproj */,
 				53913BCE26D323FE00EB3286 /* it.lproj */,
+				5E5236972D4C1C2400D80C2C /* ja.lproj */,
 				53913BEC26D323FE00EB3286 /* kk.lproj */,
 				534D4FEA26A7D7CC000A7A48 /* ko.lproj */,
+				5E52369A2D4C1C2400D80C2C /* lb.lproj */,
+				5E52369D2D4C1C2400D80C2C /* lt.lproj */,
+				5E5236A02D4C1C2400D80C2C /* mk.lproj */,
+				5E5236A32D4C1C2400D80C2C /* nb-NO.lproj */,
+				5E5236A62D4C1C2400D80C2C /* nl.lproj */,
+				5E5236A92D4C1C2400D80C2C /* nn.lproj */,
+				5E5236AC2D4C1C2400D80C2C /* pl.lproj */,
+				5E5236AF2D4C1C2400D80C2C /* ps.lproj */,
+				5E5236B22D4C1C2400D80C2C /* pt.lproj */,
+				5E5236B52D4C1C2400D80C2C /* pt-BR.lproj */,
+				5E5236B82D4C1C2400D80C2C /* ro.lproj */,
 				53913BCB26D323FE00EB3286 /* ru.lproj */,
 				53913BE926D323FE00EB3286 /* sk.lproj */,
 				53913BD726D323FE00EB3286 /* sl.lproj */,
+				5E5236BB2D4C1C2400D80C2C /* sq.lproj */,
 				53913BD426D323FE00EB3286 /* sv.lproj */,
 				53913BDD26D323FE00EB3286 /* ta.lproj */,
+				5E5236BE2D4C1C2400D80C2C /* th.lproj */,
+				5E5236C12D4C1C2400D80C2C /* tr.lproj */,
+				5E5236C42D4C1C2400D80C2C /* uk.lproj */,
 				53913BD126D323FE00EB3286 /* vi.lproj */,
 				534D4FED26A7D7CC000A7A48 /* zh-Hans.lproj */,
+				5E5236C72D4C1C2400D80C2C /* zh-Hant.lproj */,
 			);
 			path = Translations;
 			sourceTree = "<group>";
@@ -3504,6 +3620,238 @@
 				4E661A282CEFE68100025C99 /* Video3DFormatPicker.swift */,
 			);
 			path = Components;
+			sourceTree = "<group>";
+		};
+		5E5236732D4C1C2400D80C2C /* ar.lproj */ = {
+			isa = PBXGroup;
+			children = (
+				5E5236722D4C1C2400D80C2C /* Localizable.strings */,
+			);
+			path = ar.lproj;
+			sourceTree = "<group>";
+		};
+		5E5236762D4C1C2400D80C2C /* bg.lproj */ = {
+			isa = PBXGroup;
+			children = (
+				5E5236752D4C1C2400D80C2C /* Localizable.strings */,
+			);
+			path = bg.lproj;
+			sourceTree = "<group>";
+		};
+		5E5236792D4C1C2400D80C2C /* ca.lproj */ = {
+			isa = PBXGroup;
+			children = (
+				5E5236782D4C1C2400D80C2C /* Localizable.strings */,
+			);
+			path = ca.lproj;
+			sourceTree = "<group>";
+		};
+		5E52367C2D4C1C2400D80C2C /* cs.lproj */ = {
+			isa = PBXGroup;
+			children = (
+				5E52367B2D4C1C2400D80C2C /* Localizable.strings */,
+			);
+			path = cs.lproj;
+			sourceTree = "<group>";
+		};
+		5E52367F2D4C1C2400D80C2C /* da.lproj */ = {
+			isa = PBXGroup;
+			children = (
+				5E52367E2D4C1C2400D80C2C /* Localizable.strings */,
+			);
+			path = da.lproj;
+			sourceTree = "<group>";
+		};
+		5E5236822D4C1C2400D80C2C /* eo.lproj */ = {
+			isa = PBXGroup;
+			children = (
+				5E5236812D4C1C2400D80C2C /* Localizable.strings */,
+			);
+			path = eo.lproj;
+			sourceTree = "<group>";
+		};
+		5E5236852D4C1C2400D80C2C /* eu.lproj */ = {
+			isa = PBXGroup;
+			children = (
+				5E5236842D4C1C2400D80C2C /* Localizable.strings */,
+			);
+			path = eu.lproj;
+			sourceTree = "<group>";
+		};
+		5E5236882D4C1C2400D80C2C /* fi.lproj */ = {
+			isa = PBXGroup;
+			children = (
+				5E5236872D4C1C2400D80C2C /* Localizable.strings */,
+			);
+			path = fi.lproj;
+			sourceTree = "<group>";
+		};
+		5E52368B2D4C1C2400D80C2C /* hi.lproj */ = {
+			isa = PBXGroup;
+			children = (
+				5E52368A2D4C1C2400D80C2C /* Localizable.strings */,
+			);
+			path = hi.lproj;
+			sourceTree = "<group>";
+		};
+		5E52368E2D4C1C2400D80C2C /* hr.lproj */ = {
+			isa = PBXGroup;
+			children = (
+				5E52368D2D4C1C2400D80C2C /* Localizable.strings */,
+			);
+			path = hr.lproj;
+			sourceTree = "<group>";
+		};
+		5E5236912D4C1C2400D80C2C /* hu.lproj */ = {
+			isa = PBXGroup;
+			children = (
+				5E5236902D4C1C2400D80C2C /* Localizable.strings */,
+			);
+			path = hu.lproj;
+			sourceTree = "<group>";
+		};
+		5E5236942D4C1C2400D80C2C /* id.lproj */ = {
+			isa = PBXGroup;
+			children = (
+				5E5236932D4C1C2400D80C2C /* Localizable.strings */,
+			);
+			path = id.lproj;
+			sourceTree = "<group>";
+		};
+		5E5236972D4C1C2400D80C2C /* ja.lproj */ = {
+			isa = PBXGroup;
+			children = (
+				5E5236962D4C1C2400D80C2C /* Localizable.strings */,
+			);
+			path = ja.lproj;
+			sourceTree = "<group>";
+		};
+		5E52369A2D4C1C2400D80C2C /* lb.lproj */ = {
+			isa = PBXGroup;
+			children = (
+				5E5236992D4C1C2400D80C2C /* Localizable.strings */,
+			);
+			path = lb.lproj;
+			sourceTree = "<group>";
+		};
+		5E52369D2D4C1C2400D80C2C /* lt.lproj */ = {
+			isa = PBXGroup;
+			children = (
+				5E52369C2D4C1C2400D80C2C /* Localizable.strings */,
+			);
+			path = lt.lproj;
+			sourceTree = "<group>";
+		};
+		5E5236A02D4C1C2400D80C2C /* mk.lproj */ = {
+			isa = PBXGroup;
+			children = (
+				5E52369F2D4C1C2400D80C2C /* Localizable.strings */,
+			);
+			path = mk.lproj;
+			sourceTree = "<group>";
+		};
+		5E5236A32D4C1C2400D80C2C /* nb-NO.lproj */ = {
+			isa = PBXGroup;
+			children = (
+				5E5236A22D4C1C2400D80C2C /* Localizable.strings */,
+			);
+			path = "nb-NO.lproj";
+			sourceTree = "<group>";
+		};
+		5E5236A62D4C1C2400D80C2C /* nl.lproj */ = {
+			isa = PBXGroup;
+			children = (
+				5E5236A52D4C1C2400D80C2C /* Localizable.strings */,
+			);
+			path = nl.lproj;
+			sourceTree = "<group>";
+		};
+		5E5236A92D4C1C2400D80C2C /* nn.lproj */ = {
+			isa = PBXGroup;
+			children = (
+				5E5236A82D4C1C2400D80C2C /* Localizable.strings */,
+			);
+			path = nn.lproj;
+			sourceTree = "<group>";
+		};
+		5E5236AC2D4C1C2400D80C2C /* pl.lproj */ = {
+			isa = PBXGroup;
+			children = (
+				5E5236AB2D4C1C2400D80C2C /* Localizable.strings */,
+			);
+			path = pl.lproj;
+			sourceTree = "<group>";
+		};
+		5E5236AF2D4C1C2400D80C2C /* ps.lproj */ = {
+			isa = PBXGroup;
+			children = (
+				5E5236AE2D4C1C2400D80C2C /* Localizable.strings */,
+			);
+			path = ps.lproj;
+			sourceTree = "<group>";
+		};
+		5E5236B22D4C1C2400D80C2C /* pt.lproj */ = {
+			isa = PBXGroup;
+			children = (
+				5E5236B12D4C1C2400D80C2C /* Localizable.strings */,
+			);
+			path = pt.lproj;
+			sourceTree = "<group>";
+		};
+		5E5236B52D4C1C2400D80C2C /* pt-BR.lproj */ = {
+			isa = PBXGroup;
+			children = (
+				5E5236B42D4C1C2400D80C2C /* Localizable.strings */,
+			);
+			path = "pt-BR.lproj";
+			sourceTree = "<group>";
+		};
+		5E5236B82D4C1C2400D80C2C /* ro.lproj */ = {
+			isa = PBXGroup;
+			children = (
+				5E5236B72D4C1C2400D80C2C /* Localizable.strings */,
+			);
+			path = ro.lproj;
+			sourceTree = "<group>";
+		};
+		5E5236BB2D4C1C2400D80C2C /* sq.lproj */ = {
+			isa = PBXGroup;
+			children = (
+				5E5236BA2D4C1C2400D80C2C /* Localizable.strings */,
+			);
+			path = sq.lproj;
+			sourceTree = "<group>";
+		};
+		5E5236BE2D4C1C2400D80C2C /* th.lproj */ = {
+			isa = PBXGroup;
+			children = (
+				5E5236BD2D4C1C2400D80C2C /* Localizable.strings */,
+			);
+			path = th.lproj;
+			sourceTree = "<group>";
+		};
+		5E5236C12D4C1C2400D80C2C /* tr.lproj */ = {
+			isa = PBXGroup;
+			children = (
+				5E5236C02D4C1C2400D80C2C /* Localizable.strings */,
+			);
+			path = tr.lproj;
+			sourceTree = "<group>";
+		};
+		5E5236C42D4C1C2400D80C2C /* uk.lproj */ = {
+			isa = PBXGroup;
+			children = (
+				5E5236C32D4C1C2400D80C2C /* Localizable.strings */,
+			);
+			path = uk.lproj;
+			sourceTree = "<group>";
+		};
+		5E5236C72D4C1C2400D80C2C /* zh-Hant.lproj */ = {
+			isa = PBXGroup;
+			children = (
+				5E5236C62D4C1C2400D80C2C /* Localizable.strings */,
+			);
+			path = "zh-Hant.lproj";
 			sourceTree = "<group>";
 		};
 		621338912660106C00A81A2A /* Extensions */ = {
@@ -5187,6 +5535,35 @@
 				sk,
 				kk,
 				Base,
+				ar,
+				bg,
+				ca,
+				cs,
+				da,
+				eo,
+				eu,
+				fi,
+				hi,
+				hr,
+				hu,
+				id,
+				ja,
+				lb,
+				lt,
+				mk,
+				"nb-NO",
+				nl,
+				nn,
+				pl,
+				ps,
+				pt,
+				"pt-BR",
+				ro,
+				sq,
+				th,
+				tr,
+				uk,
+				"zh-Hant",
 			);
 			mainGroup = 5377CBE8263B596A003A4E83;
 			packageReferences = (
@@ -5247,6 +5624,35 @@
 				53913C1126D323FE00EB3286 /* Localizable.strings in Resources */,
 				4E11805F2CBF52380077A588 /* Assets.xcassets in Resources */,
 				535870672669D21700D05A09 /* Assets.xcassets in Resources */,
+				5E5236C82D4C1C2400D80C2C /* Localizable.strings in Resources */,
+				5E5236C92D4C1C2400D80C2C /* Localizable.strings in Resources */,
+				5E5236CA2D4C1C2400D80C2C /* Localizable.strings in Resources */,
+				5E5236CB2D4C1C2400D80C2C /* Localizable.strings in Resources */,
+				5E5236CC2D4C1C2400D80C2C /* Localizable.strings in Resources */,
+				5E5236CD2D4C1C2400D80C2C /* Localizable.strings in Resources */,
+				5E5236CE2D4C1C2400D80C2C /* Localizable.strings in Resources */,
+				5E5236CF2D4C1C2400D80C2C /* Localizable.strings in Resources */,
+				5E5236D02D4C1C2400D80C2C /* Localizable.strings in Resources */,
+				5E5236D12D4C1C2400D80C2C /* Localizable.strings in Resources */,
+				5E5236D22D4C1C2400D80C2C /* Localizable.strings in Resources */,
+				5E5236D32D4C1C2400D80C2C /* Localizable.strings in Resources */,
+				5E5236D42D4C1C2400D80C2C /* Localizable.strings in Resources */,
+				5E5236D52D4C1C2400D80C2C /* Localizable.strings in Resources */,
+				5E5236D62D4C1C2400D80C2C /* Localizable.strings in Resources */,
+				5E5236D72D4C1C2400D80C2C /* Localizable.strings in Resources */,
+				5E5236D82D4C1C2400D80C2C /* Localizable.strings in Resources */,
+				5E5236D92D4C1C2400D80C2C /* Localizable.strings in Resources */,
+				5E5236DA2D4C1C2400D80C2C /* Localizable.strings in Resources */,
+				5E5236DB2D4C1C2400D80C2C /* Localizable.strings in Resources */,
+				5E5236DC2D4C1C2400D80C2C /* Localizable.strings in Resources */,
+				5E5236DD2D4C1C2400D80C2C /* Localizable.strings in Resources */,
+				5E5236DE2D4C1C2400D80C2C /* Localizable.strings in Resources */,
+				5E5236DF2D4C1C2400D80C2C /* Localizable.strings in Resources */,
+				5E5236E02D4C1C2400D80C2C /* Localizable.strings in Resources */,
+				5E5236E12D4C1C2400D80C2C /* Localizable.strings in Resources */,
+				5E5236E22D4C1C2400D80C2C /* Localizable.strings in Resources */,
+				5E5236E32D4C1C2400D80C2C /* Localizable.strings in Resources */,
+				5E5236E42D4C1C2400D80C2C /* Localizable.strings in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -5257,6 +5663,35 @@
 				53913C0A26D323FE00EB3286 /* Localizable.strings in Resources */,
 				534D4FF026A7D7CC000A7A48 /* Localizable.strings in Resources */,
 				53913BFB26D323FE00EB3286 /* Localizable.strings in Resources */,
+				5E5236E52D4C1C2400D80C2C /* Localizable.strings in Resources */,
+				5E5236E62D4C1C2400D80C2C /* Localizable.strings in Resources */,
+				5E5236E72D4C1C2400D80C2C /* Localizable.strings in Resources */,
+				5E5236E82D4C1C2400D80C2C /* Localizable.strings in Resources */,
+				5E5236E92D4C1C2400D80C2C /* Localizable.strings in Resources */,
+				5E5236EA2D4C1C2400D80C2C /* Localizable.strings in Resources */,
+				5E5236EB2D4C1C2400D80C2C /* Localizable.strings in Resources */,
+				5E5236EC2D4C1C2400D80C2C /* Localizable.strings in Resources */,
+				5E5236ED2D4C1C2400D80C2C /* Localizable.strings in Resources */,
+				5E5236EE2D4C1C2400D80C2C /* Localizable.strings in Resources */,
+				5E5236EF2D4C1C2400D80C2C /* Localizable.strings in Resources */,
+				5E5236F02D4C1C2400D80C2C /* Localizable.strings in Resources */,
+				5E5236F12D4C1C2400D80C2C /* Localizable.strings in Resources */,
+				5E5236F22D4C1C2400D80C2C /* Localizable.strings in Resources */,
+				5E5236F32D4C1C2400D80C2C /* Localizable.strings in Resources */,
+				5E5236F42D4C1C2400D80C2C /* Localizable.strings in Resources */,
+				5E5236F52D4C1C2400D80C2C /* Localizable.strings in Resources */,
+				5E5236F62D4C1C2400D80C2C /* Localizable.strings in Resources */,
+				5E5236F72D4C1C2400D80C2C /* Localizable.strings in Resources */,
+				5E5236F82D4C1C2400D80C2C /* Localizable.strings in Resources */,
+				5E5236F92D4C1C2400D80C2C /* Localizable.strings in Resources */,
+				5E5236FA2D4C1C2400D80C2C /* Localizable.strings in Resources */,
+				5E5236FB2D4C1C2400D80C2C /* Localizable.strings in Resources */,
+				5E5236FC2D4C1C2400D80C2C /* Localizable.strings in Resources */,
+				5E5236FD2D4C1C2400D80C2C /* Localizable.strings in Resources */,
+				5E5236FE2D4C1C2400D80C2C /* Localizable.strings in Resources */,
+				5E5236FF2D4C1C2400D80C2C /* Localizable.strings in Resources */,
+				5E5237002D4C1C2400D80C2C /* Localizable.strings in Resources */,
+				5E5237012D4C1C2400D80C2C /* Localizable.strings in Resources */,
 				534D4FF326A7D7CC000A7A48 /* Localizable.strings in Resources */,
 				53913C0126D323FE00EB3286 /* Localizable.strings in Resources */,
 				53913C1326D323FE00EB3286 /* Localizable.strings in Resources */,
@@ -6574,6 +7009,238 @@
 			isa = PBXVariantGroup;
 			children = (
 				53913BEE26D323FE00EB3286 /* kk */,
+			);
+			name = Localizable.strings;
+			sourceTree = "<group>";
+		};
+		5E5236722D4C1C2400D80C2C /* Localizable.strings */ = {
+			isa = PBXVariantGroup;
+			children = (
+				5E5236712D4C1C2400D80C2C /* ar */,
+			);
+			name = Localizable.strings;
+			sourceTree = "<group>";
+		};
+		5E5236752D4C1C2400D80C2C /* Localizable.strings */ = {
+			isa = PBXVariantGroup;
+			children = (
+				5E5236742D4C1C2400D80C2C /* bg */,
+			);
+			name = Localizable.strings;
+			sourceTree = "<group>";
+		};
+		5E5236782D4C1C2400D80C2C /* Localizable.strings */ = {
+			isa = PBXVariantGroup;
+			children = (
+				5E5236772D4C1C2400D80C2C /* ca */,
+			);
+			name = Localizable.strings;
+			sourceTree = "<group>";
+		};
+		5E52367B2D4C1C2400D80C2C /* Localizable.strings */ = {
+			isa = PBXVariantGroup;
+			children = (
+				5E52367A2D4C1C2400D80C2C /* cs */,
+			);
+			name = Localizable.strings;
+			sourceTree = "<group>";
+		};
+		5E52367E2D4C1C2400D80C2C /* Localizable.strings */ = {
+			isa = PBXVariantGroup;
+			children = (
+				5E52367D2D4C1C2400D80C2C /* da */,
+			);
+			name = Localizable.strings;
+			sourceTree = "<group>";
+		};
+		5E5236812D4C1C2400D80C2C /* Localizable.strings */ = {
+			isa = PBXVariantGroup;
+			children = (
+				5E5236802D4C1C2400D80C2C /* eo */,
+			);
+			name = Localizable.strings;
+			sourceTree = "<group>";
+		};
+		5E5236842D4C1C2400D80C2C /* Localizable.strings */ = {
+			isa = PBXVariantGroup;
+			children = (
+				5E5236832D4C1C2400D80C2C /* eu */,
+			);
+			name = Localizable.strings;
+			sourceTree = "<group>";
+		};
+		5E5236872D4C1C2400D80C2C /* Localizable.strings */ = {
+			isa = PBXVariantGroup;
+			children = (
+				5E5236862D4C1C2400D80C2C /* fi */,
+			);
+			name = Localizable.strings;
+			sourceTree = "<group>";
+		};
+		5E52368A2D4C1C2400D80C2C /* Localizable.strings */ = {
+			isa = PBXVariantGroup;
+			children = (
+				5E5236892D4C1C2400D80C2C /* hi */,
+			);
+			name = Localizable.strings;
+			sourceTree = "<group>";
+		};
+		5E52368D2D4C1C2400D80C2C /* Localizable.strings */ = {
+			isa = PBXVariantGroup;
+			children = (
+				5E52368C2D4C1C2400D80C2C /* hr */,
+			);
+			name = Localizable.strings;
+			sourceTree = "<group>";
+		};
+		5E5236902D4C1C2400D80C2C /* Localizable.strings */ = {
+			isa = PBXVariantGroup;
+			children = (
+				5E52368F2D4C1C2400D80C2C /* hu */,
+			);
+			name = Localizable.strings;
+			sourceTree = "<group>";
+		};
+		5E5236932D4C1C2400D80C2C /* Localizable.strings */ = {
+			isa = PBXVariantGroup;
+			children = (
+				5E5236922D4C1C2400D80C2C /* id */,
+			);
+			name = Localizable.strings;
+			sourceTree = "<group>";
+		};
+		5E5236962D4C1C2400D80C2C /* Localizable.strings */ = {
+			isa = PBXVariantGroup;
+			children = (
+				5E5236952D4C1C2400D80C2C /* ja */,
+			);
+			name = Localizable.strings;
+			sourceTree = "<group>";
+		};
+		5E5236992D4C1C2400D80C2C /* Localizable.strings */ = {
+			isa = PBXVariantGroup;
+			children = (
+				5E5236982D4C1C2400D80C2C /* lb */,
+			);
+			name = Localizable.strings;
+			sourceTree = "<group>";
+		};
+		5E52369C2D4C1C2400D80C2C /* Localizable.strings */ = {
+			isa = PBXVariantGroup;
+			children = (
+				5E52369B2D4C1C2400D80C2C /* lt */,
+			);
+			name = Localizable.strings;
+			sourceTree = "<group>";
+		};
+		5E52369F2D4C1C2400D80C2C /* Localizable.strings */ = {
+			isa = PBXVariantGroup;
+			children = (
+				5E52369E2D4C1C2400D80C2C /* mk */,
+			);
+			name = Localizable.strings;
+			sourceTree = "<group>";
+		};
+		5E5236A22D4C1C2400D80C2C /* Localizable.strings */ = {
+			isa = PBXVariantGroup;
+			children = (
+				5E5236A12D4C1C2400D80C2C /* nb-NO */,
+			);
+			name = Localizable.strings;
+			sourceTree = "<group>";
+		};
+		5E5236A52D4C1C2400D80C2C /* Localizable.strings */ = {
+			isa = PBXVariantGroup;
+			children = (
+				5E5236A42D4C1C2400D80C2C /* nl */,
+			);
+			name = Localizable.strings;
+			sourceTree = "<group>";
+		};
+		5E5236A82D4C1C2400D80C2C /* Localizable.strings */ = {
+			isa = PBXVariantGroup;
+			children = (
+				5E5236A72D4C1C2400D80C2C /* nn */,
+			);
+			name = Localizable.strings;
+			sourceTree = "<group>";
+		};
+		5E5236AB2D4C1C2400D80C2C /* Localizable.strings */ = {
+			isa = PBXVariantGroup;
+			children = (
+				5E5236AA2D4C1C2400D80C2C /* pl */,
+			);
+			name = Localizable.strings;
+			sourceTree = "<group>";
+		};
+		5E5236AE2D4C1C2400D80C2C /* Localizable.strings */ = {
+			isa = PBXVariantGroup;
+			children = (
+				5E5236AD2D4C1C2400D80C2C /* ps */,
+			);
+			name = Localizable.strings;
+			sourceTree = "<group>";
+		};
+		5E5236B12D4C1C2400D80C2C /* Localizable.strings */ = {
+			isa = PBXVariantGroup;
+			children = (
+				5E5236B02D4C1C2400D80C2C /* pt */,
+			);
+			name = Localizable.strings;
+			sourceTree = "<group>";
+		};
+		5E5236B42D4C1C2400D80C2C /* Localizable.strings */ = {
+			isa = PBXVariantGroup;
+			children = (
+				5E5236B32D4C1C2400D80C2C /* pt-BR */,
+			);
+			name = Localizable.strings;
+			sourceTree = "<group>";
+		};
+		5E5236B72D4C1C2400D80C2C /* Localizable.strings */ = {
+			isa = PBXVariantGroup;
+			children = (
+				5E5236B62D4C1C2400D80C2C /* ro */,
+			);
+			name = Localizable.strings;
+			sourceTree = "<group>";
+		};
+		5E5236BA2D4C1C2400D80C2C /* Localizable.strings */ = {
+			isa = PBXVariantGroup;
+			children = (
+				5E5236B92D4C1C2400D80C2C /* sq */,
+			);
+			name = Localizable.strings;
+			sourceTree = "<group>";
+		};
+		5E5236BD2D4C1C2400D80C2C /* Localizable.strings */ = {
+			isa = PBXVariantGroup;
+			children = (
+				5E5236BC2D4C1C2400D80C2C /* th */,
+			);
+			name = Localizable.strings;
+			sourceTree = "<group>";
+		};
+		5E5236C02D4C1C2400D80C2C /* Localizable.strings */ = {
+			isa = PBXVariantGroup;
+			children = (
+				5E5236BF2D4C1C2400D80C2C /* tr */,
+			);
+			name = Localizable.strings;
+			sourceTree = "<group>";
+		};
+		5E5236C32D4C1C2400D80C2C /* Localizable.strings */ = {
+			isa = PBXVariantGroup;
+			children = (
+				5E5236C22D4C1C2400D80C2C /* uk */,
+			);
+			name = Localizable.strings;
+			sourceTree = "<group>";
+		};
+		5E5236C62D4C1C2400D80C2C /* Localizable.strings */ = {
+			isa = PBXVariantGroup;
+			children = (
+				5E5236C52D4C1C2400D80C2C /* zh-Hant */,
 			);
 			name = Localizable.strings;
 			sourceTree = "<group>";


### PR DESCRIPTION
Fixing: #1327

About 30 localizations that have been merged from Weblate were not added into the Xcode project so they weren't actually usable

For reference the way I added them from the UI was:
Right click the Translations folder > Add Files to "Swiftfin" > Select the .lproj folders > Add > Reference files in place & Create groups & check both targets > Finish