### PR TITLE
[Meta] Add External Display to Player Documentation

### DIFF
--- a/Documentation/players.md
+++ b/Documentation/players.md
@@ -176,3 +176,12 @@ Swiftfin track selection is limited by compatibility with each player. In testin
 | External Audio + Internal Audio + External Subtitles  | 🟡         | ❌        | - The default audio track will played </br> - subtitles cannot be selected. |
 | External Audio + Internal Audio + Internal Subtitles  | 🟡         | ❌        | - The default audio track will played </br> - subtitles cannot be selected. |
 | External Audio + Internal Audio + Internal Subtitles + External Subtitles | 🟡 | ❌ | - The default audio track will played </br> - subtitles cannot be selected. |
+
+--- 
+
+### Miscellaneous
+
+| Feature | Swiftfin (VLCKit) | Native (AVKit) | Notes |
+|-------------|-------------------|----------------|----------------|
+| **External Display Support** | 🟡        | ✅        | Swiftfin Player can only be mirrored. As a result, the player will retain the source device dimensions. |
+


### PR DESCRIPTION
### Summary

Adds a Miscellaneous section to the bottom of `Players.md`. This may populate more in the future but for now this just displays the state of https://github.com/jellyfin/Swiftfin/pull/1453.