### PR TITLE
Make UnmaskSecureField respond to dynamic type

### DIFF
--- a/Shared/Extensions/Font.swift
+++ b/Shared/Extensions/Font.swift
@@ -10,7 +10,7 @@ import SwiftUI
 
 extension Font {
 
-    var uiFont: UIFont {
+    var uiFont: UIFont? {
         switch self {
         #if os(iOS)
         case .largeTitle:
@@ -37,7 +37,7 @@ extension Font {
         case .body:
             return UIFont.preferredFont(forTextStyle: .body)
         default:
-            return UIFont.preferredFont(forTextStyle: .body)
+            return nil
         }
     }
 }

--- a/Swiftfin/Components/UnmaskSecureField.swift
+++ b/Swiftfin/Components/UnmaskSecureField.swift
@@ -32,7 +32,7 @@ struct UnmaskSecureField: UIViewRepresentable {
     func makeUIView(context: Context) -> UITextField {
 
         let textField = UITextField()
-        textField.font = UIFont.preferredFont(forTextStyle: .body)
+        textField.font = context.environment.font?.uiFont ?? UIFont.preferredFont(forTextStyle: .body)
         textField.adjustsFontForContentSizeCategory = true
         textField.isSecureTextEntry = true
         textField.keyboardType = .asciiCapable

--- a/Swiftfin/Components/UnmaskSecureField.swift
+++ b/Swiftfin/Components/UnmaskSecureField.swift
@@ -32,6 +32,8 @@ struct UnmaskSecureField: UIViewRepresentable {
     func makeUIView(context: Context) -> UITextField {
 
         let textField = UITextField()
+        textField.font = UIFont.preferredFont(forTextStyle: .body)
+        textField.adjustsFontForContentSizeCategory = true
         textField.isSecureTextEntry = true
         textField.keyboardType = .asciiCapable
         textField.placeholder = title

--- a/Swiftfin/Views/ItemView/Components/EpisodeSelector/Components/EpisodeContent.swift
+++ b/Swiftfin/Views/ItemView/Components/EpisodeSelector/Components/EpisodeContent.swift
@@ -66,7 +66,7 @@ extension SeriesEpisodeSelector {
                             v.frame(
                                 height: "A\nA\nA".height(
                                     withConstrainedWidth: 10,
-                                    font: Font.caption.uiFont
+                                    font: Font.caption.uiFont ?? UIFont.preferredFont(forTextStyle: .body)
                                 )
                             )
                         }


### PR DESCRIPTION
UnmaskSecureField didn't change in size with dynamic type changes, making it stick out in the UI