### PR TITLE
[tvOS] Fix First Login Crash

### DIFF
--- a/Swiftfin tvOS/Views/UserSignInView/UserSignInView.swift
+++ b/Swiftfin tvOS/Views/UserSignInView/UserSignInView.swift
@@ -204,7 +204,8 @@ struct UserSignInView: View {
             isPresented: $isPresentingDuplicateUser,
             presenting: duplicateUser
         ) { _ in
-//            TODO: uncomment when duplicate user fixed
+
+            // TODO: uncomment when duplicate user fixed
 //            Button(L10n.signIn) {
 //                signInDuplicate(user: user, replace: false)
 //            }
@@ -212,6 +213,7 @@ struct UserSignInView: View {
 //            Button("Replace") {
 //                signInDuplicate(user: user, replace: true)
 //            }
+
             Button(L10n.dismiss, role: .cancel)
         } message: { duplicateUser in
             Text(L10n.duplicateUserSaved(duplicateUser.username))

--- a/Swiftfin tvOS/Views/UserSignInView/UserSignInView.swift
+++ b/Swiftfin tvOS/Views/UserSignInView/UserSignInView.swift
@@ -36,6 +36,9 @@ struct UserSignInView: View {
     private var router: UserSignInCoordinator.Router
 
     @StateObject
+    private var focusGuide: FocusGuide = .init()
+
+    @StateObject
     private var viewModel: UserSignInViewModel
 
     // MARK: - User Sign In Variables
@@ -201,6 +204,14 @@ struct UserSignInView: View {
             isPresented: $isPresentingDuplicateUser,
             presenting: duplicateUser
         ) { _ in
+//            TODO: uncomment when duplicate user fixed
+//            Button(L10n.signIn) {
+//                signInDuplicate(user: user, replace: false)
+//            }
+
+//            Button("Replace") {
+//                signInDuplicate(user: user, replace: true)
+//            }
             Button(L10n.dismiss, role: .cancel)
         } message: { duplicateUser in
             Text(L10n.duplicateUserSaved(duplicateUser.username))


### PR DESCRIPTION
### Summary

Resolves: https://github.com/jellyfin/Swiftfin/issues/1477

tvOS seems to crash on first login due to a memory allocation issue. By wrapping these operations in `DispatchQueue.main.async`, we ensure that:

1. **UI Updates Happen on the Main Thread**: SwiftUI requires all UI updates to happen on the main thread. When we modify Defaults or post notifications that trigger UI updates, doing this on a background thread can cause crashes.

2. **Thread Safety for Shared Resources**: `Container.shared.currentUserSession.reset()` deals with a shared resource that might be accessed from multiple threads. The async wrapper ensures thread-safe access.

3. **Memory Access Synchronization**: The crash was an `EXC_BAD_ACCESS` error, which often happens when memory is deallocated on one thread while being accessed on another. The async wrapper ensures proper synchronization.

4. **Deferred Execution**: By deferring these operations to the next run loop cycle, we give any pending UI updates a chance to complete before changing application state.

(According to Claude) tvOS is particularly sensitive to threading issues because:

1. Its rendering pipeline has different timing characteristics than iOS
2. Memory management is more aggressive due to limited resources
3. The focus system adds additional complexity to the UI update cycle

---

Does it make sense to, where possible, move these operations to the `viewModel` instead?