### PR TITLE
[iOS & tvOS] Improve rounded corner performance

### DIFF
--- a/Shared/Extensions/ViewExtensions/ViewExtensions.swift
+++ b/Shared/Extensions/ViewExtensions/ViewExtensions.swift
@@ -161,8 +161,13 @@ extension View {
         shadow(radius: 4, y: 2)
     }
 
+    @ViewBuilder
     func cornerRadius(_ radius: CGFloat, corners: UIRectCorner) -> some View {
-        clipShape(RoundedCorner(radius: radius, corners: corners))
+        if corners == .allCorners {
+            clipShape(RoundedRectangle(cornerRadius: radius))
+        } else {
+            clipShape(RoundedCorner(radius: radius, corners: corners))
+        }
     }
 
     /// Apply a corner radius as a ratio of a view's side


### PR DESCRIPTION
Rounding all four corners of a View using a bezier path (which RoundedCorner uses) performs worse than a RoundedRectangle and results in poor performance on screens that have many rounded objects like the home screen or the Moves/Series screens. Note that UnevenRoundedRectangle performs as poorly as RoundedCorner.

In my testing this is more obvious on an iPad with lots of posters visible on screen, but it also causes more subtle hitching on my phone.

Mostly fixes #1110, but the posterShadow effect also contributes to the hitches more subtly.