### PR TITLE
[iOS] External display wide ratio support

### DIFF
--- a/Swiftfin/Views/VideoPlayer/NativeVideoPlayer.swift
+++ b/Swiftfin/Views/VideoPlayer/NativeVideoPlayer.swift
@@ -116,6 +116,9 @@ class UINativeVideoPlayerViewController: AVPlayerViewController {
 
     override func viewDidLoad() {
         super.viewDidLoad()
+
+        // Add external screen support configuration
+        player?.usesExternalPlaybackWhileExternalScreenIsActive = true
     }
 
     override func viewWillDisappear(_ animated: Bool) {


### PR DESCRIPTION
### Summary

Current SwiftFin app only mirror directly what's on iPad screen to external display, therefore when plugging in a monitor or projector, there's huge black bars on the sides. 

### Changes

Use built-in function supported by AVKit, applying to native player

### After 

Main display
![IMG_2781](https://github.com/user-attachments/assets/e06bf3ca-e47f-4abc-a13f-d1dc6694a1d0)
External display
![IMG_2780](https://github.com/user-attachments/assets/d9b50eb7-06bc-4ef5-801e-668a5f89a47d)

P/s: if this small ticket works I'm happy to continue working on the VideoPlayer struct (the VLC player)