### PR TITLE
Cinematic Episode Image

### DIFF
--- a/Swiftfin tvOS/Views/ItemView/ScrollViews/CinematicScrollView.swift
+++ b/Swiftfin tvOS/Views/ItemView/ScrollViews/CinematicScrollView.swift
@@ -20,12 +20,7 @@ extension ItemView {
 
         var body: some View {
             ZStack {
-                // Use the Image Backdrop if provided. Otherwise, use the Series Backdrop.
-                if viewModel.item.type == .episode && viewModel.item.backdropImageTags == [] {
-                    ImageView(viewModel.item.seriesImageSource(.backdrop, maxWidth: 1920))
-                } else {
-                    ImageView(viewModel.item.imageSource(.backdrop, maxWidth: 1920))
-                }
+                ImageView(viewModel.item.imageSource(.backdrop, maxWidth: 1920))
 
                 ScrollView(.vertical, showsIndicators: false) {
                     content()

--- a/Swiftfin tvOS/Views/ItemView/ScrollViews/CinematicScrollView.swift
+++ b/Swiftfin tvOS/Views/ItemView/ScrollViews/CinematicScrollView.swift
@@ -20,7 +20,11 @@ extension ItemView {
 
         var body: some View {
             ZStack {
-                ImageView(viewModel.item.imageSource(.backdrop, maxWidth: 1920))
+                if viewModel.item.type == .episode {
+                    ImageView(viewModel.item.imageSource(.primary, maxWidth: 1920))
+                } else {
+                    ImageView(viewModel.item.imageSource(.backdrop, maxWidth: 1920))
+                }
 
                 ScrollView(.vertical, showsIndicators: false) {
                     content()

--- a/Swiftfin tvOS/Views/ItemView/ScrollViews/CinematicScrollView.swift
+++ b/Swiftfin tvOS/Views/ItemView/ScrollViews/CinematicScrollView.swift
@@ -20,8 +20,9 @@ extension ItemView {
 
         var body: some View {
             ZStack {
-                if viewModel.item.type == .episode {
-                    ImageView(viewModel.item.imageSource(.primary, maxWidth: 1920))
+                // Use the Image Backdrop if provided. Otherwise, use the Series Backdrop.
+                if viewModel.item.type == .episode && viewModel.item.backdropImageTags == [] {
+                    ImageView(viewModel.item.seriesImageSource(.backdrop, maxWidth: 1920))
                 } else {
                     ImageView(viewModel.item.imageSource(.backdrop, maxWidth: 1920))
                 }

--- a/Swiftfin/Views/ItemView/ScrollViews/iPadOSCinematicScrollView.swift
+++ b/Swiftfin/Views/ItemView/ScrollViews/iPadOSCinematicScrollView.swift
@@ -48,8 +48,14 @@ extension ItemView {
             OffsetScrollView(
                 headerHeight: globalSize.isLandscape ? 0.75 : 0.6
             ) {
-                ImageView(viewModel.item.imageSource(.backdrop, maxWidth: 1920))
-                    .aspectRatio(1.77, contentMode: .fill)
+                // Use the Image Backdrop if provided. Otherwise, use the Series Backdrop.
+                if viewModel.item.type == .episode && viewModel.item.backdropImageTags == [] {
+                    ImageView(viewModel.item.seriesImageSource(.backdrop, maxWidth: 1920))
+                        .aspectRatio(1.77, contentMode: .fill)
+                } else {
+                    ImageView(viewModel.item.imageSource(.backdrop, maxWidth: 1920))
+                        .aspectRatio(1.77, contentMode: .fill)
+                }
             } overlay: {
                 VStack(spacing: 0) {
                     Spacer()

--- a/Swiftfin/Views/ItemView/ScrollViews/iPadOSCinematicScrollView.swift
+++ b/Swiftfin/Views/ItemView/ScrollViews/iPadOSCinematicScrollView.swift
@@ -48,14 +48,8 @@ extension ItemView {
             OffsetScrollView(
                 headerHeight: globalSize.isLandscape ? 0.75 : 0.6
             ) {
-                // Use the Image Backdrop if provided. Otherwise, use the Series Backdrop.
-                if viewModel.item.type == .episode && viewModel.item.backdropImageTags == [] {
-                    ImageView(viewModel.item.seriesImageSource(.backdrop, maxWidth: 1920))
-                        .aspectRatio(1.77, contentMode: .fill)
-                } else {
-                    ImageView(viewModel.item.imageSource(.backdrop, maxWidth: 1920))
-                        .aspectRatio(1.77, contentMode: .fill)
-                }
+                ImageView(viewModel.item.imageSource(imageType, maxWidth: 1920))
+                    .aspectRatio(1.77, contentMode: .fill)
             } overlay: {
                 VStack(spacing: 0) {
                     Spacer()


### PR DESCRIPTION
### Summary

After [1543](https://github.com/jellyfin/Swiftfin/pull/1543), the Cinematic view on iPadOS was using the Episode Backdrop. It looks like most metadata providers for episodes don't provide backdrops so this always fails and falls back to `EmptyView()`. Similar to how we handle collection and [their more limited metadata](https://github.com/jellyfin/Swiftfin/pull/1543#issuecomment-2895493278). Just in case someone has a manual backdrop added, I have this PR do the following:

1. If the item is both an episode and does not contain a backdrop image, use the series backdrop image.
2. If the item is either a non-episode or *does* contain a backdrop image, use the item's backdrop image.

I've update this same logic on tvOS so this is consistent between the environments.