### PR TITLE
Make Text Static on Single Season

### DIFF
--- a/Swiftfin/Views/ItemView/Components/EpisodeSelector/EpisodeSelector.swift
+++ b/Swiftfin/Views/ItemView/Components/EpisodeSelector/EpisodeSelector.swift
@@ -32,10 +32,8 @@ struct SeriesEpisodeSelector: View {
            viewModel.seasons.count <= 1
         {
             Text(seasonDisplayName)
-                .font(.headline)
-                .foregroundStyle(Color.accentColor)
-                .padding(.vertical, 5)
-                .padding(.horizontal, 10)
+                .font(.title2)
+                .fontWeight(.semibold)
         } else {
             Menu {
                 ForEach(viewModel.seasons, id: \.season.id) { seasonViewModel in


### PR DESCRIPTION
### Summary

Resolves: https://github.com/jellyfin/Swiftfin/issues/1577

Make the `SeasonSelector` static Text for single Season shows.

**Notes:**
- I mirrored the regular `SeasonSelector` spacing. I'm not sure if that's a good fit so it might be worth removing the horizontal spacing.
- I made this text also accent color. It looks good as `.primary` as well so we have alternatives. 

### Screenshot

<details>

<summary>Single vs Multiple Season(s)</summary>

<img width="450" alt="Screenshot 2025-06-16 at 08 36 50" src="https://github.com/user-attachments/assets/3d5cbcf9-bb57-44c7-b4b6-35de1a7096d6" />

</details>