### PR TITLE
Fix Show Icon

### DIFF
--- a/Shared/Coordinators/Tabs/MainTabView.swift
+++ b/Shared/Coordinators/Tabs/MainTabView.swift
@@ -55,6 +55,7 @@ struct MainTabView: View {
                         systemImage: tab.item.systemImage
                     )
                     .labelStyle(tab.item.labelStyle)
+                    .symbolRenderingMode(.monochrome)
                     .eraseToAnyView()
                 }
                 .tag(tab.item.id)


### PR DESCRIPTION
### Summary

After the navigation changes, the TV Show _icon_ doesn't highlight when hovered:

<details>
<summary>TV Shows (Current)</summary>

**Unselected:**
![Screenshot 2024-05-26 at 5 39 36 PM](https://github.com/jellyfin/Swiftfin/assets/37599297/4f663b41-2db0-4f52-b03e-d01713b85646)

**Selected:**
![Screenshot 2024-05-26 at 5 39 48 PM](https://github.com/jellyfin/Swiftfin/assets/37599297/d418a5b0-e610-478f-9eac-46863c4f7263)

</details>

<details>
<summary>TV Shows (This PR)</summary>

**Unselected:**
![Screenshot 2024-05-26 at 5 29 23 PM](https://github.com/jellyfin/Swiftfin/assets/37599297/c964e4f9-29ef-4d98-9033-46fb5902a15d)

**Selected:**
![Screenshot 2024-05-26 at 5 29 11 PM](https://github.com/jellyfin/Swiftfin/assets/37599297/76eccab4-f2d0-4c2d-86f5-883a93114c22)

</details>