### PR TITLE
Cleanup `ParentalRating` Usage

### DIFF
--- a/Shared/Components/Localization/ParentalRatingPicker.swift
+++ b/Shared/Components/Localization/ParentalRatingPicker.swift
@@ -1,0 +1,124 @@
+//
+// Swiftfin is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, you can obtain one at https://mozilla.org/MPL/2.0/.
+//
+// Copyright (c) 2025 Jellyfin & Jellyfin Contributors
+//
+
+import JellyfinAPI
+import SwiftUI
+
+struct ParentalRatingPicker: View {
+
+    // MARK: - State Objects
+
+    @StateObject
+    private var viewModel: ParentalRatingsViewModel
+
+    // MARK: - Input Properties
+
+    private var selectionBinding: Binding<ParentalRating?>
+    private let title: String
+
+    @State
+    private var selection: ParentalRating?
+
+    // MARK: - Body
+
+    var body: some View {
+        Group {
+            #if os(tvOS)
+            ListRowMenu(title, subtitle: selection?.name ?? L10n.none) {
+                Picker(title, selection: $selection) {
+                    Text(L10n.none)
+                        .tag(nil as ParentalRating?)
+
+                    ForEach(viewModel.value, id: \.self) { value in
+                        Text(value.name ?? L10n.unknown)
+                            .tag(value as ParentalRating?)
+                    }
+                }
+            }
+            .onChange(of: viewModel.value) {
+                updateSelection()
+            }
+            .onChange(of: selection) { _, newValue in
+                selectionBinding.wrappedValue = newValue
+            }
+            .menuStyle(.borderlessButton)
+            .listRowInsets(.zero)
+            #else
+            Picker(title, selection: $selection) {
+
+                Text(L10n.none)
+                    .tag(nil as ParentalRating?)
+
+                ForEach(viewModel.value, id: \.self) { value in
+                    Text(value.name ?? L10n.unknown)
+                        .tag(value as ParentalRating?)
+                }
+            }
+            .onChange(of: viewModel.value) { _ in
+                updateSelection()
+            }
+            .onChange(of: selection) { newValue in
+                selectionBinding.wrappedValue = newValue
+            }
+            #endif
+        }
+        .onFirstAppear {
+            viewModel.send(.refresh)
+        }
+        .onAppear {
+            updateSelection()
+        }
+    }
+
+    // MARK: - Update Selection
+
+    private func updateSelection() {
+        let newValue = viewModel.value.first { value in
+            if let selectedName = selection?.name,
+               let candidateName = value.name,
+               selectedName == candidateName
+            {
+                return true
+            }
+            return false
+        }
+
+        selection = newValue
+    }
+}
+
+// MARK: - Initializers
+
+extension ParentalRatingPicker {
+
+    init(_ title: String, selection: Binding<ParentalRating?>) {
+        self.title = title
+        self._selection = State(initialValue: selection.wrappedValue)
+        self.selectionBinding = selection
+        self._viewModel = StateObject(wrappedValue: ParentalRatingsViewModel(initialValue: []))
+    }
+
+    init(_ title: String, selection: Binding<String?>) {
+        self.title = title
+        self._selection = State(
+            initialValue: selection.wrappedValue.flatMap { ParentalRating(name: $0) }
+        )
+
+        self.selectionBinding = Binding<ParentalRating?>(
+            get: {
+                guard let ratingName = selection.wrappedValue else { return nil }
+                return ParentalRating(name: ratingName)
+            },
+            set: { newRating in
+                selection.wrappedValue = newRating?.name
+            }
+        )
+
+        self._viewModel = StateObject(wrappedValue: ParentalRatingsViewModel(initialValue: []))
+    }
+}

--- a/Shared/Extensions/JellyfinAPI/ParentalRating.swift
+++ b/Shared/Extensions/JellyfinAPI/ParentalRating.swift
@@ -9,6 +9,21 @@
 import Foundation
 import JellyfinAPI
 
+extension ParentalRating: Displayable {
+
+    var displayTitle: String {
+        self.name ?? L10n.unknown
+    }
+
+    static var none: ParentalRating {
+        ParentalRating(
+            name: L10n.none,
+            value: nil
+        )
+    }
+}
+
+// TODO: I don't think this is a ParentalRating?
 extension UnratedItem: Displayable {
 
     var displayTitle: String {

--- a/Swiftfin.xcodeproj/project.pbxproj
+++ b/Swiftfin.xcodeproj/project.pbxproj
@@ -86,6 +86,8 @@
 		4E35CE6C2CBEDB7600DBD886 /* TaskState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4E35CE6B2CBEDB7300DBD886 /* TaskState.swift */; };
 		4E35CE6D2CBEDB7600DBD886 /* TaskState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4E35CE6B2CBEDB7300DBD886 /* TaskState.swift */; };
 		4E36395C2CC4DF0E00110EBC /* APIKeysViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4E36395A2CC4DF0900110EBC /* APIKeysViewModel.swift */; };
