### PR TITLE
[iOS] Address Bad UX on Password Change

### DIFF
--- a/Shared/ViewModels/ServerCheckViewModel.swift
+++ b/Shared/ViewModels/ServerCheckViewModel.swift
@@ -9,6 +9,7 @@
 import Combine
 import Factory
 import Foundation
+import Get
 import JellyfinAPI
 
 class ServerCheckViewModel: ViewModel, Stateful {
@@ -21,6 +22,7 @@ class ServerCheckViewModel: ViewModel, Stateful {
         case connecting
         case connected
         case error(JellyfinAPIError)
+        case loginInvalidated
         case initial
     }
 
@@ -46,6 +48,10 @@ class ServerCheckViewModel: ViewModel, Stateful {
                         userSession.user.data = response.value
                         self.state = .connected
                         Container.shared.currentUserSession.reset()
+                    }
+                } catch let Get.APIError.unacceptableStatusCode(code) where code == 401 {
+                    await MainActor.run {
+                        self.state = .loginInvalidated
                     }
                 } catch {
                     await MainActor.run {

--- a/Swiftfin/Views/ServerCheckView.swift
+++ b/Swiftfin/Views/ServerCheckView.swift
@@ -6,6 +6,8 @@
 // Copyright (c) 2025 Jellyfin & Jellyfin Contributors
 //
 
+import Defaults
+import Factory
 import SwiftUI
 
 struct ServerCheckView: View {
@@ -40,6 +42,39 @@ struct ServerCheckView: View {
         }
     }
 
+    @ViewBuilder
+    private func loginInvalidatedView() -> some View {
+        VStack(spacing: 10) {
+            Image(systemName: "xmark.circle.fill")
+                .font(.system(size: 72))
+                .foregroundColor(Color.red)
+
+            Text(viewModel.userSession.server.name)
+                .fontWeight(.semibold)
+                .foregroundStyle(.secondary)
+
+            Text(
+                "\(viewModel.userSession.user.username): The login for this user has been invalidated by the server. Please try registering the user again."
+            )
+            .frame(minWidth: 50, maxWidth: 240)
+            .multilineTextAlignment(.center)
+
+            PrimaryButton(title: L10n.ok)
+                .onSelect {
+                    do {
+                        try viewModel.userSession.user.delete()
+                        Defaults[.lastSignedInUserID] = .signedOut
+                        Container.shared.currentUserSession.reset()
+                        Notifications[.didSignOut].post()
+                    } catch {
+                        print(error)
+                    }
+                }
+                .frame(maxWidth: 300)
+                .frame(height: 50)
+        }
+    }
+
     var body: some View {
         ZStack {
             switch viewModel.state {
@@ -51,6 +86,8 @@ struct ServerCheckView: View {
                 }
             case let .error(error):
                 errorView(error)
+            case .loginInvalidated:
+                loginInvalidatedView()
             }
         }
         .animation(.linear(duration: 0.1), value: viewModel.state)


### PR DESCRIPTION
### Summary
My contribution here, would appreciate any feedback. 

Resolves: #1413 

Previously a user would enter a 'retry' loop when attempting to log into an account that has had its password changed. This fix seeks to provide the user clearer verbiage and add an exit to the flow. This is done by catching `APIError(401)` inside the `ServerCheckViewModel` and using it to trigger a new view state in `ServerCheckView`

### Outstanding Items
Would specific feedback on:
- The specific verbiage on the new screen
- How to localize the new verbiage
- Potential edge cases I could be missing

### Screenshots
New screen
![newErrorScreen](https://github.com/user-attachments/assets/ae631c72-db84-4e09-b7a3-f4b9b53c0b1d)
Example flow gif
![updatedFlowInitial](https://github.com/user-attachments/assets/59bad5a2-d96c-4e71-ab67-dc0eff34b3a7)
