### PR TITLE
Fix `release.yml` labels

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -7,7 +7,7 @@ changelog:
   categories:
     - title: New Features 🎉
       labels:
-        - *
+        - "*"
     - title: Bug Fixes 🛠
       labels:
         - bug


### PR DESCRIPTION
For 1.3 generated release notes, fix syntax.