### PR TITLE
[tvOS] External Trailer Fix

### DIFF
--- a/Swiftfin tvOS/Resources/Info.plist
+++ b/Swiftfin tvOS/Resources/Info.plist
@@ -18,6 +18,10 @@
 	<string>$(CURRENT_PROJECT_VERSION)</string>
 	<key>CFBundledisplayTitle</key>
 	<string>Jellyfin</string>
+	<key>LSApplicationQueriesSchemes</key>
+	<array>
+		<string>youtube</string>
+	</array>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
 	<key>NSAppTransportSecurity</key>

--- a/Swiftfin tvOS/Views/ItemView/Components/ActionButtonHStack/Components/TrailerMenu.swift
+++ b/Swiftfin tvOS/Views/ItemView/Components/ActionButtonHStack/Components/TrailerMenu.swift
@@ -136,11 +136,22 @@ extension ItemView {
         // MARK: - Play: External Trailer
 
         private func playExternalTrailer(_ trailer: MediaURL) {
-            if let url = URL(string: trailer.url), UIApplication.shared.canOpenURL(url) {
+            if let trailerUrlString = trailer.url {
+                let youtubeDeepLink = "youtube://\(trailerUrlString)"
+                if let youtubeURL = URL(string: youtubeDeepLink), UIApplication.shared.canOpenURL(youtubeURL) {
+                    UIApplication.shared.open(youtubeURL) { success in
+                        if !success {
+                            error = JellyfinAPIError(L10n.unableToOpenTrailer)
+                        }
+                    }
+                    return
+                }
+            }
+            if let urlString = trailer.url, let url = URL(string: urlString), UIApplication.shared.canOpenURL(url) {
                 UIApplication.shared.open(url) { success in
-                    guard !success else { return }
-
-                    error = JellyfinAPIError(L10n.unableToOpenTrailer)
+                    if !success {
+                        error = JellyfinAPIError(L10n.unableToOpenTrailer)
+                    }
                 }
             } else {
                 error = JellyfinAPIError(L10n.unableToOpenTrailer)


### PR DESCRIPTION
### Summary

Today, I build the Main tvOS build on my actual Apple TV and I found that external trailers always failed to open. I needed to add this to info.plist:

```
<?xml version="1.0" encoding="UTF-8"?>
<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
<plist version="1.0">
<array>
	<string>youtube</string>
</array>
</plist>
```

This is IF we want to proceed with this. I've tested this on a real device and can confirm this now works. I wasn't even aware there was a way to build on a remote Apple TV because I never looked into it...

I think the two major reasons we wouldn't want to do this are: 
1. Not all external trailers are going to be YouTube. Do we want to add URL schema for all various sources that come up? This opens us up to the requests for "Enable Trailers for X Platform" which adds some additional maintenance.
2. From a FOSS perspective, linking into Google's YouTube can feel a bit taboo. I don't personally see the issue but I can understand why that might less than ideal to some folks.

Let me know if we want to proceed!

### Proof

https://github.com/user-attachments/assets/1864c765-88a7-40de-ab4a-bed7c5737034
