### PR TITLE
[WIP] [iOS & tvOS] Check API / Server Version

### DIFF
--- a/Shared/Coordinators/MainCoordinator/tvOSMainCoordinator.swift
+++ b/Shared/Coordinators/MainCoordinator/tvOSMainCoordinator.swift
@@ -29,6 +29,8 @@ final class MainCoordinator: NavigationCoordinatable {
     var mainTab = makeMainTab
     @Root
     var selectUser = makeSelectUser
+    @Root
+    var serverCheck = makeServerCheck
 
     init() {
 
@@ -41,7 +43,7 @@ final class MainCoordinator: NavigationCoordinatable {
                 if Container.shared.currentUserSession() != nil {
                     await MainActor.run {
                         withAnimation(.linear(duration: 0.1)) {
-                            let _ = root(\.mainTab)
+                            let _ = root(\.serverCheck)
                         }
                     }
                 } else {
@@ -94,6 +96,14 @@ final class MainCoordinator: NavigationCoordinatable {
     }
 
     func makeSelectUser() -> NavigationViewCoordinator<SelectUserCoordinator> {
-        NavigationViewCoordinator(SelectUserCoordinator())
+        NavigationViewCoordinator(
+            SelectUserCoordinator()
+        )
+    }
+
+    func makeServerCheck() -> NavigationViewCoordinator<BasicNavigationViewCoordinator> {
+        NavigationViewCoordinator {
+            ServerCheckView()
+        }
     }
 }

--- a/Shared/Extensions/UIApplication.swift
+++ b/Shared/Extensions/UIApplication.swift
@@ -10,6 +10,10 @@ import UIKit
 
 extension UIApplication {
 
+    static var apiVersion: String? {
+        Bundle.main.object(forInfoDictionaryKey: "MinimumJellyfinVersion") as? String
+    }
+
     static var appVersion: String? {
         Bundle.main.object(forInfoDictionaryKey: "CFBundleShortVersionString") as? String
     }

--- a/Swiftfin tvOS/Components/ErrorView.swift
+++ b/Swiftfin tvOS/Components/ErrorView.swift
@@ -17,6 +17,7 @@ struct ErrorView<ErrorType: Error>: View {
 
     private let error: ErrorType
     private var onRetry: (() -> Void)?
+    private var onSwitchUser: (() -> Void)?
 
     var body: some View {
         VStack(spacing: 20) {
@@ -33,6 +34,11 @@ struct ErrorView<ErrorType: Error>: View {
                     .foregroundStyle(accentColor.overlayColor, accentColor)
                     .frame(maxWidth: 750)
             }
+
+            if let onSwitchUser {
+                ListRowButton(L10n.switchUser, role: .destructive, action: onSwitchUser)
+                    .frame(maxWidth: 750)
+            }
         }
     }
 }
@@ -42,11 +48,16 @@ extension ErrorView {
     init(error: ErrorType) {
         self.init(
             error: error,
-            onRetry: nil
+            onRetry: nil,
+            onSwitchUser: nil
         )
     }
 
     func onRetry(_ action: @escaping () -> Void) -> Self {
         copy(modifying: \.onRetry, with: action)
+    }
+
+    func onSwitchUser(_ action: @escaping () -> Void) -> Self {
+        copy(modifying: \.onSwitchUser, with: action)
     }
 }

--- a/Swiftfin tvOS/Resources/Info.plist
+++ b/Swiftfin tvOS/Resources/Info.plist
@@ -36,5 +36,7 @@
 	</array>
 	<key>UIUserInterfaceStyle</key>
 	<string>Dark</string>
+	<key>MinimumJellyfinVersion</key>
+	<string>10.10.0</string>
 </dict>
 </plist>

--- a/Swiftfin tvOS/Views/ServerCheckView.swift
+++ b/Swiftfin tvOS/Views/ServerCheckView.swift
@@ -1,0 +1,52 @@
+//
+// Swiftfin is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, you can obtain one at https://mozilla.org/MPL/2.0/.
+//
+// Copyright (c) 2025 Jellyfin & Jellyfin Contributors
+//
+
+import SwiftUI
+
+struct ServerCheckView: View {
+
+    @EnvironmentObject
+    private var router: MainCoordinator.Router
+
+    @StateObject
+    private var viewModel = ServerCheckViewModel()
+    @StateObject
+    private var settingsViewModel = SettingsViewModel()
+
+    var body: some View {
+        ZStack {
+            switch viewModel.state {
+            case .initial, .connecting, .connected:
+                ZStack {
+                    Color.clear
+
+                    ProgressView()
+                }
+            case let .error(error):
+                ErrorView(error: error)
+                    .onRetry {
+                        viewModel.send(.checkServer)
+                    }
+                    .onSwitchUser {
+                        settingsViewModel.signOut()
+                    }
+            }
+        }
+        .animation(.linear(duration: 0.1), value: viewModel.state)
+        .onFirstAppear {
+            viewModel.send(.checkServer)
+        }
+        .onReceive(viewModel.$state) { newState in
+            if newState == .connected {
+                withAnimation(.linear(duration: 0.1)) {
+                    let _ = router.root(\.mainTab)
+                }
+            }
+        }
+    }
+}

--- a/Swiftfin.xcodeproj/project.pbxproj
+++ b/Swiftfin.xcodeproj/project.pbxproj
@@ -155,6 +155,8 @@
 		4E699BB92CB33FC2007CBD5D /* HomeSection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4E699BB82CB33FB5007CBD5D /* HomeSection.swift */; };
 		4E699BC02CB3477D007CBD5D /* HomeSection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4E699BBF2CB34775007CBD5D /* HomeSection.swift */; };
 		4E6C27082C8BD0AD00FD2185 /* ServerSessionDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4E6C27072C8BD0AD00FD2185 /* ServerSessionDetailView.swift */; };
+		4E6EB7E12DB03047009A3D9F /* ServerCheckView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4E6EB7E02DB03047009A3D9F /* ServerCheckView.swift */; };
+		4E6EB7E22DB030C5009A3D9F /* ServerCheckViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = E19D41AD2BF288320082B8B2 /* ServerCheckViewModel.swift */; };
 		4E71D6892C80910900A0174D /* EditCustomDeviceProfileView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4E71D6882C80910900A0174D /* EditCustomDeviceProfileView.swift */; };
 		4E7315742D14772700EA2A95 /* UserProfileHeroImage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4E7315732D14770E00EA2A95 /* UserProfileHeroImage.swift */; };
 		4E7315752D1485C900EA2A95 /* UserProfileImage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4E5508722D13AFE3002A5345 /* UserProfileImage.swift */; };
