### PR TITLE
[Meta] Cleanup Jellyfin Version Badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
   <h1>Swiftfin</h1>
   <img src="https://img.shields.io/badge/iOS-15+-red"/>
   <img src="https://img.shields.io/badge/tvOS-17+-red"/>
-  <img src="https://img.shields.io/badge/Jellyfin-10.10.6-9962be"/>
+  <img src="https://img.shields.io/badge/Jellyfin-10.10-9962be"/>
   
   <a href="https://translate.jellyfin.org/engage/swiftfin/">
     <img src="https://translate.jellyfin.org/widgets/swiftfin/-/svg-badge.svg"/>


### PR DESCRIPTION
### Summary

Jellyfin badge has 3 digits when API should only change for X.Y. So, X.Y.Z isn't required but can be added back in if it is required. This is so completely unimportant but I cannot boast that the SDK is up-to-date if the version is off by 1!

Alternatively, I can update this to 10.10.7 but then you can expect a PR from me in 6-8 weeks for 10.10.8 😆

### Before
<img width="108" alt="Screenshot 2025-04-06 at 22 26 10" src="https://github.com/user-attachments/assets/c25a0ebd-3ea4-47ad-980a-2cd3fbf741cb" />


### After
<img width="98" alt="Screenshot 2025-04-06 at 22 24 03" src="https://github.com/user-attachments/assets/3d58179a-a250-4968-93a8-fe4be7d8110b" />
