### PR TITLE
Coordinator `.Sheet` Cleanup

### DIFF
--- a/Shared/Coordinators/Navigation/NavigationRoute/NavigationRoute+Admin.swift
+++ b/Shared/Coordinators/Navigation/NavigationRoute/NavigationRoute+Admin.swift
@@ -34,6 +34,15 @@ extension NavigationRoute {
         ServerActivityView()
     }
 
+    static func activityFilters(viewModel: ServerActivityViewModel) -> NavigationRoute {
+        NavigationRoute(
+            id: "activityFilters",
+            style: .sheet
+        ) {
+            ServerActivityFilterView(viewModel: viewModel)
+        }
+    }
+
     static func activityDetails(viewModel: ServerActivityDetailViewModel) -> NavigationRoute {
         NavigationRoute(id: "activityDetails") {
             ServerActivityDetailsView(viewModel: viewModel)

--- a/Shared/Coordinators/Navigation/NavigationRoute/NavigationRoute+Admin.swift
+++ b/Shared/Coordinators/Navigation/NavigationRoute/NavigationRoute+Admin.swift
@@ -34,18 +34,18 @@ extension NavigationRoute {
         ServerActivityView()
     }
 
+    static func activityDetails(viewModel: ServerActivityDetailViewModel) -> NavigationRoute {
+        NavigationRoute(id: "activityDetails") {
+            ServerActivityDetailsView(viewModel: viewModel)
+        }
+    }
+
     static func activityFilters(viewModel: ServerActivityViewModel) -> NavigationRoute {
         NavigationRoute(
             id: "activityFilters",
             style: .sheet
         ) {
             ServerActivityFilterView(viewModel: viewModel)
-        }
-    }
-
-    static func activityDetails(viewModel: ServerActivityDetailViewModel) -> NavigationRoute {
-        NavigationRoute(id: "activityDetails") {
-            ServerActivityDetailsView(viewModel: viewModel)
         }
     }
 

--- a/Shared/Coordinators/Navigation/NavigationRoute/NavigationRoute+Item.swift
+++ b/Shared/Coordinators/Navigation/NavigationRoute/NavigationRoute+Item.swift
@@ -207,48 +207,27 @@ extension NavigationRoute {
         }
     }
 
-    static func itemImageDetails(
-        viewModel: ItemImagesViewModel,
-        imageInfo: ImageInfo
-    ) -> NavigationRoute {
+    static func itemImageDetails(viewModel: ItemImagesViewModel, imageInfo: ImageInfo) -> NavigationRoute {
         NavigationRoute(
             id: "itemImageDetails",
             style: .sheet
         ) {
             ItemImageDetailsView(
                 viewModel: viewModel,
-                imageSource: imageInfo.itemImageSource(
-                    itemID: viewModel.item.id!,
-                    client: viewModel.userSession.client
-                ),
-                index: imageInfo.imageIndex,
-                width: imageInfo.width,
-                height: imageInfo.height,
-                onDelete: {
-                    viewModel.send(.deleteImage(imageInfo))
-                }
+                imageInfo: imageInfo
             )
             .environment(\.isEditing, true)
         }
     }
 
-    static func itemSearchImageDetails(viewModel: ItemImagesViewModel, imageInfo: RemoteImageInfo) -> NavigationRoute {
+    static func itemSearchImageDetails(viewModel: ItemImagesViewModel, remoteImageInfo: RemoteImageInfo) -> NavigationRoute {
         NavigationRoute(
             id: "itemSearchImageDetails",
             style: .sheet
         ) {
             ItemImageDetailsView(
                 viewModel: viewModel,
-                imageSource: ImageSource(url: imageInfo.url?.url),
-                width: imageInfo.width,
-                height: imageInfo.height,
-                language: imageInfo.language,
-                provider: imageInfo.providerName,
-                rating: imageInfo.communityRating,
-                ratingVotes: imageInfo.voteCount,
-                onSave: {
-                    viewModel.send(.setImage(imageInfo))
-                }
+                remoteImageInfo: remoteImageInfo
             )
             .environment(\.isEditing, false)
         }

--- a/Shared/Coordinators/Navigation/NavigationRoute/NavigationRoute+Item.swift
+++ b/Shared/Coordinators/Navigation/NavigationRoute/NavigationRoute+Item.swift
@@ -23,6 +23,18 @@ extension NavigationRoute {
         }
     }
 
+    static func addItemImage(viewModel: ItemImagesViewModel, imageType: ImageType) -> NavigationRoute {
+        NavigationRoute(
+            id: "addItemImage",
+            style: .push(.automatic)
+        ) {
+            AddItemImageView(
+                viewModel: viewModel,
+                imageType: imageType
+            )
+        }
+    }
+
     static func addPeople(viewModel: PeopleEditorViewModel) -> NavigationRoute {
         NavigationRoute(
             id: "addPeople",
@@ -139,6 +151,21 @@ extension NavigationRoute {
             IdentifyItemView(item: item)
         }
     }
+
+    static func identifyItemResults(
+        viewModel: IdentifyItemViewModel,
+        result: RemoteSearchResult
+    ) -> NavigationRoute {
+        NavigationRoute(
+            id: "identifyItemResults",
+            style: .sheet
+        ) {
+            IdentifyItemView.RemoteSearchResultView(
+                viewModel: viewModel,
+                result: result,
+            )
+        }
+    }
     #endif
 
     static func item(item: BaseItemDto) -> NavigationRoute {
@@ -159,54 +186,6 @@ extension NavigationRoute {
         }
     }
 
-    static func itemIdentify(
-        viewModel: IdentifyItemViewModel,
-        result: RemoteSearchResult
-    ) -> NavigationRoute {
-        NavigationRoute(
-            id: "itemIdentify",
-            style: .sheet
-        ) {
-            IdentifyItemView.RemoteSearchResultView(
-                viewModel: viewModel,
-                result: result,
-            )
-        }
-    }
-
-    static func itemImages(viewModel: ItemImagesViewModel) -> NavigationRoute {
-        NavigationRoute(
-            id: "itemImages",
-            style: .sheet
-        ) {
-            ItemImagesView(viewModel: viewModel)
-        }
-    }
-
-    static func selectItemImage(viewModel: ItemImagesViewModel, imageType: ImageType) -> NavigationRoute {
-        NavigationRoute(
-            id: "selectItemImage",
-            style: .sheet
-        ) {
-            ItemImagePicker(
-                viewModel: viewModel,
-                type: imageType
-            )
-        }
-    }
-
-    static func addItemImage(viewModel: ItemImagesViewModel, imageType: ImageType) -> NavigationRoute {
-        NavigationRoute(
-            id: "addItemImage",
-            style: .push(.automatic)
-        ) {
-            AddItemImageView(
-                viewModel: viewModel,
-                imageType: imageType
-            )
-        }
-    }
-
     static func itemImageDetails(viewModel: ItemImagesViewModel, imageInfo: ImageInfo) -> NavigationRoute {
         NavigationRoute(
             id: "itemImageDetails",
@@ -220,6 +199,40 @@ extension NavigationRoute {
         }
     }
 
+    static func itemImages(viewModel: ItemImagesViewModel) -> NavigationRoute {
+        NavigationRoute(
+            id: "itemImages",
+            style: .sheet
+        ) {
+            ItemImagesView(viewModel: viewModel)
+        }
+    }
+
+    static func itemImageSelector(viewModel: ItemImagesViewModel, imageType: ImageType) -> NavigationRoute {
+        NavigationRoute(
+            id: "itemImageSelector",
+            style: .sheet
+        ) {
+            ItemImagePicker(
+                viewModel: viewModel,
+                type: imageType
+            )
+        }
+    }
+
+    #endif
+
+    static func itemOverview(item: BaseItemDto) -> NavigationRoute {
+        NavigationRoute(
+            id: "itemOverview",
+            style: .sheet
+        ) {
+            ItemOverviewView(item: item)
+        }
+    }
+
+    #if os(iOS)
+
     static func itemSearchImageDetails(viewModel: ItemImagesViewModel, remoteImageInfo: RemoteImageInfo) -> NavigationRoute {
         NavigationRoute(
             id: "itemSearchImageDetails",
@@ -232,14 +245,6 @@ extension NavigationRoute {
             .environment(\.isEditing, false)
         }
     }
-    #endif
 
-    static func itemOverview(item: BaseItemDto) -> NavigationRoute {
-        NavigationRoute(
-            id: "itemOverview",
-            style: .sheet
-        ) {
-            ItemOverviewView(item: item)
-        }
-    }
+    #endif
 }

--- a/Shared/Coordinators/Navigation/NavigationRoute/NavigationRoute+Item.swift
+++ b/Shared/Coordinators/Navigation/NavigationRoute/NavigationRoute+Item.swift
@@ -207,37 +207,34 @@ extension NavigationRoute {
         }
     }
 
-    static func itemImageDetailsLocal(
+    static func itemImageDetails(
         viewModel: ItemImagesViewModel,
-        imageSource: ImageSource,
-        imageInfo: ImageInfo,
-        onDelete: (() -> Void)?
+        imageInfo: ImageInfo
     ) -> NavigationRoute {
         NavigationRoute(
-            id: "itemImageDetailsLocal",
+            id: "itemImageDetails",
             style: .sheet
         ) {
             ItemImageDetailsView(
                 viewModel: viewModel,
-                imageSource: imageSource,
+                imageSource: imageInfo.itemImageSource(
+                    itemID: viewModel.item.id!,
+                    client: viewModel.userSession.client
+                ),
                 index: imageInfo.imageIndex,
                 width: imageInfo.width,
                 height: imageInfo.height,
                 onDelete: {
-                    onDelete?()
+                    viewModel.send(.deleteImage(imageInfo))
                 }
             )
             .environment(\.isEditing, true)
         }
     }
 
-    static func itemImageDetailsRemote(
-        viewModel: ItemImagesViewModel,
-        imageInfo: RemoteImageInfo,
-        onSave: (() -> Void)?
-    ) -> NavigationRoute {
+    static func itemSearchImageDetails(viewModel: ItemImagesViewModel, imageInfo: RemoteImageInfo) -> NavigationRoute {
         NavigationRoute(
-            id: "itemImageDetailsRemote",
+            id: "itemSearchImageDetails",
             style: .sheet
         ) {
             ItemImageDetailsView(
@@ -250,7 +247,7 @@ extension NavigationRoute {
                 rating: imageInfo.communityRating,
                 ratingVotes: imageInfo.voteCount,
                 onSave: {
-                    onSave?()
+                    viewModel.send(.setImage(imageInfo))
                 }
             )
             .environment(\.isEditing, false)

--- a/Shared/Coordinators/Navigation/NavigationRoute/NavigationRoute+Item.swift
+++ b/Shared/Coordinators/Navigation/NavigationRoute/NavigationRoute+Item.swift
@@ -159,16 +159,17 @@ extension NavigationRoute {
         }
     }
 
-    static func itemSearchIdentity(remoteSearchResult: RemoteSearchResult, onSave: (() -> Void)?) -> NavigationRoute {
+    static func itemIdentify(
+        viewModel: IdentifyItemViewModel,
+        result: RemoteSearchResult
+    ) -> NavigationRoute {
         NavigationRoute(
-            id: "itemSearchIdentity",
+            id: "itemIdentify",
             style: .sheet
         ) {
             IdentifyItemView.RemoteSearchResultView(
-                result: remoteSearchResult,
-                onSave: {
-                    onSave?()
-                }
+                viewModel: viewModel,
+                result: result,
             )
         }
     }

--- a/Shared/Coordinators/Navigation/NavigationRoute/NavigationRoute+Item.swift
+++ b/Shared/Coordinators/Navigation/NavigationRoute/NavigationRoute+Item.swift
@@ -159,12 +159,100 @@ extension NavigationRoute {
         }
     }
 
+    static func itemSearchIdentity(remoteSearchResult: RemoteSearchResult, onSave: (() -> Void)?) -> NavigationRoute {
+        NavigationRoute(
+            id: "itemSearchIdentity",
+            style: .sheet
+        ) {
+            IdentifyItemView.RemoteSearchResultView(
+                result: remoteSearchResult,
+                onSave: {
+                    onSave?()
+                }
+            )
+        }
+    }
+
     static func itemImages(viewModel: ItemImagesViewModel) -> NavigationRoute {
         NavigationRoute(
             id: "itemImages",
             style: .sheet
         ) {
             ItemImagesView(viewModel: viewModel)
+        }
+    }
+
+    static func selectItemImage(viewModel: ItemImagesViewModel, imageType: ImageType) -> NavigationRoute {
+        NavigationRoute(
+            id: "selectItemImage",
+            style: .sheet
+        ) {
+            ItemImagePicker(
+                viewModel: viewModel,
+                type: imageType
+            )
+        }
+    }
+
+    static func addItemImage(viewModel: ItemImagesViewModel, imageType: ImageType) -> NavigationRoute {
+        NavigationRoute(
+            id: "addItemImage",
+            style: .push(.automatic)
+        ) {
+            AddItemImageView(
+                viewModel: viewModel,
+                imageType: imageType
+            )
+        }
+    }
+
+    static func itemImageDetailsLocal(
+        viewModel: ItemImagesViewModel,
+        imageSource: ImageSource,
+        imageInfo: ImageInfo,
+        onDelete: (() -> Void)?
+    ) -> NavigationRoute {
+        NavigationRoute(
+            id: "itemImageDetailsLocal",
+            style: .sheet
+        ) {
+            ItemImageDetailsView(
+                viewModel: viewModel,
+                imageSource: imageSource,
+                index: imageInfo.imageIndex,
+                width: imageInfo.width,
+                height: imageInfo.height,
+                onDelete: {
+                    onDelete?()
+                }
+            )
+            .environment(\.isEditing, true)
+        }
+    }
+
+    static func itemImageDetailsRemote(
+        viewModel: ItemImagesViewModel,
+        imageInfo: RemoteImageInfo,
+        onSave: (() -> Void)?
+    ) -> NavigationRoute {
+        NavigationRoute(
+            id: "itemImageDetailsRemote",
+            style: .sheet
+        ) {
+            ItemImageDetailsView(
+                viewModel: viewModel,
+                imageSource: ImageSource(url: imageInfo.url?.url),
+                width: imageInfo.width,
+                height: imageInfo.height,
+                language: imageInfo.language,
+                provider: imageInfo.providerName,
+                rating: imageInfo.communityRating,
+                ratingVotes: imageInfo.voteCount,
+                onSave: {
+                    onSave?()
+                }
+            )
+            .environment(\.isEditing, false)
         }
     }
     #endif

--- a/Shared/ViewModels/ItemAdministration/RefreshMetadataViewModel.swift
+++ b/Shared/ViewModels/ItemAdministration/RefreshMetadataViewModel.swift
@@ -152,7 +152,8 @@ final class RefreshMetadataViewModel: ViewModel, Stateful, Eventful {
 
     // MARK: - Poll Progress
 
-    // TODO: Find a way to actually check refresh progress. Not currently possible on 10.10.6 (2025-03-27)
+    // TODO: Find a way to actually check refresh progress.
+    // - Will require the WebSocket to be implemented first.
     private func pollRefreshProgress() async throws {
         let totalDuration: Double = 5.0
         let interval: Double = 0.05

--- a/Swiftfin tvOS/Components/OrderedSectionSelectorView.swift
+++ b/Swiftfin tvOS/Components/OrderedSectionSelectorView.swift
@@ -42,7 +42,7 @@ struct OrderedSectionSelectorView<Element: Displayable & Hashable>: View {
     }
 
     var body: some View {
-        NavigationView {
+        NavigationStack {
             SplitFormWindowView()
                 .descriptionView {
                     Image(systemName: systemImage)

--- a/Swiftfin/Views/AdminDashboardView/ServerActivity/ServerActivityFilterView/ServerActivityFilterView.swift
+++ b/Swiftfin/Views/AdminDashboardView/ServerActivity/ServerActivityFilterView/ServerActivityFilterView.swift
@@ -20,12 +20,25 @@ struct ServerActivityFilterView: View {
     // MARK: - State Objects
 
     @ObservedObject
-    var viewModel: ServerActivityViewModel
+    private var viewModel: ServerActivityViewModel
 
     // MARK: - Dialog States
 
     @State
     private var tempDate: Date?
+
+    // MARK: - Initializer
+
+    init(viewModel: ServerActivityViewModel) {
+
+        self.viewModel = viewModel
+
+        if let minDate = viewModel.minDate {
+            tempDate = minDate
+        } else {
+            tempDate = .now
+        }
+    }
 
     // MARK: - Body
 
@@ -69,13 +82,6 @@ struct ServerActivityFilterView: View {
             }
             .buttonStyle(.toolbarPill)
             .disabled(viewModel.minDate != nil && startOfDay == viewModel.minDate)
-        }
-        .onFirstAppear {
-            if let minDate = viewModel.minDate {
-                tempDate = minDate
-            } else {
-                tempDate = .now
-            }
         }
     }
 }

--- a/Swiftfin/Views/AdminDashboardView/ServerActivity/ServerActivityFilterView/ServerActivityFilterView.swift
+++ b/Swiftfin/Views/AdminDashboardView/ServerActivity/ServerActivityFilterView/ServerActivityFilterView.swift
@@ -1,0 +1,81 @@
+//
+// Swiftfin is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, you can obtain one at https://mozilla.org/MPL/2.0/.
+//
+// Copyright (c) 2025 Jellyfin & Jellyfin Contributors
+//
+
+import CollectionVGrid
+import JellyfinAPI
+import SwiftUI
+
+struct ServerActivityFilterView: View {
+
+    // MARK: - Environment Objects
+
+    @Router
+    private var router
+
+    // MARK: - State Objects
+
+    @ObservedObject
+    var viewModel: ServerActivityViewModel
+
+    // MARK: - Dialog States
+
+    @State
+    private var tempDate: Date?
+
+    // MARK: - Body
+
+    var body: some View {
+        List {
+            Section {
+                DatePicker(
+                    L10n.date,
+                    selection: $tempDate.coalesce(.now),
+                    in: ...Date.now,
+                    displayedComponents: .date
+                )
+                .datePickerStyle(.graphical)
+                .labelsHidden()
+            }
+
+            /// Reset button to remove the filter
+            if viewModel.minDate != nil {
+                Section {
+                    ListRowButton(L10n.reset, role: .destructive) {
+                        viewModel.minDate = nil
+                        router.dismiss()
+                    }
+                } footer: {
+                    Text(L10n.resetFilterFooter)
+                }
+            }
+        }
+        .navigationTitle(L10n.startDate.localizedCapitalized)
+        .navigationBarTitleDisplayMode(.inline)
+        .navigationBarCloseButton {
+            router.dismiss()
+        }
+        .topBarTrailing {
+            let startOfDay = Calendar.current
+                .startOfDay(for: tempDate ?? .now)
+
+            Button(L10n.save) {
+                viewModel.minDate = startOfDay
+                router.dismiss()
+            }
+            .buttonStyle(.toolbarPill)
+            .disabled(viewModel.minDate != nil && startOfDay == viewModel.minDate)
+        }
+        .onFirstAppear {
+            if let minDate = viewModel.minDate {
+                tempDate = minDate
+            } else {
+                tempDate = .now
+            }
+        }
+    }
+}

--- a/Swiftfin/Views/AdminDashboardView/ServerActivity/ServerActivityView/ServerActivityView.swift
+++ b/Swiftfin/Views/AdminDashboardView/ServerActivity/ServerActivityView/ServerActivityView.swift
@@ -22,13 +22,6 @@ struct ServerActivityView: View {
     @StateObject
     private var viewModel = ServerActivityViewModel()
 
-    // MARK: - Dialog States
-
-    @State
-    private var isDatePickerShowing: Bool = false
-    @State
-    private var tempDate: Date?
-
     // MARK: - Body
 
     var body: some View {
@@ -58,9 +51,6 @@ struct ServerActivityView: View {
         }
         .onFirstAppear {
             viewModel.send(.refresh)
-        }
-        .sheet(isPresented: $isDatePickerShowing, onDismiss: { isDatePickerShowing = false }) {
-            startDatePickerSheet
         }
     }
 
@@ -139,60 +129,7 @@ struct ServerActivityView: View {
     @ViewBuilder
     private var startDateButton: some View {
         Button(L10n.startDate, systemImage: "calendar") {
-            if let minDate = viewModel.minDate {
-                tempDate = minDate
-            } else {
-                tempDate = .now
-            }
-            isDatePickerShowing = true
-        }
-    }
-
-    // MARK: - Start Date Picker Sheet
-
-    @ViewBuilder
-    private var startDatePickerSheet: some View {
-        NavigationStack {
-            List {
-                Section {
-                    DatePicker(
-                        L10n.date,
-                        selection: $tempDate.coalesce(.now),
-                        in: ...Date.now,
-                        displayedComponents: .date
-                    )
-                    .datePickerStyle(.graphical)
-                    .labelsHidden()
-                }
-
-                /// Reset button to remove the filter
-                if viewModel.minDate != nil {
-                    Section {
-                        ListRowButton(L10n.reset, role: .destructive) {
-                            viewModel.minDate = nil
-                            isDatePickerShowing = false
-                        }
-                    } footer: {
-                        Text(L10n.resetFilterFooter)
-                    }
-                }
-            }
-            .navigationTitle(L10n.startDate.localizedCapitalized)
-            .navigationBarTitleDisplayMode(.inline)
-            .navigationBarCloseButton {
-                isDatePickerShowing = false
-            }
-            .topBarTrailing {
-                let startOfDay = Calendar.current
-                    .startOfDay(for: tempDate ?? .now)
-
-                Button(L10n.save) {
-                    viewModel.minDate = startOfDay
-                    isDatePickerShowing = false
-                }
-                .buttonStyle(.toolbarPill)
-                .disabled(viewModel.minDate != nil && startOfDay == viewModel.minDate)
-            }
+            router.route(to: .activityFilters(viewModel: viewModel))
         }
     }
 }

--- a/Swiftfin/Views/AdminDashboardView/ServerActivity/ServerActivityView/ServerActivityView.swift
+++ b/Swiftfin/Views/AdminDashboardView/ServerActivity/ServerActivityView/ServerActivityView.swift
@@ -152,7 +152,7 @@ struct ServerActivityView: View {
 
     @ViewBuilder
     private var startDatePickerSheet: some View {
-        NavigationView {
+        NavigationStack {
             List {
                 Section {
                     DatePicker(

--- a/Swiftfin/Views/AppSettingsView/AppSettingsView.swift
+++ b/Swiftfin/Views/AppSettingsView/AppSettingsView.swift
@@ -44,7 +44,6 @@ struct AppSettingsView: View {
             Section(L10n.accessibility) {
 
                 ChevronButton(L10n.appIcon) {
-                    // TODO: Create NavigationRoute.appIconSelector
                     router.route(to: .appIconSelector(viewModel: viewModel))
                 }
 

--- a/Swiftfin/Views/ItemEditorView/IdentifyItemView/Components/RemoteSearchResultView.swift
+++ b/Swiftfin/Views/ItemEditorView/IdentifyItemView/Components/RemoteSearchResultView.swift
@@ -13,6 +13,11 @@ extension IdentifyItemView {
 
     struct RemoteSearchResultView: View {
 
+        // MARK: - Router
+
+        @Router
+        private var router
+
         // MARK: - Item Info Variables
 
         let result: RemoteSearchResult
@@ -20,7 +25,6 @@ extension IdentifyItemView {
         // MARK: - Item Info Actions
 
         let onSave: () -> Void
-        let onClose: () -> Void
 
         // MARK: - Body
 
@@ -97,11 +101,13 @@ extension IdentifyItemView {
                 .navigationTitle(L10n.identify)
                 .navigationBarTitleDisplayMode(.inline)
                 .navigationBarCloseButton {
-                    onClose()
+                    router.dismiss()
                 }
                 .topBarTrailing {
-                    Button(L10n.save, action: onSave)
-                        .buttonStyle(.toolbarPill)
+                    Button(L10n.save) {
+                        onSave()
+                    }
+                    .buttonStyle(.toolbarPill)
                 }
             }
         }

--- a/Swiftfin/Views/ItemEditorView/IdentifyItemView/Components/RemoteSearchResultView.swift
+++ b/Swiftfin/Views/ItemEditorView/IdentifyItemView/Components/RemoteSearchResultView.swift
@@ -20,11 +20,15 @@ extension IdentifyItemView {
 
         // MARK: - Item Info Variables
 
+        @StateObject
+        var viewModel: IdentifyItemViewModel
+
         let result: RemoteSearchResult
 
-        // MARK: - Item Info Actions
+        // MARK: - Error State
 
-        let onSave: () -> Void
+        @State
+        private var error: Error?
 
         // MARK: - Body
 
@@ -92,24 +96,35 @@ extension IdentifyItemView {
         }
 
         var body: some View {
-            NavigationView {
-                List {
-                    header
+            List {
+                header
 
-                    resultDetails
+                resultDetails
+            }
+            .navigationTitle(L10n.identify)
+            .navigationBarTitleDisplayMode(.inline)
+            .navigationBarCloseButton {
+                router.dismiss()
+            }
+            .topBarTrailing {
+                Button(L10n.save) {
+                    viewModel.send(.update(result))
                 }
-                .navigationTitle(L10n.identify)
-                .navigationBarTitleDisplayMode(.inline)
-                .navigationBarCloseButton {
+                .buttonStyle(.toolbarPill)
+            }
+            .onReceive(viewModel.events) { event in
+                switch event {
+                case let .error(eventError):
+                    UIDevice.feedback(.error)
+                    error = eventError
+                case .cancelled:
+                    break
+                case .updated:
+                    UIDevice.feedback(.success)
                     router.dismiss()
                 }
-                .topBarTrailing {
-                    Button(L10n.save) {
-                        onSave()
-                    }
-                    .buttonStyle(.toolbarPill)
-                }
             }
+            .errorMessage($error)
         }
     }
 }

--- a/Swiftfin/Views/ItemEditorView/IdentifyItemView/IdentifyItemView.swift
+++ b/Swiftfin/Views/ItemEditorView/IdentifyItemView/IdentifyItemView.swift
@@ -39,11 +39,6 @@ struct IdentifyItemView: View {
     @StateObject
     private var viewModel: IdentifyItemViewModel
 
-    // MARK: - Identity Variables
-
-    @State
-    private var selectedResult: RemoteSearchResult?
-
     // MARK: - Error State
 
     @State
@@ -74,26 +69,12 @@ struct IdentifyItemView: View {
         .navigationTitle(L10n.identify)
         .navigationBarTitleDisplayMode(.inline)
         .navigationBarBackButtonHidden(viewModel.state == .updating)
-        .sheet(item: $selectedResult) {
-            selectedResult = nil
-        } content: { result in
-            RemoteSearchResultView(
-                result: result,
-                onSave: {
-                    selectedResult = nil
-                    viewModel.send(.update(result))
-                },
-                onClose: {
-                    selectedResult = nil
-                }
-            )
-        }
         .onReceive(viewModel.events) { events in
             switch events {
             case let .error(eventError):
                 error = eventError
             case .cancelled:
-                selectedResult = nil
+                break
             case .updated:
                 router.dismiss()
             }
@@ -176,7 +157,13 @@ struct IdentifyItemView: View {
             Section(L10n.items) {
                 ForEach(viewModel.searchResults) { result in
                     RemoteSearchResultRow(result: result) {
-                        selectedResult = result
+                        router.route(
+                            to: .itemSearchIdentity(
+                                remoteSearchResult: result
+                            ) {
+                                viewModel.send(.update(result))
+                            }
+                        )
                     }
                 }
             }

--- a/Swiftfin/Views/ItemEditorView/IdentifyItemView/IdentifyItemView.swift
+++ b/Swiftfin/Views/ItemEditorView/IdentifyItemView/IdentifyItemView.swift
@@ -158,11 +158,10 @@ struct IdentifyItemView: View {
                 ForEach(viewModel.searchResults) { result in
                     RemoteSearchResultRow(result: result) {
                         router.route(
-                            to: .itemSearchIdentity(
-                                remoteSearchResult: result
-                            ) {
-                                viewModel.send(.update(result))
-                            }
+                            to: .itemIdentify(
+                                viewModel: viewModel,
+                                result: result
+                            )
                         )
                     }
                 }

--- a/Swiftfin/Views/ItemEditorView/IdentifyItemView/IdentifyItemView.swift
+++ b/Swiftfin/Views/ItemEditorView/IdentifyItemView/IdentifyItemView.swift
@@ -158,7 +158,7 @@ struct IdentifyItemView: View {
                 ForEach(viewModel.searchResults) { result in
                     RemoteSearchResultRow(result: result) {
                         router.route(
-                            to: .itemIdentify(
+                            to: .identifyItemResults(
                                 viewModel: viewModel,
                                 result: result
                             )

--- a/Swiftfin/Views/ItemEditorView/ItemImages/AddItemImageView.swift
+++ b/Swiftfin/Views/ItemEditorView/ItemImages/AddItemImageView.swift
@@ -151,12 +151,9 @@ struct AddItemImageView: View {
     private func imageButton(_ image: RemoteImageInfo) -> some View {
         Button {
             router.route(
-                to: .itemImageDetailsRemote(
+                to: .itemSearchImageDetails(
                     viewModel: viewModel,
-                    imageInfo: image,
-                    onSave: {
-                        viewModel.send(.setImage(image))
-                    }
+                    imageInfo: image
                 )
             )
         } label: {

--- a/Swiftfin/Views/ItemEditorView/ItemImages/AddItemImageView.swift
+++ b/Swiftfin/Views/ItemEditorView/ItemImages/AddItemImageView.swift
@@ -30,8 +30,6 @@ struct AddItemImageView: View {
     // MARK: - Dialog State
 
     @State
-    private var selectedImage: RemoteImageInfo?
-    @State
     private var error: Error?
 
     // MARK: - Collection Layout
@@ -112,27 +110,6 @@ struct AddItemImageView: View {
                 }
             }
         }
-        .sheet(item: $selectedImage) {
-            selectedImage = nil
-        } content: { remoteImageInfo in
-            ItemImageDetailsView(
-                viewModel: viewModel,
-                imageSource: ImageSource(url: remoteImageInfo.url?.url),
-                width: remoteImageInfo.width,
-                height: remoteImageInfo.height,
-                language: remoteImageInfo.language,
-                provider: remoteImageInfo.providerName,
-                rating: remoteImageInfo.communityRating,
-                ratingVotes: remoteImageInfo.voteCount,
-                onClose: {
-                    selectedImage = nil
-                },
-                onSave: {
-                    viewModel.send(.setImage(remoteImageInfo))
-                    selectedImage = nil
-                }
-            )
-        }
         .onFirstAppear {
             remoteImageInfoViewModel.send(.refresh)
         }
@@ -173,7 +150,15 @@ struct AddItemImageView: View {
     @ViewBuilder
     private func imageButton(_ image: RemoteImageInfo) -> some View {
         Button {
-            selectedImage = image
+            router.route(
+                to: .itemImageDetailsRemote(
+                    viewModel: viewModel,
+                    imageInfo: image,
+                    onSave: {
+                        viewModel.send(.setImage(image))
+                    }
+                )
+            )
         } label: {
             posterImage(
                 image,

--- a/Swiftfin/Views/ItemEditorView/ItemImages/AddItemImageView.swift
+++ b/Swiftfin/Views/ItemEditorView/ItemImages/AddItemImageView.swift
@@ -153,7 +153,7 @@ struct AddItemImageView: View {
             router.route(
                 to: .itemSearchImageDetails(
                     viewModel: viewModel,
-                    imageInfo: image
+                    remoteImageInfo: image
                 )
             )
         } label: {

--- a/Swiftfin/Views/ItemEditorView/ItemImages/ItemImageDetailsView/ItemImageDetailsView.swift
+++ b/Swiftfin/Views/ItemEditorView/ItemImages/ItemImageDetailsView/ItemImageDetailsView.swift
@@ -48,34 +48,6 @@ struct ItemImageDetailsView: View {
     @State
     private var error: Error?
 
-    // MARK: - Initializer
-
-    init(
-        viewModel: ItemImagesViewModel,
-        imageSource: ImageSource,
-        index: Int? = nil,
-        width: Int? = nil,
-        height: Int? = nil,
-        language: String? = nil,
-        provider: String? = nil,
-        rating: Double? = nil,
-        ratingVotes: Int? = nil,
-        onSave: (() -> Void)? = nil,
-        onDelete: (() -> Void)? = nil
-    ) {
-        self.viewModel = viewModel
-        self.imageSource = imageSource
-        self.index = index
-        self.width = width
-        self.height = height
-        self.language = language
-        self.provider = provider
-        self.rating = rating
-        self.ratingVotes = ratingVotes
-        self.onSave = onSave
-        self.onDelete = onDelete
-    }
-
     // MARK: - Body
 
     var body: some View {
@@ -137,5 +109,53 @@ struct ItemImageDetailsView: View {
                 }
             }
         }
+    }
+}
+
+extension ItemImageDetailsView {
+
+    // Initialize as a Local Server Image
+
+    init(
+        viewModel: ItemImagesViewModel,
+        imageInfo: ImageInfo
+    ) {
+        self.viewModel = viewModel
+        self.imageSource = imageInfo.itemImageSource(
+            itemID: viewModel.item.id!,
+            client: viewModel.userSession.client
+        )
+        self.index = imageInfo.imageIndex
+        self.width = imageInfo.width
+        self.height = imageInfo.height
+        self.language = nil
+        self.provider = nil
+        self.rating = nil
+        self.ratingVotes = nil
+        self.onSave = nil
+        self.onDelete = {
+            viewModel.send(.deleteImage(imageInfo))
+        }
+    }
+
+    // Initialize as a Remote Search Image
+
+    init(
+        viewModel: ItemImagesViewModel,
+        remoteImageInfo: RemoteImageInfo
+    ) {
+        self.viewModel = viewModel
+        self.imageSource = ImageSource(url: remoteImageInfo.url?.url)
+        self.index = nil
+        self.width = remoteImageInfo.width
+        self.height = remoteImageInfo.height
+        self.language = remoteImageInfo.language
+        self.provider = remoteImageInfo.providerName
+        self.rating = remoteImageInfo.communityRating
+        self.ratingVotes = remoteImageInfo.voteCount
+        self.onSave = {
+            viewModel.send(.setImage(remoteImageInfo))
+        }
+        self.onDelete = nil
     }
 }

--- a/Swiftfin/Views/ItemEditorView/ItemImages/ItemImagesView.swift
+++ b/Swiftfin/Views/ItemEditorView/ItemImages/ItemImagesView.swift
@@ -28,8 +28,6 @@ struct ItemImagesView: View {
     // MARK: - Dialog State
 
     @State
-    private var selectedImage: ImageInfo?
-    @State
     private var selectedType: ImageType?
     @State
     private var isFilePickerPresented = false
@@ -62,28 +60,6 @@ struct ItemImagesView: View {
         }
         .navigationBarCloseButton {
             router.dismiss()
-        }
-        .sheet(item: $selectedImage) {
-            selectedImage = nil
-        } content: { imageInfo in
-            ItemImageDetailsView(
-                viewModel: viewModel,
-                imageSource: imageInfo.itemImageSource(
-                    itemID: viewModel.item.id!,
-                    client: viewModel.userSession.client
-                ),
-                index: imageInfo.imageIndex,
-                width: imageInfo.width,
-                height: imageInfo.height,
-                onClose: {
-                    selectedImage = nil
-                },
-                onDelete: {
-                    viewModel.send(.deleteImage(imageInfo))
-                    selectedImage = nil
-                }
-            )
-            .environment(\.isEditing, true)
         }
         .fileImporter(
             isPresented: $isFilePickerPresented,
@@ -140,7 +116,19 @@ struct ItemImagesView: View {
                 HStack {
                     ForEach(images, id: \.self) { imageInfo in
                         imageButton(imageInfo: imageInfo) {
-                            selectedImage = imageInfo
+                            router.route(
+                                to: .itemImageDetailsLocal(
+                                    viewModel: viewModel,
+                                    imageSource: imageInfo.itemImageSource(
+                                        itemID: viewModel.item.id!,
+                                        client: viewModel.userSession.client
+                                    ),
+                                    imageInfo: imageInfo,
+                                    onDelete: {
+                                        viewModel.send(.deleteImage(imageInfo))
+                                    }
+                                )
+                            )
                         }
                     }
                 }
@@ -161,11 +149,7 @@ struct ItemImagesView: View {
 
             Menu(L10n.options, systemImage: "plus") {
                 Button(L10n.search, systemImage: "magnifyingglass") {
-                    // TODO: Convert to NavigationRoute pattern - router.route(to: .addImage(imageType: imageType))
-//                    router.route(
-//                        to: \.addImage,
-//                        imageType
-//                    )
+                    router.route(to: .addItemImage(viewModel: viewModel, imageType: imageType))
                 }
 
                 Divider()
@@ -176,8 +160,7 @@ struct ItemImagesView: View {
                 }
 
                 Button(L10n.uploadPhoto, systemImage: "photo.badge.plus") {
-                    // TODO: Convert to NavigationRoute pattern - router.route(to: .photoPicker(imageType: imageType))
-//                    router.route(to: \.photoPicker, imageType)
+                    router.route(to: .selectItemImage(viewModel: viewModel, imageType: imageType))
                 }
             }
             .font(.body)

--- a/Swiftfin/Views/ItemEditorView/ItemImages/ItemImagesView.swift
+++ b/Swiftfin/Views/ItemEditorView/ItemImages/ItemImagesView.swift
@@ -117,16 +117,9 @@ struct ItemImagesView: View {
                     ForEach(images, id: \.self) { imageInfo in
                         imageButton(imageInfo: imageInfo) {
                             router.route(
-                                to: .itemImageDetailsLocal(
+                                to: .itemImageDetails(
                                     viewModel: viewModel,
-                                    imageSource: imageInfo.itemImageSource(
-                                        itemID: viewModel.item.id!,
-                                        client: viewModel.userSession.client
-                                    ),
-                                    imageInfo: imageInfo,
-                                    onDelete: {
-                                        viewModel.send(.deleteImage(imageInfo))
-                                    }
+                                    imageInfo: imageInfo
                                 )
                             )
                         }

--- a/Swiftfin/Views/ItemEditorView/ItemImages/ItemImagesView.swift
+++ b/Swiftfin/Views/ItemEditorView/ItemImages/ItemImagesView.swift
@@ -153,7 +153,7 @@ struct ItemImagesView: View {
                 }
 
                 Button(L10n.uploadPhoto, systemImage: "photo.badge.plus") {
-                    router.route(to: .selectItemImage(viewModel: viewModel, imageType: imageType))
+                    router.route(to: .itemImageSelector(viewModel: viewModel, imageType: imageType))
                 }
             }
             .font(.body)

--- a/Swiftfin/Views/ItemEditorView/ItemImages/ItemPhotoPickerView/ItemPhotoPickerView.swift
+++ b/Swiftfin/Views/ItemEditorView/ItemImages/ItemPhotoPickerView/ItemPhotoPickerView.swift
@@ -21,6 +21,11 @@ struct ItemImagePicker: View {
 
     let type: ImageType
 
+    // MARK: - Error State
+
+    @State
+    private var error: Error?
+
     // MARK: - Body
 
     var body: some View {
@@ -35,5 +40,16 @@ struct ItemImagePicker: View {
         } onCancel: {
             router.dismiss()
         }
+        .onReceive(viewModel.events) { event in
+            switch event {
+            case let .error(eventError):
+                UIDevice.feedback(.error)
+                error = eventError
+            case .updated:
+                UIDevice.feedback(.success)
+                router.dismiss()
+            }
+        }
+        .errorMessage($error)
     }
 }


### PR DESCRIPTION
## Summary

Resolves: https://github.com/jellyfin/Swiftfin/issues/1608

This PR resolves the `.sheet` routing found in `ItemEditorView` Image adding and Item Identification processes. I originally wanted to leave this for other folks to work on but:

1. I realized the `ItemImage` routing was non-functionality. This increased the priority for me.
2. Getting `ItemImage` routing working was more complicated than I originally thought it would be. So, I felt like I should take the lead

This migrates all `.sheet` to use the coordinator. As part of this, some of the `router.dismiss()` we were previously using needed to be migrated. I instead have this await the `viewModel.event` so we don't dismiss too early. I have recorded the processes below to confirm this is working as expected.

For `ServerActivityView`, I moved the filter from a `.sheet` to `ServerActivityFilterView`. This was probably the biggest change in terms of number of lines but this was almost a pure copy-paste.

I also migrated our last 2 `NavigationView` to `NavigationStack`.

## Assumptions

I left the following as stand alone `.sheet`:

1. `LearnMoreButton` - _Should_ be fine

I left the following as stand alone `.NavigationStack`:

1. `LearnMoreButton` - _Should_ be fine
2. `OrderedSectionSelectorView` - tvOS (didn't want to touch that yet)

## Outstanding Questions:

1. There is a TODO in `AppSettingsView`: `// TODO: Create NavigationRoute.appIconSelector`
2. I am getting this `Call to main actor-isolated instance method 'send' in a synchronous nonisolated context; this is an error in the Swift 6 language mode` in a few spots. Do we need to address this in advance?

## Videos

### Image - Deletion, Remote Search, & Upload

https://github.com/user-attachments/assets/fd4d507b-5154-48d0-9917-edb521c57c97

---

### Identification

https://github.com/user-attachments/assets/e1cd983a-4149-4832-bdc0-23efeac156e9

---

### Activity Filters

https://github.com/user-attachments/assets/491fb996-a890-4de5-a966-c40f1e9a6fdf
