### PR TITLE
optimize: Send media source id to playback info

### DIFF
--- a/Shared/Extensions/JellyfinAPI/BaseItemDto/BaseItemDto+VideoPlayerViewModel.swift
+++ b/Shared/Extensions/JellyfinAPI/BaseItemDto/BaseItemDto+VideoPlayerViewModel.swift
@@ -32,7 +32,8 @@ extension BaseItemDto {
         let playbackInfo = PlaybackInfoDto(deviceProfile: profile)
         let playbackInfoParameters = Paths.GetPostedPlaybackInfoParameters(
             userID: userSession.user.id,
-            maxStreamingBitrate: maxBitrate
+            maxStreamingBitrate: maxBitrate,
+            mediaSourceID: mediaSource.id
         )
 
         let request = Paths.getPostedPlaybackInfo(


### PR DESCRIPTION
Jellyfin accepts the media source id. This way the return body will only include that source.

Smaller response body and massive speed gains if the sources are remote like a strm file because those files probe on playback info not when scanning

I kept the source matching on the response just in case an old server version doesn’t support it