### PR TITLE
Cast & Crew Fix

### DIFF
--- a/Shared/Extensions/JellyfinAPI/BaseItemDto/BaseItemDto+LibraryParent.swift
+++ b/Shared/Extensions/JellyfinAPI/BaseItemDto/BaseItemDto+LibraryParent.swift
@@ -33,7 +33,7 @@ extension BaseItemDto: LibraryParent {
     }
 
     var isRecursiveCollection: Bool {
-        if let collectionType, [CollectionType.tvshows, CollectionType.boxsets].contains(collectionType) {
+        if let collectionType, [.tvshows, .boxsets].contains(collectionType) {
             return false
         }
         return true

--- a/Shared/ViewModels/LibraryViewModel/ItemLibraryViewModel.swift
+++ b/Shared/ViewModels/LibraryViewModel/ItemLibraryViewModel.swift
@@ -62,7 +62,7 @@ final class ItemLibraryViewModel: PagingLibraryViewModel<BaseItemDto> {
         parameters.sortBy = [ItemSortBy.name.rawValue]
 
         /// Recursive should only apply to parents/folders and not to baseItems
-        parameters.isRecursive = (parent as? BaseItemDto)?.isRecursiveCollection ?? false
+        parameters.isRecursive = (parent as? BaseItemDto)?.isRecursiveCollection ?? true
 
         // Parent
         if let parent {


### PR DESCRIPTION
### Summary

Resolves: https://github.com/jellyfin/Swiftfin/issues/1557

Prior to #1495, we defaulted to Recursive for everything. After #1495, we default to Recursive false unless we can validate it's a `BaseItemDto` and not a `tvShow` or `collection`. The reason this causes issues is that selecting a cast member is not a `BaseItemDto` but a `BaseItemPerson` so this casting fails and, instead of defaulting to true it would default to false.

### Issue (Now Resolved in this PR)

https://github.com/user-attachments/assets/01f10f53-4cd1-47f1-aced-53f25a9de27a