### PR TITLE
[iOS] Show critic & community ratings alongside attributes

### DIFF
--- a/Swiftfin/Views/ItemView/Components/AttributeHStack.swift
+++ b/Swiftfin/Views/ItemView/Components/AttributeHStack.swift
@@ -17,6 +17,33 @@ extension ItemView {
 
         var body: some View {
             HStack {
+                if let criticRating = viewModel.item.criticRating {
+                    HStack(spacing: 2) {
+                        Group {
+                            if criticRating >= 60 {
+                                Image(.tomatoFresh)
+                                    .symbolRenderingMode(.hierarchical)
+                            } else {
+                                Image(.tomatoRotten)
+                            }
+                        }
+                        .font(.caption2)
+
+                        Text("\(criticRating, specifier: "%.0f")")
+                    }
+                    .asAttributeStyle(.outline)
+                }
+
+                if let communityRating = viewModel.item.communityRating {
+                    HStack(spacing: 2) {
+                        Image(systemName: "star.fill")
+                            .font(.caption2)
+
+                        Text("\(communityRating, specifier: "%.1f")")
+                    }
+                    .asAttributeStyle(.outline)
+                }
+
                 if let officialRating = viewModel.item.officialRating {
                     Text(officialRating)
                         .asAttributeStyle(.outline)


### PR DESCRIPTION
Adding a feature requested in: #1337 

This shows critic and audience ratings above the fold in a similar place to where the Jellyfin web UI shows them.

Examples:
![Image](https://github.com/user-attachments/assets/e6b0d8a8-55c2-4055-93c5-cce522a4206d)
![Image](https://github.com/user-attachments/assets/98a32bac-ce2e-4816-965b-d0c8969a8344)