### PR TITLE
Reverting to VLCKit 3.5.0 | solving OPUS issue

### DIFF
--- a/Cartfile
+++ b/Cartfile
@@ -1,3 +1,3 @@
-binary "https://code.videolan.org/videolan/VLCKit/raw/master/Packaging/MobileVLCKit.json" == 3.6.0
-binary "https://code.videolan.org/videolan/VLCKit/raw/master/Packaging/TVVLCKit.json" == 3.6.0
+binary "https://code.videolan.org/videolan/VLCKit/raw/master/Packaging/MobileVLCKit.json" == 3.5.0
+binary "https://code.videolan.org/videolan/VLCKit/raw/master/Packaging/TVVLCKit.json" == 3.5.0
 # binary "ChromeCastFramework.json"  


### PR DESCRIPTION
Had issue with OPUS codec, due to regression in VLCKit 3.6.0.