+		4E36FAE62DFC96A70054B2B2 /* ParentalRatingPicker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4E36FAE52DFC96A70054B2B2 /* ParentalRatingPicker.swift */; };
+		4E36FAE72DFC96A70054B2B2 /* ParentalRatingPicker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4E36FAE52DFC96A70054B2B2 /* ParentalRatingPicker.swift */; };
 		4E37F6162D17C1860022AADD /* RemoteImageInfoViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4E37F6152D17C1710022AADD /* RemoteImageInfoViewModel.swift */; };
 		4E3A24DA2CFE34A00083A72C /* SearchResultsSection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4E3A24D92CFE349A0083A72C /* SearchResultsSection.swift */; };
 		4E3A24DC2CFE35D50083A72C /* NameInput.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4E3A24DB2CFE35CC0083A72C /* NameInput.swift */; };
@@ -1348,6 +1350,7 @@
 		4E35CE682CBED95F00DBD886 /* DayOfWeek.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DayOfWeek.swift; sourceTree = "<group>"; };
 		4E35CE6B2CBEDB7300DBD886 /* TaskState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TaskState.swift; sourceTree = "<group>"; };
 		4E36395A2CC4DF0900110EBC /* APIKeysViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APIKeysViewModel.swift; sourceTree = "<group>"; };
+		4E36FAE52DFC96A70054B2B2 /* ParentalRatingPicker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ParentalRatingPicker.swift; sourceTree = "<group>"; };
 		4E37F6152D17C1710022AADD /* RemoteImageInfoViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteImageInfoViewModel.swift; sourceTree = "<group>"; };
 		4E3A24D92CFE349A0083A72C /* SearchResultsSection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchResultsSection.swift; sourceTree = "<group>"; };
 		4E3A24DB2CFE35CC0083A72C /* NameInput.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NameInput.swift; sourceTree = "<group>"; };
@@ -2744,6 +2747,7 @@
 			children = (
 				4E661A242CEFE64200025C99 /* CountryPicker.swift */,
 				4E661A262CEFE64D00025C99 /* CulturePicker.swift */,
+				4E36FAE52DFC96A70054B2B2 /* ParentalRatingPicker.swift */,
 			);
 			path = Localization;
 			sourceTree = "<group>";
@@ -6082,6 +6086,7 @@
 				4E8274F52D2ECF1900F5E610 /* UserProfileSettingsCoordinator.swift in Sources */,
 				4E7BEBE82DA8546800F66F8D /* CountriesViewModel.swift in Sources */,
 				4E9654482D99C553006CB024 /* CollectionType.swift in Sources */,
+				4E36FAE72DFC96A70054B2B2 /* ParentalRatingPicker.swift in Sources */,
 				E178859B2780F1F40094FBCF /* tvOSSlider.swift in Sources */,
 				E103DF952BCF31CD000229B2 /* MediaItem.swift in Sources */,
 				E1ED91192B95993300802036 /* TitledLibraryParent.swift in Sources */,
@@ -6823,6 +6828,7 @@
 				E1BDF2F529524E6400CC0294 /* PlayNextItemActionButton.swift in Sources */,
 				BD3957772C112AD30078CEF8 /* SliderSection.swift in Sources */,
 				E14EA1692BF7330A00DE757A /* UserProfileImageViewModel.swift in Sources */,
+				4E36FAE62DFC96A70054B2B2 /* ParentalRatingPicker.swift in Sources */,
 				4EB1A8CE2C9B2D0800F43898 /* ActiveSessionRow.swift in Sources */,
 				E1D5C39B28DF993400CDBEFB /* ThumbSlider.swift in Sources */,
 				E1DD95CD2D07876400335494 /* SeparatorVStack.swift in Sources */,