@@ -1407,6 +1409,7 @@
 		4E699BB82CB33FB5007CBD5D /* HomeSection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeSection.swift; sourceTree = "<group>"; };
 		4E699BBF2CB34775007CBD5D /* HomeSection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeSection.swift; sourceTree = "<group>"; };
 		4E6C27072C8BD0AD00FD2185 /* ServerSessionDetailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ServerSessionDetailView.swift; sourceTree = "<group>"; };
+		4E6EB7E02DB03047009A3D9F /* ServerCheckView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ServerCheckView.swift; sourceTree = "<group>"; };
 		4E71D6882C80910900A0174D /* EditCustomDeviceProfileView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditCustomDeviceProfileView.swift; sourceTree = "<group>"; };
 		4E7315732D14770E00EA2A95 /* UserProfileHeroImage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserProfileHeroImage.swift; sourceTree = "<group>"; };
 		4E73E2A52C41CFD3002D2A78 /* PlaybackBitrateTestSize.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlaybackBitrateTestSize.swift; sourceTree = "<group>"; };
@@ -4529,6 +4532,7 @@
 				E1E1643928BAC2EF00323B0A /* SearchView.swift */,
 				4EF18B232CB9932F00343666 /* PagingLibraryView */,
 				E164A8122BE4995200A54B18 /* SelectUserView */,
+				4E6EB7E02DB03047009A3D9F /* ServerCheckView.swift */,
 				E193D54F2719430400900D82 /* ServerDetailView.swift */,
 				E1E5D54D2783E66600692DFE /* SettingsView */,
 				E1763A672BF3D168004DF6AB /* UserSignInView */,
@@ -6219,6 +6223,7 @@
 				E1DC9842296DEBD800982F06 /* WatchedIndicator.swift in Sources */,
 				4ECDAA9F2C920A8E0030F2F5 /* TranscodeReason.swift in Sources */,
 				E1575E6C293E77B5001665B1 /* SliderType.swift in Sources */,
+				4E6EB7E22DB030C5009A3D9F /* ServerCheckViewModel.swift in Sources */,
 				E1E2F8402B757DFA00B75998 /* OnFinalDisappearModifier.swift in Sources */,
 				E17DC74B2BE740D900B42379 /* StoredValues+Server.swift in Sources */,
 				4E0253BD2CBF0C06007EB9CD /* DeviceType.swift in Sources */,
