### PR TITLE
Add File Information to `IdentifyItemView` 

### DIFF
--- a/Swiftfin/Views/ItemEditorView/IdentifyItemView/IdentifyItemView.swift
+++ b/Swiftfin/Views/ItemEditorView/IdentifyItemView/IdentifyItemView.swift
@@ -109,6 +109,11 @@ struct IdentifyItemView: View {
     @ViewBuilder
     private var contentView: some View {
         Form {
+            ListTitleSection(
+                viewModel.item.name ?? L10n.unknown,
+                description: viewModel.item.path
+            )
+
             searchView
 
             resultsView


### PR DESCRIPTION
### Summary

Resolves: https://github.com/jellyfin/Swiftfin/issues/1586

Continuation of the Admin cleanup. This adds the existing file path and name to the identification screen. [Linux Kernel says we should be 4096 characters](https://www.man7.org/linux/man-pages/man0/limits.h.0p.html) or less so I don't foresee this being an issue to put this in place.

I used the same `ListTitleSection` used elsewhere. Let me know if we would prefer to handle this differently.

### Video

https://github.com/user-attachments/assets/704b3446-3911-4371-8d78-70e7071930fe

### Longest String

This is an example of the longest string XCode would let me run with. I think the actual 4096b is even larger than this but this is the potential risk of this method. I don't foresee this being an issue but just an item of note:

https://github.com/user-attachments/assets/4bb23364-6cdf-4acd-9512-51eb82186e64