--- a/Swiftfin/Views/AdminDashboardView/ServerUsers/ServerUserSettings/ServerUserParentalRatingView/ServerUserParentalRatingView.swift
+++ b/Swiftfin/Views/AdminDashboardView/ServerUsers/ServerUserSettings/ServerUserParentalRatingView/ServerUserParentalRatingView.swift
@@ -19,8 +19,8 @@ struct ServerUserParentalRatingView: View {
 
     @StateObject
     private var viewModel: ServerUserAdminViewModel
-    @ObservedObject
-    private var parentalRatingsViewModel = ParentalRatingsViewModel()
+    @StateObject
+    private var parentalRatingsViewModel: ParentalRatingsViewModel
 
     // MARK: - Policy Variable
 
@@ -36,6 +36,7 @@ struct ServerUserParentalRatingView: View {
 
     init(viewModel: ServerUserAdminViewModel) {
         self._viewModel = StateObject(wrappedValue: viewModel)
+        self._parentalRatingsViewModel = StateObject(wrappedValue: ParentalRatingsViewModel(initialValue: []))
 
         guard let policy = viewModel.user.policy else {
             preconditionFailure("User policy cannot be empty.")
@@ -139,7 +140,7 @@ struct ServerUserParentalRatingView: View {
 
     private var parentalRatingGroups: [ParentalRating] {
         let groups = Dictionary(
-            grouping: parentalRatingsViewModel.parentalRatings
+            grouping: parentalRatingsViewModel.value
         ) {
             $0.value ?? 0
         }
@@ -152,7 +153,6 @@ struct ServerUserParentalRatingView: View {
                     return ParentalRating(name: L10n.agesGroup(key), value: key)
                 }
             } else {
-                // Concatenate all 100+ ratings at the same value with '/' but as of 10.10 there should be none.
                 let name = group
                     .compactMap(\.name)
                     .sorted()
@@ -173,7 +173,7 @@ struct ServerUserParentalRatingView: View {
 
     private var parentalRatingLearnMore: [TextPair] {
         let groups = Dictionary(
-            grouping: parentalRatingsViewModel.parentalRatings
+            grouping: parentalRatingsViewModel.value
         ) {
             $0.value ?? 0
         }

--- a/Swiftfin/Views/ItemEditorView/ItemMetadata/EditMetadataView/Components/Sections/ParentialRatingsSection.swift
+++ b/Swiftfin/Views/ItemEditorView/ItemMetadata/EditMetadataView/Components/Sections/ParentialRatingsSection.swift
@@ -6,7 +6,6 @@
 // Copyright (c) 2025 Jellyfin & Jellyfin Contributors
 //
 
-import Combine
 import JellyfinAPI
 import SwiftUI
 
@@ -14,96 +13,17 @@ extension EditMetadataView {
 
     struct ParentalRatingSection: View {
 
-        // MARK: - Observed Object
-
-        @ObservedObject
-        private var viewModel = ParentalRatingsViewModel()
-
         // MARK: - Item
 
         @Binding
         var item: BaseItemDto
 
-        // MARK: - Ratings States
-
-        @State
-        private var officialRatings: [ParentalRating] = []
-        @State
-        private var customRatings: [ParentalRating] = []
-
         // MARK: - Body
 
         var body: some View {
             Section(L10n.parentalRating) {
-
-                // MARK: - Official Rating Picker
-
-                Picker(
-                    L10n.officialRating,
-                    selection: $item.officialRating
-                        .map(
-                            getter: { value in officialRatings.first { $0.name == value } },
-                            setter: { $0?.name }
-                        )
-                ) {
-                    Text(L10n.none).tag(nil as ParentalRating?)
-                    ForEach(officialRatings, id: \.self) { rating in
-                        Text(rating.name ?? "").tag(rating as ParentalRating?)
-                    }
-                }
-                .onAppear {
-                    updateOfficialRatings()
-                }
-                .onChange(of: viewModel.parentalRatings) { _ in
-                    updateOfficialRatings()
-                }
-
-                // MARK: - Custom Rating Picker
-
-                Picker(
-                    L10n.customRating,
-                    selection: $item.customRating
-                        .map(
-                            getter: { value in customRatings.first { $0.name == value } },
-                            setter: { $0?.name }
-                        )
-                ) {
-                    Text(L10n.none).tag(nil as ParentalRating?)
-                    ForEach(customRatings, id: \.self) { rating in
-                        Text(rating.name ?? "").tag(rating as ParentalRating?)
-                    }
-                }
-                .onAppear {
-                    updateCustomRatings()
-                }
-                .onChange(of: viewModel.parentalRatings) { _ in
-                    updateCustomRatings()
-                }
-            }
-            .onFirstAppear {
-                viewModel.send(.refresh)
-            }
-        }
-
-        // MARK: - Update Official Rating
-
-        private func updateOfficialRatings() {
-            officialRatings = viewModel.parentalRatings
-            if let currentRatingName = item.officialRating,
-               !officialRatings.contains(where: { $0.name == currentRatingName })
-            {
-                officialRatings.append(ParentalRating(name: currentRatingName))
-            }
-        }
-
-        // MARK: - Update Custom Rating
-
-        private func updateCustomRatings() {
-            customRatings = viewModel.parentalRatings
-            if let currentRatingName = item.customRating,
-               !customRatings.contains(where: { $0.name == currentRatingName })
-            {
-                customRatings.append(ParentalRating(name: currentRatingName))
+                ParentalRatingPicker(L10n.officialRating, selection: $item.officialRating)
+                ParentalRatingPicker(L10n.customRating, selection: $item.customRating)
             }
         }
     }


### PR DESCRIPTION
### Summary

Migration of `ParentalRating` related functionality into a cleaner format similar to what we just did for Cultures and Countries.

1. Move `ParentalRatingsViewModel` to conform to `BaseFetchViewModel`.
2. Move `ParentalRating` pickers to a picker that mirrors `Country/CulturePicker`

### Issues

It looks like, when we go to `ParentalRatings`, `Cultures`, or `Countries` that we generate ourselves, we get the following errors. Functionally, these still work find. It's mostly just `ParentalRating(name: Optional("TV-14"), value: nil)` isn't in our list because it *should be* `ParentalRating(name: Optional("TV-14"), value: 14)`. 

I want to clean this up before this is ready.

```
Picker: the selection "Optional(JellyfinAPI.ParentalRating(name: Optional("TV-14"), value: nil))" is invalid and does not have an associated tag, this will give undefined results.
Picker: the selection "Optional(JellyfinAPI.ParentalRating(name: Optional("TV-14"), value: nil))" is invalid and does not have an associated tag, this will give undefined results.
Picker: the selection "Optional(JellyfinAPI.ParentalRating(name: Optional(""), value: nil))" is invalid and does not have an associated tag, this will give undefined results.
Picker: the selection "Optional(JellyfinAPI.ParentalRating(name: Optional(""), value: nil))" is invalid and does not have an associated tag, this will give undefined results.
Picker: the selection "Optional(JellyfinAPI.CultureDto(displayName: nil, name: nil, threeLetterISOLanguageName: nil, threeLetterISOLanguageNames: nil, twoLetterISOLanguageName: Optional("")))" is invalid and does not have an associated tag, this will give undefined results.
Picker: the selection "Optional(JellyfinAPI.CultureDto(displayName: nil, name: nil, threeLetterISOLanguageName: nil, threeLetterISOLanguageNames: nil, twoLetterISOLanguageName: Optional("")))" is invalid and does not have an associated tag, this will give undefined results.
Picker: the selection "Optional(JellyfinAPI.CountryInfo(displayName: nil, name: Optional(""), threeLetterISORegionName: nil, twoLetterISORegionName: Optional("")))" is invalid and does not have an associated tag, this will give undefined results.
Picker: the selection "Optional(JellyfinAPI.CountryInfo(displayName: nil, name: Optional(""), threeLetterISORegionName: nil, twoLetterISORegionName: Optional("")))" is invalid and does not have an associated tag, this will give undefined results.
Picker: the selection "Optional(JellyfinAPI.CultureDto(displayName: nil, name: nil, threeLetterISOLanguageName: nil, threeLetterISOLanguageNames: nil, twoLetterISOLanguageName: Optional("")))" is invalid and does not have an associated tag, this will give undefined results.
Picker: the selection "Optional(JellyfinAPI.CultureDto(displayName: nil, name: nil, threeLetterISOLanguageName: nil, threeLetterISOLanguageNames: nil, twoLetterISOLanguageName: Optional("")))" is invalid and does not have an associated tag, this will give undefined results.
load_eligibility_plist: Failed to open /Users/jpkribs/Library/Developer/CoreSimulator/Devices/4656693D-8967-405B-BBE9-1D80FA471172/data/Containers/Data/Application/4667920D-8A49-49B4-8893-B1BBDCC25BE5/private/var/db/eligibilityd/eligibility.plist: No such file or directory(2)
Picker: the selection "Optional(JellyfinAPI.CountryInfo(displayName: nil, name: Optional(""), threeLetterISORegionName: nil, twoLetterISORegionName: Optional("")))" is invalid and does not have an associated tag, this will give undefined results.
Picker: the selection "Optional(JellyfinAPI.CountryInfo(displayName: nil, name: Optional(""), threeLetterISORegionName: nil, twoLetterISORegionName: Optional("")))" is invalid and does not have an associated tag, this will give undefined results.
```