### PR TITLE
[tvOS] Stops the `SeasonHStack` Shadow from Clipping

### DIFF
--- a/Swiftfin tvOS/Views/ItemView/Components/EpisodeSelector/Components/HStacks/SeasonHStack.swift
+++ b/Swiftfin tvOS/Views/ItemView/Components/EpisodeSelector/Components/HStacks/SeasonHStack.swift
@@ -86,6 +86,7 @@ extension SeriesEpisodeSelector {
                     }
                 }
             }
+            .scrollClipDisabled()
         }
 
         // MARK: - Season Button


### PR DESCRIPTION
### Summary

Adds `.scrollClipDisabled()`.

### Before
<img width="323" alt="Screenshot 2025-04-03 at 14 58 14" src="https://github.com/user-attachments/assets/57a9cfd3-3dd4-44d8-9e37-ef14c18fa8fa" />

### After
<img width="325" alt="Screenshot 2025-04-03 at 14 58 46" src="https://github.com/user-attachments/assets/8656dedd-31b5-4c4e-ba8f-ec248ba03858" />