### PR TITLE
[tvOS] Fix fresh tomato being shown for all rating values

### DIFF
--- a/Swiftfin tvOS/Views/ItemView/Components/AboutView/Components/RatingsCard.swift
+++ b/Swiftfin tvOS/Views/ItemView/Components/AboutView/Components/RatingsCard.swift
@@ -23,9 +23,9 @@ extension ItemView.AboutView {
                             VStack {
                                 Group {
                                     if criticRating >= 60 {
-                                        Image("tomato.fresh")
+                                        Image(.tomatoFresh)
                                     } else {
-                                        Image("tomato.fresh")
+                                        Image(.tomatoRotten)
                                     }
                                 }
                                 .symbolRenderingMode(.multicolor)


### PR DESCRIPTION
Happened to notice this typo that was always showing the fresh tomato icon