### PR TITLE
Prioritize hevc over h264 for transcoding with native player

### DIFF
--- a/Shared/Objects/VideoPlayerType/VideoPlayerType+Native.swift
+++ b/Shared/Objects/VideoPlayerType/VideoPlayerType+Native.swift
@@ -110,8 +110,8 @@ extension VideoPlayerType {
             AudioCodec.eac3
             AudioCodec.flac
         } videoCodecs: {
-            VideoCodec.h264
             VideoCodec.hevc
+            VideoCodec.h264
             VideoCodec.mpeg4
         } containers: {
             MediaContainer.mp4


### PR DESCRIPTION
Right now, native player will transcode to h264 over hevc if the server has both transcoding options enabled. For the native player, HEVC is objectively a better option due to size efficiency and compatibility with DoVi/HDR, among other things.

This PR prioritizes HEVC in the device profile when transcoding is required.