@@ -6230,6 +6235,7 @@
 				E43918672AD5C8310045A18C /* OnScenePhaseChangedModifier.swift in Sources */,
 				E154966F296CA2EF00C4EF88 /* LogManager.swift in Sources */,
 				E1575E75293E77B5001665B1 /* LibraryDisplayType.swift in Sources */,
+				4E6EB7E12DB03047009A3D9F /* ServerCheckView.swift in Sources */,
 				E193D53427193F7F00900D82 /* HomeCoordinator.swift in Sources */,
 				E193D5502719430400900D82 /* ServerDetailView.swift in Sources */,
 				4E661A312CEFE7BC00025C99 /* SeriesStatus.swift in Sources */,

--- a/Swiftfin/Resources/Info.plist
+++ b/Swiftfin/Resources/Info.plist
@@ -96,5 +96,7 @@ network.</string>
 		<string>UIInterfaceOrientationLandscapeLeft</string>
 		<string>UIInterfaceOrientationLandscapeRight</string>
 	</array>
+	<key>MinimumJellyfinVersion</key>
+	<string>10.10.0</string>
 </dict>
 </plist>


### PR DESCRIPTION
### Summary

Resolves: https://github.com/jellyfin/Swiftfin/issues/1091

---

**This PR is a starting point but does not fully resolve the issue. If there are folks looking to help out with Swiftfin this would be a great intermediate-level PR to help out. If you are interested in taking this on, please let me know in the comments!Otherwise, I can work on this later down the road.**

---

The goal of this PR is to check the Jellyfin Version and compare it against the current API version we are using for Swiftfin. If the version is too old (or too new!), it should warn the user that their API version might result in a degraded experience. The current version results in an error but I think it should be a warning since *most* APIs aren't going to cause issues between like 10.9 and 10.10 but it's still worth letting the user know without fully blocking usage. If they do run into issues, they will have a warning / alert to give them the first troubleshooting step.

iOS was very simple. I added a check in `ServerCheckViewModel` and throw an error if the Server version is too low.

tvOS there was no `ServerCheckView` so I had to update the coordinator to add one. Because iOS and tvOS have differing coordinators, there isn't a clean way to get to the `SettingsView` from `ServerCheckView`. For now, I've added a `Switch Users` option but I am open to this changing. This was just the easiest route to preventing soft-locking Swiftin on tvOS.

---

### TODO

- [ ] Perform the same check when adding the Jellyfin Server. This data should be available in the [Public Server Info](https://api.jellyfin.org/#tag/System/operation/GetPublicSystemInfo). Have this produce a warning. Allow them to add the server to Swiftfin but alert them that some features may not work correctly.
- [ ] Perform the same check when signing into a Jellyfin User or Switching users. Either should be fine. Basically, when going from `SelectUserView` to `HomeView`, we should be validating that their API version is compliant with Swiftfin.
- [ ] Make a less intrusive UI. Right now, I am using the `ServerCheckView` and fully erroring out using the `ErrorView`. It makes more sense for this to be a non-error view. Instead, just have a `WarningView` on the `ServerCheckView` that says "Your version of Jellyfin is out of date. Some features may not perform correctly." with an `Okay` button. This would require a change to `ServerCheckView` to return a new event for `serverVersionWarning` or something like that.
- [ ] Add a badge to the `SettingsView` or something as a persistent badge that their version version is out of date.
- [ ] Add a route to the `SettingsView` for tvOS instead of just a "Switch Users" option. This should better mirror iOS.
- [ ] General cleanup and localization. This current version is rushed. A final version will need to be localized in the error messages.

---

### Screenshots [WIP]

Both of these are created artificially changing the minimum version. The actual minimum version is 10.10 based on API.

<details>

<summary>tvOS</summary>

![Simulator Screenshot - Apple TV 4K (3rd generation) - 2025-04-16 at 13 14 17](https://github.com/user-attachments/assets/4ef852ea-8fb4-432a-aa14-f1bbe8416fd6)

</details>

<details>

<summary>iOS</summary>

![Simulator Screenshot - iPhone 16 Pro - 2025-04-16 at 11 25 15](https://github.com/user-attachments/assets/16beed1f-10c0-4632-a659-22965f72a0bc)

</details>