### PR TITLE
Formatting overview label for HTML elements

### DIFF
--- a/Shared/Extensions/JellyfinAPI/BaseItemDto/BaseItemDto.swift
+++ b/Shared/Extensions/JellyfinAPI/BaseItemDto/BaseItemDto.swift
@@ -273,4 +273,33 @@ extension BaseItemDto {
             nil
         }
     }
+
+    var formattedOverview: AttributedString? {
+        guard let overview else { return nil }
+        guard let data = overview.data(using: .utf8) else { return nil }
+
+        do {
+            let mutableAttributedString = try NSMutableAttributedString(
+                data: data,
+                options: [
+                    .documentType: NSAttributedString.DocumentType.html,
+                    .characterEncoding: String.Encoding.utf8.rawValue,
+                ],
+                documentAttributes: nil
+            )
+
+            // Remove font attributes from the entire range
+            let fullRange = NSRange(location: 0, length: mutableAttributedString.length)
+            mutableAttributedString.removeAttribute(.font, range: fullRange)
+
+            return AttributedString(mutableAttributedString)
+        } catch {
+            return nil
+        }
+    }
+
+    var cleanedOverview: String? {
+        guard let overview else { return nil }
+        return overview.replacingOccurrences(of: "<[^>]+>", with: "", options: .regularExpression)
+    }
 }

--- a/Swiftfin tvOS/Views/ItemOverviewView.swift
+++ b/Swiftfin tvOS/Views/ItemOverviewView.swift
@@ -29,8 +29,12 @@ struct ItemOverviewView: View {
                             .multilineTextAlignment(.leading)
                     }
 
-                    if let overview = item.overview {
-                        Text(overview)
+                    if let itemOverview = item.overview {
+                        if let formattedOverview = item.formattedOverview {
+                            Text(formattedOverview)
+                        } else {
+                            Text(itemOverview)
+                        }
                     }
                 }
             }

--- a/Swiftfin tvOS/Views/ItemView/Components/AboutView/Components/OverviewCard.swift
+++ b/Swiftfin tvOS/Views/ItemView/Components/AboutView/Components/OverviewCard.swift
@@ -21,7 +21,7 @@ extension ItemView.AboutView {
         var body: some View {
             Card(title: item.displayTitle)
                 .content {
-                    TruncatedText(item.overview ?? L10n.noOverviewAvailable)
+                    TruncatedText(item.cleanedOverview ?? L10n.noOverviewAvailable)
                         .font(.subheadline)
                         .lineLimit(4)
                 }

--- a/Swiftfin tvOS/Views/ItemView/EpisodeItemView/EpisodeItemContentView.swift
+++ b/Swiftfin tvOS/Views/ItemView/EpisodeItemView/EpisodeItemContentView.swift
@@ -96,8 +96,8 @@ extension EpisodeItemView.ContentView {
                             .multilineTextAlignment(.leading)
                             .foregroundColor(.white)
 
-                        if let overview = viewModel.item.overview {
-                            Text(overview)
+                        if let cleanedOverview = viewModel.item.cleanedOverview {
+                            Text(cleanedOverview)
                                 .font(.subheadline)
                                 .lineLimit(3)
                         } else {

--- a/Swiftfin tvOS/Views/ItemView/ScrollViews/CinematicScrollView.swift
+++ b/Swiftfin tvOS/Views/ItemView/ScrollViews/CinematicScrollView.swift
@@ -90,7 +90,7 @@ extension ItemView {
                                 .lineLimit(1)
                         }
 
-                        Text(viewModel.item.overview ?? L10n.noOverviewAvailable)
+                        Text(viewModel.item.cleanedOverview ?? L10n.noOverviewAvailable)
                             .font(.subheadline)
                             .lineLimit(3)
 

--- a/Swiftfin/Views/ItemOverviewView.swift
+++ b/Swiftfin/Views/ItemOverviewView.swift
@@ -28,9 +28,15 @@ struct ItemOverviewView: View {
                 }
 
                 if let itemOverview = item.overview {
-                    Text(itemOverview)
-                        .font(.body)
-                        .multilineTextAlignment(.leading)
+                    if let formattedOverview = item.formattedOverview {
+                        Text(formattedOverview)
+                            .font(.body)
+                            .multilineTextAlignment(.leading)
+                    } else {
+                        Text(itemOverview)
+                            .font(.body)
+                            .multilineTextAlignment(.leading)
+                    }
                 }
             }
             .frame(maxWidth: .infinity, alignment: .leading)

--- a/Swiftfin/Views/ItemView/Components/AboutView/Components/OverviewCard.swift
+++ b/Swiftfin/Views/ItemView/Components/AboutView/Components/OverviewCard.swift
@@ -21,8 +21,8 @@ extension ItemView.AboutView {
         var body: some View {
             Card(title: item.displayTitle, subtitle: item.alternateTitle)
                 .content {
-                    if let overview = item.overview {
-                        TruncatedText(overview)
+                    if let cleanedOverview = item.cleanedOverview {
+                        TruncatedText(cleanedOverview)
                             .lineLimit(4)
                             .font(.footnote)
                             .allowsHitTesting(false)

--- a/Swiftfin/Views/ItemView/Components/OverviewView.swift
+++ b/Swiftfin/Views/ItemView/Components/OverviewView.swift
@@ -31,8 +31,8 @@ extension ItemView {
                         .lineLimit(taglineLineLimit)
                 }
 
-                if let itemOverview = item.overview {
-                    TruncatedText(itemOverview)
+                if let cleanedOverview = item.cleanedOverview {
+                    TruncatedText(cleanedOverview)
                         .onSeeMore {
                             router.route(to: \.itemOverview, item)
                         }


### PR DESCRIPTION
Resolves(?): https://github.com/jellyfin/Swiftfin/issues/1537

## ✅ Proposed Fix (via PR)
### 🔧 The fix includes two strategies:

1. **Sanitize (Remove HTML Tags)**  
   - For areas where clean, plain text is preferred — like truncated labels or condensed views — we simply strip HTML tags.  
   - This ensures no layout breaks and provides a more readable summary.

2. **Render as `AttributedString` (Rich Text Display)**  
   - In areas where there's more space (like full overview popups), we convert the HTML into an `AttributedString`.  
   - This preserves formatting like line breaks, italics, etc., giving a richer and more faithful display of the original metadata.

---

## ✨ Benefits

- Cleaner, more professional UI  
- Preserves intent of metadata providers when space allows  
- Prevents broken or ugly HTML from leaking into user-facing views

## ✨ Screenshots of fix:
![Simulator Screenshot - iPhone 16 Pro - 2025-05-14 at 18 26 33](https://github.com/user-attachments/assets/cf9d77a1-a5ab-4695-b7c6-c66e3d00ccba)
85)
![Simulator Screenshot - iPhone 16 Pro - 2025-05-14 at 18 26 39](https://github.com/user-attachments/assets/6894733e-b87f-4ec6-8d48-dc00389760ab)
