### PR TITLE
[iOS & tvOS] Explicitly request transparent logos

### DIFF
--- a/Shared/Extensions/JellyfinAPI/BaseItemDto/BaseItemDto+Images.swift
+++ b/Shared/Extensions/JellyfinAPI/BaseItemDto/BaseItemDto+Images.swift
@@ -101,7 +101,8 @@ extension BaseItemDto {
         let parameters = Paths.GetItemImageParameters(
             maxWidth: scaleWidth,
             maxHeight: scaleHeight,
-            tag: tag
+            tag: tag,
+            format: type == .logo ? .png : nil
         )
 
         let request = Paths.getItemImage(


### PR DESCRIPTION
Fixes #1240. Currently with Jellyfin's API, logos that are stored as SVG's on the server are served as non-transparent jpegs unless we explicitly request a transparent format like webp.

Using png since I see no indication that tvOS supports webp.