### PR TITLE
[tvOS] Select button now pauses/plays

### DIFF
--- a/Swiftfin tvOS/Views/VideoPlayer/Overlays/Overlay.swift
+++ b/Swiftfin tvOS/Views/VideoPlayer/Overlays/Overlay.swift
@@ -91,7 +91,21 @@ extension VideoPlayer {
                     PressCommandAction(title: L10n.pressDownForMenu, press: .downArrow, action: arrowPress)
                     PressCommandAction(title: L10n.pressDownForMenu, press: .leftArrow, action: arrowPress)
                     PressCommandAction(title: L10n.pressDownForMenu, press: .rightArrow, action: arrowPress)
-                    PressCommandAction(title: L10n.pressDownForMenu, press: .select, action: arrowPress)
+                    PressCommandAction(title: L10n.pressDownForMenu, press: .select) {
+                        if videoPlayerManager.state == .playing {
+                            videoPlayerManager.proxy.pause()
+                        } else if videoPlayerManager.state == .paused {
+                            videoPlayerManager.proxy.play()
+                        }
+
+                        if !isPresentingOverlay {
+                            currentOverlayType = .main
+                            overlayTimer.start(5)
+                            withAnimation {
+                                isPresentingOverlay = true
+                            }
+                        }
+                    }
                 }
         }
 


### PR DESCRIPTION
Fixes issue #1229 

This PR modified the select button handling to pause/play content while still displaying the overlay.
I think this behaviour is more in line with what other tvOS apps normally do. 
I tested this on Apple TV 4K via both the iOS app remote and LG Magic remote. 