### PR TITLE
[iOS & tvOS] Fix Recently Added Missing Movies

### DIFF
--- a/Shared/Objects/ItemFilter/ItemFilterCollection.swift
+++ b/Shared/Objects/ItemFilter/ItemFilterCollection.swift
@@ -29,7 +29,7 @@ struct ItemFilterCollection: Codable, Defaults.Serializable, Hashable {
         traits: [ItemTrait.isFavorite]
     )
     static let recent: ItemFilterCollection = .init(
-        sortBy: [ItemSortBy.dateLastContentAdded],
+        sortBy: [ItemSortBy.dateCreated],
         sortOrder: [ItemSortOrder.descending]
     )
 

--- a/Shared/ViewModels/LibraryViewModel/RecentlyAddedViewModel.swift
+++ b/Shared/ViewModels/LibraryViewModel/RecentlyAddedViewModel.swift
@@ -42,7 +42,7 @@ final class RecentlyAddedLibraryViewModel: PagingLibraryViewModel<BaseItemDto> {
         parameters.includeItemTypes = [.movie, .series]
         parameters.isRecursive = true
         parameters.limit = pageSize
-        parameters.sortBy = [ItemSortBy.dateLastContentAdded.rawValue]
+        parameters.sortBy = [ItemSortBy.dateCreated.rawValue]
         parameters.sortOrder = [.descending]
         parameters.startIndex = page
 


### PR DESCRIPTION
### Summary

Resolves: https://github.com/jellyfin/Swiftfin/issues/1486

This changes the `ItemSortBy` to use `dateCreated`. After 10.10, the enum `dateAdded` was no longer available so we changed to `dateLastContentAdded`. This `ItemSortBy` only returns/sorts folder items so Movies are not included / always at the bottom with `nil`. This should reflect our pre-10.10 Recently Added section better.