### PR TITLE
[tvOS] Fix Next Up Overlapping with TabBar

### DIFF
--- a/Swiftfin tvOS/Views/HomeView/HomeView.swift
+++ b/Swiftfin tvOS/Views/HomeView/HomeView.swift
@@ -39,7 +39,9 @@ struct HomeView: View {
                     if showRecentlyAdded {
                         CinematicRecentlyAddedView(viewModel: viewModel.recentlyAddedViewModel)
                     }
+
                     NextUpView(viewModel: viewModel.nextUpViewModel)
+                        .safeAreaPadding(.top, 150)
                 }
 
                 ForEach(viewModel.libraries) { viewModel in


### PR DESCRIPTION
The issue here is that the ZStack has `.ignoresSafeArea()` which allows for the CinematicResumeView to overlap with the TabBar but if there is no CinematicResumeView then ignoring the safe area allows the NextUpView to move all of the way up to the top edge. The fix here is to simply apply `.safeAreaPadding()` when there is no CinematicResumeView.

I had considered the possibility of adding this to the PosterHStack inside of `NextUpView` but decided this is most likely a one-off issue so a one-off solution will suffice.

The value here is rather arbitrary so there is very likely a better/more dynamic way at determining the amount, I was originally thinking of using GeometryReader but I made the mistake of not taking notes and have now forgotten the idea I had :/

>[!NOTE]
>This issue occurs whether the posters are portrait or landscape

<img width="808" alt="Screenshot 2025-04-26 at 3 23 42 PM" src="https://github.com/user-attachments/assets/45672583-2083-4684-9bc0-2174f0d39362" />

closes #1479 