### PR TITLE
[tvOS] Handle Empty Episode Selector

### DIFF
--- a/Swiftfin tvOS/Views/ItemView/Components/EpisodeSelector/Components/EpisodeHStack.swift
+++ b/Swiftfin tvOS/Views/ItemView/Components/EpisodeSelector/Components/EpisodeHStack.swift
@@ -61,11 +61,27 @@ extension SeriesEpisodeSelector {
             }
         }
 
+        @ViewBuilder
+        private var emptyView: some View {
+            VStack {
+                Text(L10n.noEpisodesAvailable)
+                Button(L10n.retry) {
+                    viewModel.send(.refresh)
+                }
+                .buttonStyle(.bordered)
+                .focused($focusedEpisodeID, equals: "RefreshButton")
+            }
+        }
+
         var body: some View {
-            WrappedView {
+            ZStack {
                 switch viewModel.state {
                 case .content:
-                    contentView(viewModel: viewModel)
+                    if viewModel.elements.isEmpty {
+                         emptyView
+                     } else {
+                         contentView(viewModel: viewModel)
+                     }
                 case let .error(error):
                     ErrorHStack(viewModel: viewModel, error: error)
                 case .initial, .refreshing:
@@ -76,7 +92,7 @@ extension SeriesEpisodeSelector {
             .focusGuide(
                 focusGuide,
                 tag: "episodes",
-                onContentFocus: { focusedEpisodeID = lastFocusedEpisodeID },
+                onContentFocus: { focusedEpisodeID = viewModel.elements.isEmpty ? "RefreshButton" : lastFocusedEpisodeID },
                 top: "seasons"
             )
             .onChange(of: viewModel.id) {


### PR DESCRIPTION
### Summary

This is a very rare occurrence, but I found that if you have empty folder for a season, you can lock the episode selector until you re-enter the `ItemView`.

The issue is, without episodes, the episode selector does not exist. Because of the `FocusGuide`, there is no way to go down to Cast & Crew without episodes. Additionally, because there is no set area for episodes, going back to a season that contains episodes, the selector is tiny and shoved outside the screen.

This PR creates a "No episodes" filler text when episodes are not available along with a refresh button in case they want to update this season.

### Issue

https://github.com/user-attachments/assets/182337b4-cb25-4f8a-a005-469e36b091e6

### Resolution

https://github.com/user-attachments/assets/016476fb-659e-4b18-83fc-17967a78d9c1
