### PR TITLE
[iOS] Preserve vector data in preview app icons

### DIFF
--- a/Swiftfin/Resources/Assets.xcassets/AppIcon-dark-blue.imageset/Contents.json
+++ b/Swiftfin/Resources/Assets.xcassets/AppIcon-dark-blue.imageset/Contents.json
@@ -8,5 +8,8 @@
   "info" : {
     "author" : "xcode",
     "version" : 1
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/Swiftfin/Resources/Assets.xcassets/AppIcon-dark-green.imageset/Contents.json
+++ b/Swiftfin/Resources/Assets.xcassets/AppIcon-dark-green.imageset/Contents.json
@@ -8,5 +8,8 @@
   "info" : {
     "author" : "xcode",
     "version" : 1
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/Swiftfin/Resources/Assets.xcassets/AppIcon-dark-jellyfin.imageset/Contents.json
+++ b/Swiftfin/Resources/Assets.xcassets/AppIcon-dark-jellyfin.imageset/Contents.json
@@ -8,5 +8,8 @@
   "info" : {
     "author" : "xcode",
     "version" : 1
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/Swiftfin/Resources/Assets.xcassets/AppIcon-dark-orange.imageset/Contents.json
+++ b/Swiftfin/Resources/Assets.xcassets/AppIcon-dark-orange.imageset/Contents.json
@@ -8,5 +8,8 @@
   "info" : {
     "author" : "xcode",
     "version" : 1
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/Swiftfin/Resources/Assets.xcassets/AppIcon-dark-red.imageset/Contents.json
+++ b/Swiftfin/Resources/Assets.xcassets/AppIcon-dark-red.imageset/Contents.json
@@ -8,5 +8,8 @@
   "info" : {
     "author" : "xcode",
     "version" : 1
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/Swiftfin/Resources/Assets.xcassets/AppIcon-dark-yellow.imageset/Contents.json
+++ b/Swiftfin/Resources/Assets.xcassets/AppIcon-dark-yellow.imageset/Contents.json
@@ -8,5 +8,8 @@
   "info" : {
     "author" : "xcode",
     "version" : 1
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/Swiftfin/Resources/Assets.xcassets/AppIcon-invertedDark-blue.imageset/Contents.json
+++ b/Swiftfin/Resources/Assets.xcassets/AppIcon-invertedDark-blue.imageset/Contents.json
@@ -8,5 +8,8 @@
   "info" : {
     "author" : "xcode",
     "version" : 1
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/Swiftfin/Resources/Assets.xcassets/AppIcon-invertedDark-green.imageset/Contents.json
+++ b/Swiftfin/Resources/Assets.xcassets/AppIcon-invertedDark-green.imageset/Contents.json
@@ -8,5 +8,8 @@
   "info" : {
     "author" : "xcode",
     "version" : 1
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/Swiftfin/Resources/Assets.xcassets/AppIcon-invertedDark-jellyfin.imageset/Contents.json
+++ b/Swiftfin/Resources/Assets.xcassets/AppIcon-invertedDark-jellyfin.imageset/Contents.json
@@ -8,5 +8,8 @@
   "info" : {
     "author" : "xcode",
     "version" : 1
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/Swiftfin/Resources/Assets.xcassets/AppIcon-invertedDark-orange.imageset/Contents.json
+++ b/Swiftfin/Resources/Assets.xcassets/AppIcon-invertedDark-orange.imageset/Contents.json
@@ -8,5 +8,8 @@
   "info" : {
     "author" : "xcode",
     "version" : 1
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/Swiftfin/Resources/Assets.xcassets/AppIcon-invertedDark-red.imageset/Contents.json
+++ b/Swiftfin/Resources/Assets.xcassets/AppIcon-invertedDark-red.imageset/Contents.json
@@ -8,5 +8,8 @@
   "info" : {
     "author" : "xcode",
     "version" : 1
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/Swiftfin/Resources/Assets.xcassets/AppIcon-invertedDark-yellow.imageset/Contents.json
+++ b/Swiftfin/Resources/Assets.xcassets/AppIcon-invertedDark-yellow.imageset/Contents.json
@@ -8,5 +8,8 @@
   "info" : {
     "author" : "xcode",
     "version" : 1
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/Swiftfin/Resources/Assets.xcassets/AppIcon-invertedLight-blue.imageset/Contents.json
+++ b/Swiftfin/Resources/Assets.xcassets/AppIcon-invertedLight-blue.imageset/Contents.json
@@ -8,5 +8,8 @@
   "info" : {
     "author" : "xcode",
     "version" : 1
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/Swiftfin/Resources/Assets.xcassets/AppIcon-invertedLight-green.imageset/Contents.json
+++ b/Swiftfin/Resources/Assets.xcassets/AppIcon-invertedLight-green.imageset/Contents.json
@@ -8,5 +8,8 @@
   "info" : {
     "author" : "xcode",
     "version" : 1
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/Swiftfin/Resources/Assets.xcassets/AppIcon-invertedLight-jellyfin.imageset/Contents.json
+++ b/Swiftfin/Resources/Assets.xcassets/AppIcon-invertedLight-jellyfin.imageset/Contents.json
@@ -8,5 +8,8 @@
   "info" : {
     "author" : "xcode",
     "version" : 1
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/Swiftfin/Resources/Assets.xcassets/AppIcon-invertedLight-orange.imageset/Contents.json
+++ b/Swiftfin/Resources/Assets.xcassets/AppIcon-invertedLight-orange.imageset/Contents.json
@@ -8,5 +8,8 @@
   "info" : {
     "author" : "xcode",
     "version" : 1
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/Swiftfin/Resources/Assets.xcassets/AppIcon-invertedLight-red.imageset/Contents.json
+++ b/Swiftfin/Resources/Assets.xcassets/AppIcon-invertedLight-red.imageset/Contents.json
@@ -8,5 +8,8 @@
   "info" : {
     "author" : "xcode",
     "version" : 1
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/Swiftfin/Resources/Assets.xcassets/AppIcon-invertedLight-yellow.imageset/Contents.json
+++ b/Swiftfin/Resources/Assets.xcassets/AppIcon-invertedLight-yellow.imageset/Contents.json
@@ -8,5 +8,8 @@
   "info" : {
     "author" : "xcode",
     "version" : 1
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/Swiftfin/Resources/Assets.xcassets/AppIcon-light-blue.imageset/Contents.json
+++ b/Swiftfin/Resources/Assets.xcassets/AppIcon-light-blue.imageset/Contents.json
@@ -8,5 +8,8 @@
   "info" : {
     "author" : "xcode",
     "version" : 1
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/Swiftfin/Resources/Assets.xcassets/AppIcon-light-green.imageset/Contents.json
+++ b/Swiftfin/Resources/Assets.xcassets/AppIcon-light-green.imageset/Contents.json
@@ -8,5 +8,8 @@
   "info" : {
     "author" : "xcode",
     "version" : 1
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/Swiftfin/Resources/Assets.xcassets/AppIcon-light-jellyfin.imageset/Contents.json
+++ b/Swiftfin/Resources/Assets.xcassets/AppIcon-light-jellyfin.imageset/Contents.json
@@ -8,5 +8,8 @@
   "info" : {
     "author" : "xcode",
     "version" : 1
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/Swiftfin/Resources/Assets.xcassets/AppIcon-light-orange.imageset/Contents.json
+++ b/Swiftfin/Resources/Assets.xcassets/AppIcon-light-orange.imageset/Contents.json
@@ -8,5 +8,8 @@
   "info" : {
     "author" : "xcode",
     "version" : 1
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/Swiftfin/Resources/Assets.xcassets/AppIcon-light-red.imageset/Contents.json
+++ b/Swiftfin/Resources/Assets.xcassets/AppIcon-light-red.imageset/Contents.json
@@ -8,5 +8,8 @@
   "info" : {
     "author" : "xcode",
     "version" : 1
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/Swiftfin/Resources/Assets.xcassets/AppIcon-light-yellow.imageset/Contents.json
+++ b/Swiftfin/Resources/Assets.xcassets/AppIcon-light-yellow.imageset/Contents.json
@@ -8,5 +8,8 @@
   "info" : {
     "author" : "xcode",
     "version" : 1
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/Swiftfin/Resources/Assets.xcassets/AppIcon-primary-primary.imageset/Contents.json
+++ b/Swiftfin/Resources/Assets.xcassets/AppIcon-primary-primary.imageset/Contents.json
@@ -8,5 +8,8 @@
   "info" : {
     "author" : "xcode",
     "version" : 1
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }


### PR DESCRIPTION
Fixes #1516

Other vector graphics already has this property set, but the icons used in the icon selector didn't

After & Before:
![iconinterp](https://github.com/user-attachments/assets/cd4f1870-0d96-4ba2-976f-c51b1d96f59f)
