### PR TITLE
[tvOS] Add accent colors to settings

### DIFF
--- a/Swiftfin tvOS/Components/PosterButton.swift
+++ b/Swiftfin tvOS/Components/PosterButton.swift
@@ -232,7 +232,8 @@ extension PosterButton {
 
     // TODO: Find better way for these indicators, see EpisodeCard
     struct DefaultOverlay: View {
-
+        @Default(.accentColor)
+        private var accentColor
         @Default(.Customization.Indicators.showFavorited)
         private var showFavorited
         @Default(.Customization.Indicators.showProgress)
@@ -256,7 +257,7 @@ extension PosterButton {
                                 .visible(showProgress)
                         } else {
                             UnwatchedIndicator(size: 45)
-                                .foregroundColor(.jellyfinPurple)
+                                .foregroundColor(accentColor)
                                 .visible(showUnplayed)
                         }
                     }

--- a/Swiftfin tvOS/Views/ItemView/Components/ActionButtons/ActionButtonHStack.swift
+++ b/Swiftfin tvOS/Views/ItemView/Components/ActionButtons/ActionButtonHStack.swift
@@ -6,6 +6,7 @@
 // Copyright (c) 2025 Jellyfin & Jellyfin Contributors
 //
 
+import Defaults
 import SwiftUI
 
 extension ItemView {
@@ -25,6 +26,8 @@ extension ItemView {
 
         // MARK: - Defaults
 
+        @Default(.accentColor)
+        private var accentColor
         @StoredValue(.User.enableItemDeletion)
         private var enableItemDeletion: Bool
         @StoredValue(.User.enableItemEditing)
@@ -85,7 +88,7 @@ extension ItemView {
                 ) {
                     viewModel.send(.toggleIsPlayed)
                 }
-                .foregroundStyle(.purple)
+                .foregroundStyle(accentColor)
                 .environment(\.isSelected, viewModel.item.userData?.isPlayed ?? false)
                 .frame(minWidth: 80, maxWidth: .infinity)
 

--- a/Swiftfin tvOS/Views/SelectUserView/SelectUserView.swift
+++ b/Swiftfin tvOS/Views/SelectUserView/SelectUserView.swift
@@ -30,6 +30,8 @@ struct SelectUserView: View {
     private var serverSelection
     @Default(.selectUserUseSplashscreen)
     private var selectUserUseSplashscreen
+    @Default(.accentColor)
+    private var accentColor
 
     // MARK: - Environment Variable
 
@@ -321,7 +323,7 @@ struct SelectUserView: View {
                     .font(.callout)
                     .fontWeight(.bold)
                     .frame(width: 400, height: 75)
-                    .background(Color.jellyfinPurple)
+                    .background(accentColor)
             }
             .buttonStyle(.card)
         }

--- a/Swiftfin tvOS/Views/SettingsView/SettingsView.swift
+++ b/Swiftfin tvOS/Views/SettingsView/SettingsView.swift
@@ -15,12 +15,28 @@ struct SettingsView: View {
 
     @Default(.VideoPlayer.videoPlayerType)
     private var videoPlayerType
+    @Default(.accentColor)
+    private var accentColor
 
     @EnvironmentObject
     private var router: SettingsCoordinator.Router
 
     @StateObject
     private var viewModel = SettingsViewModel()
+
+    struct NamedColor: Hashable {
+        let name: String
+        let value: Color
+
+        static let availableColors: [NamedColor] = [
+            NamedColor(name: L10n.jellyfin, value: .jellyfinPurple),
+            NamedColor(name: L10n.red, value: .red),
+            NamedColor(name: L10n.orange, value: .orange),
+            NamedColor(name: L10n.yellow, value: .yellow),
+            NamedColor(name: L10n.green, value: .green),
+            NamedColor(name: L10n.blue, value: .blue),
+        ]
+    }
 
     var body: some View {
         SplitFormWindowView()
@@ -50,7 +66,7 @@ struct SettingsView: View {
                     ListRowButton(L10n.switchUser) {
                         viewModel.signOut()
                     }
-                    .foregroundStyle(Color.jellyfinPurple.overlayColor, Color.jellyfinPurple)
+                    .foregroundStyle(accentColor.overlayColor, accentColor)
                     .listRowInsets(.zero)
                 }
 
@@ -80,6 +96,31 @@ struct SettingsView: View {
 //                        .onSelect {
 //                            router.route(to: \.experimentalSettings)
 //                        }
+                }
+
+                Section(L10n.appearance) {
+                    Menu {
+                        ForEach(NamedColor.availableColors, id: \.self) { color in
+                            Button(action: {
+                                guard accentColor != color.value else { return }
+                                accentColor = color.value
+                            }) {
+                                Text(color.name)
+                                    .foregroundColor(.primary)
+                            }
+                        }
+                    } label: {
+                        HStack {
+                            Text(L10n.accentColor)
+                            Spacer()
+                            Circle()
+                                .fill(accentColor)
+                                .frame(width: 16, height: 16)
+                        }
+                    }
+                    .listRowBackground(Color.clear)
+                    .listRowInsets(.zero)
+                    .foregroundStyle(.primary, .secondary)
                 }
 
                 Section {

--- a/Swiftfin tvOS/Views/VideoPlayer/Overlays/ChapterOverlay.swift
+++ b/Swiftfin tvOS/Views/VideoPlayer/Overlays/ChapterOverlay.swift
@@ -6,6 +6,7 @@
 // Copyright (c) 2025 Jellyfin & Jellyfin Contributors
 //
 
+import Defaults
 import SwiftUI
 import VLCUI
 
@@ -16,6 +17,9 @@ extension VideoPlayer {
         @Environment(\.currentOverlayType)
         @Binding
         private var currentOverlayType
+
+        @Default(.accentColor)
+        private var accentColor
 
         @EnvironmentObject
         private var currentProgressHandler: VideoPlayerManager.CurrentProgressHandler
@@ -58,7 +62,7 @@ extension VideoPlayer {
                                 .imageOverlay {
                                     if chapter.secondsRange.contains(currentProgressHandler.seconds) {
                                         RoundedRectangle(cornerRadius: 6)
-                                            .stroke(Color.jellyfinPurple, lineWidth: 8)
+                                            .stroke(accentColor, lineWidth: 8)
                                     }
                                 }
                                 .content {


### PR DESCRIPTION
Hey there,

I’ve added the ability to select an accent color in the tvOS version of the app, similar to what’s already available in the iOS app. Since the `ColorPicker` component isn’t available on tvOS, I decided to implement a few preset colors for users to choose from. I also added the accent color to some more elements (like on iOS)

> I’m relatively new to Swift and SwiftUI, but I’m not new to programming in general. If there are any concerns with my idea (or code), I'll try my best to solve them.