### PR TITLE
Use `xcconfig`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -97,6 +97,10 @@ iOSInjectionProject/
 .Trashes
 ehthumbs.db
 Thumbs.db
-Shared/Generated/Strings.swift
 
+# Swiftfin
+Shared/Generated/Strings.swift
+XcodeConfig/DevelopmentTeam.xcconfig
+
+# Other
 .idea

--- a/Documentation/contributing.md
+++ b/Documentation/contributing.md
@@ -18,6 +18,25 @@ $ carthage update --use-xcframeworks
 
 In the event that all of the Swift Packages cannot be installed, clean the Swift Packages cache or close and reopen Xcode to restart the process.
 
+### Xcode Config
+
+Use an `xcconfig` file to easily set and keep your development team and a custom bundle identifier for local development to your devices.
+
+Create the `XcodeConfig/DevelopmentTeam.xcconfig` file [through Xcode](https://developer.apple.com/documentation/xcode/adding-a-build-configuration-file-to-your-project) or locally with the following values:
+
+```
+DEVELOPMENT_TEAM = ""
+PRODUCT_BUNDLE_IDENTIFIER = org.jellyfin.swiftfin
+```
+
+Update the `DEVELOPMENT_TEAM` value with your Team ID. This can be found by:
+- Setting the `Development Team` value under the `Signing & Capabilities` tab in Xcode and get the value from source control. Make sure to discard this change.
+- Logging into your Apple Developer account and [view your membership details](https://developer.apple.com/account/#/membership). It will be listed next to `Team ID`.
+
+You can change the `PRODUCT_BUNDLE_IDENTIFIER` value to have multiple builds of Swiftfin on your devices or for provisioning purposes.
+
+`DevelopmentTeam.xcconfig` is already added to the `.gitignore`.
+
 ## Git Flow
 
 Swiftfin follows the same Pull Request Guidelines as outlined in the [Jellyfin Pull Request Guidelines](https://jellyfin.org/docs/general/contributing/development.html#pull-request-guidelines).

--- a/Swiftfin.xcodeproj/project.pbxproj
+++ b/Swiftfin.xcodeproj/project.pbxproj
@@ -3,7 +3,7 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 70;
+	objectVersion = 71;
 	objects = {
 
 /* Begin PBXBuildFile section */
@@ -275,6 +275,7 @@
 		E14565DD2DFCAE78008FF700 /* Scripts */ = {isa = PBXFileSystemSynchronizedRootGroup; explicitFileTypes = {}; explicitFolders = (); path = Scripts; sourceTree = "<group>"; };
 		E145669F2DFCAEFD008FF700 /* Swiftfin tvOS */ = {isa = PBXFileSystemSynchronizedRootGroup; exceptions = (E14567272DFCAEFD008FF700 /* PBXFileSystemSynchronizedBuildFileExceptionSet */, ); explicitFileTypes = {}; explicitFolders = (); path = "Swiftfin tvOS"; sourceTree = "<group>"; };
 		E1456FC82DFCB323008FF700 /* Translations */ = {isa = PBXFileSystemSynchronizedRootGroup; explicitFileTypes = {}; explicitFolders = (); path = Translations; sourceTree = "<group>"; };
+		E150B7D12DFF2E7C00DC7CF4 /* XcodeConfig */ = {isa = PBXFileSystemSynchronizedRootGroup; explicitFileTypes = {}; explicitFolders = (); path = XcodeConfig; sourceTree = "<group>"; };
 /* End PBXFileSystemSynchronizedRootGroup section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -405,6 +406,7 @@
 				5377CBF2263B596A003A4E83 /* Products */,
 				53D5E3DB264B47EE00BADDC8 /* Frameworks */,
 				E14565DD2DFCAE78008FF700 /* Scripts */,
+				E150B7D12DFF2E7C00DC7CF4 /* XcodeConfig */,
 			);
 			sourceTree = "<group>";
 		};
@@ -498,6 +500,7 @@
 				E14563272DFCAE6E008FF700 /* Shared */,
 				E145669F2DFCAEFD008FF700 /* Swiftfin tvOS */,
 				E1456FC82DFCB323008FF700 /* Translations */,
+				E150B7D12DFF2E7C00DC7CF4 /* XcodeConfig */,
 			);
 			name = "Swiftfin tvOS";
 			packageProductDependencies = (
@@ -552,6 +555,7 @@
 				E14560852DFCAE51008FF700 /* Swiftfin */,
 				E14563272DFCAE6E008FF700 /* Shared */,
 				E1456FC82DFCB323008FF700 /* Translations */,
+				E150B7D12DFF2E7C00DC7CF4 /* XcodeConfig */,
 			);
 			name = "Swiftfin iOS";
 			packageProductDependencies = (
@@ -924,6 +928,8 @@
 		};
 		5377CC19263B596B003A4E83 /* Debug */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReferenceAnchor = E150B7D12DFF2E7C00DC7CF4 /* XcodeConfig */;
+			baseConfigurationReferenceRelativePath = Shared.xcconfig;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
 				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;
@@ -1076,7 +1082,6 @@
 				);
 				MARKETING_VERSION = 1.0.0;
 				OTHER_CFLAGS = "";
-				PRODUCT_BUNDLE_IDENTIFIER = org.jellyfin.swiftfin;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				SUPPORTS_MACCATALYST = NO;
@@ -1100,7 +1105,6 @@
 				CURRENT_PROJECT_VERSION = 78;
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
 				DEVELOPMENT_ASSET_PATHS = "";
-				DEVELOPMENT_TEAM = "";
 				ENABLE_BITCODE = NO;
 				ENABLE_PREVIEWS = YES;
 				ENABLE_USER_SCRIPT_SANDBOXING = NO;
@@ -1116,7 +1120,6 @@
 				);
 				MARKETING_VERSION = 1.0.0;
 				OTHER_CFLAGS = "";
-				PRODUCT_BUNDLE_IDENTIFIER = org.jellyfin.swiftfin;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				SUPPORTS_MACCATALYST = NO;

--- a/XcodeConfig/Shared.xcconfig
+++ b/XcodeConfig/Shared.xcconfig
@@ -1,0 +1,9 @@
+//
+// Swiftfin is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, you can obtain one at https://mozilla.org/MPL/2.0/.
+//
+// Copyright (c) 2025 Jellyfin & Jellyfin Contributors
+//
+
+#include? "DevelopmentTeam.xcconfig"


### PR DESCRIPTION
Introduces using `xcconfig` files for setting local development team and bundle identifiers during development, largely avoiding accidentally checking in those changes from the project settings.

After this I need to verify the TestFlight action still works and I would like to transition build settings we've made in the project to the `Shared.xcconfig`.