### PR TITLE
[iOS] Handle interruption notifications

### DIFF
--- a/Shared/Services/Notifications.swift
+++ b/Shared/Services/Notifications.swift
@@ -6,6 +6,7 @@
 // Copyright (c) 2025 Jellyfin & Jellyfin Contributors
 //
 
+import AVFoundation
 import Combine
 import Factory
 import Foundation
@@ -74,6 +75,10 @@ enum Notifications {
 
         func subscribe(_ object: Any, selector: Selector) {
             notificationCenter.addObserver(object, selector: selector, name: name, object: nil)
+        }
+
+        func subscribe(_ object: Any, selector: Selector, observed: Any) {
+            notificationCenter.addObserver(object, selector: selector, name: name, object: observed)
         }
     }
 
@@ -166,6 +171,10 @@ extension Notifications.Key {
 
     static var didStartPlayback: Key<Void> {
         Key("didStartPlayback")
+    }
+
+    static var interruption: Key<Void> {
+        Key(AVAudioSession.interruptionNotification)
     }
 
     // MARK: - UIApplication


### PR DESCRIPTION
Fixes issue #430 where interruptions break the player and causes the app to hang indefinitely. I know there's a big refactor coming in #1203 but if that's not going to be included in the next version or in iOS15, I think it's worth fixing this before then.