### PR TITLE
[tvOS] Fix ItemType Libraries

### DIFF
--- a/Shared/Objects/LibraryParent/LibraryParent.swift
+++ b/Shared/Objects/LibraryParent/LibraryParent.swift
@@ -50,7 +50,6 @@ extension LibraryParent {
             parameters.parentID = id
         case .folder:
             parameters.parentID = id
-            parameters.isRecursive = nil
         case .person:
             parameters.personIDs = [id]
         case .studio:

--- a/Shared/Objects/LibraryParent/LibraryParent.swift
+++ b/Shared/Objects/LibraryParent/LibraryParent.swift
@@ -42,7 +42,6 @@ extension LibraryParent {
         guard let id else { return parameters }
 
         var parameters = parameters
-        parameters.isRecursive = true
         parameters.includeItemTypes = supportedItemTypes
 
         switch libraryType {
@@ -50,6 +49,7 @@ extension LibraryParent {
             parameters.parentID = id
         case .folder:
             parameters.parentID = id
+            parameters.isRecursive = nil
         case .person:
             parameters.personIDs = [id]
         case .studio:

--- a/Shared/ViewModels/LibraryViewModel/ItemLibraryViewModel.swift
+++ b/Shared/ViewModels/LibraryViewModel/ItemLibraryViewModel.swift
@@ -85,6 +85,7 @@ final class ItemLibraryViewModel: PagingLibraryViewModel<BaseItemDto> {
             // Only set filtering on item types if selected, where
             // supported values should have been set by the parent.
             if filters.itemTypes.isNotEmpty {
+                parameters.isRecursive = true
                 parameters.includeItemTypes = filters.itemTypes
             }
 

--- a/Shared/ViewModels/LibraryViewModel/ItemLibraryViewModel.swift
+++ b/Shared/ViewModels/LibraryViewModel/ItemLibraryViewModel.swift
@@ -57,6 +57,7 @@ final class ItemLibraryViewModel: PagingLibraryViewModel<BaseItemDto> {
 
         // Default values, expected to be overridden
         // by parent or filters
+        parameters.isRecursive = true
         parameters.includeItemTypes = BaseItemKind.supportedCases
         parameters.sortOrder = [.ascending]
         parameters.sortBy = [ItemSortBy.name.rawValue]
@@ -85,7 +86,6 @@ final class ItemLibraryViewModel: PagingLibraryViewModel<BaseItemDto> {
             // Only set filtering on item types if selected, where
             // supported values should have been set by the parent.
             if filters.itemTypes.isNotEmpty {
-                parameters.isRecursive = true
                 parameters.includeItemTypes = filters.itemTypes
             }
 


### PR DESCRIPTION
### Summary

In https://github.com/jellyfin/Swiftfin/pull/1411 we drop the `isRecursive` flag. This is only a requirement for `itemType` libraries. I've added it to the bool logic so if the `filter.itemType.isNotEmpty` then make it recursive. Resolves the issue where these libraries are folders instead of the items. See screenshot.

### Screenshot

Fixes:
![Simulator Screenshot - Apple TV 4K (3rd generation) - 2025-02-07 at 12 28 01](https://github.com/user-attachments/assets/706dea2a-9c5c-4d15-8c62-bea18b633d2f)
