### PR TITLE
Cleanup Player Documentation

### DIFF
--- a/Documentation/players.md
+++ b/Documentation/players.md
@@ -1,6 +1,6 @@
 # Player Differences
 
-Swiftfin offers two player options: Swiftfin (VLCKit) and Native (AVKit). The Swiftfin team recommends using Swiftfin (VLCKit) for optimal compatibility and features, though Native (AVKit) is also available for certain cases that benefit from Apple's native capabilities. All video, audio, and subtitle formats listed are supported for direct playback but may be repackaged based on container support. If transcoding is enabled on your server, any unsupported formats will be converted automatically.
+Swiftfin offers two player options: **Swiftfin** (VLCKit) and **Native** (AVKit). The Swiftfin team recommends using Swiftfin (VLCKit) for optimal compatibility and features, though Native (AVKit) is also available for certain cases that benefit from Apple's native capabilities. All video, audio, and subtitle formats listed are supported for direct playback but may be repackaged based on container support. If transcoding is enabled on your server, any unsupported formats will be converted automatically.
 
 ---
 
@@ -9,17 +9,17 @@ Swiftfin offers two player options: Swiftfin (VLCKit) and Native (AVKit). The Sw
 | Feature                 | Swiftfin (VLCKit) | Native (AVKit) |
 |-------------------------|-------------------|----------------|
 | **Framerate Matching**  | ❌                | ✅             |
-| **HDR to SDR Tonemapping** | ✅ [1]         | 🟡 Limited (MP4 only) [2] |
+| **HDR to SDR Tonemapping** | ✅ [1]         | 🔶 [2] |
 | **Player Controls**     | - Speed adjustment<br>- Aspect Fill<br>- Chapter Support<br>- Subtitle Support<br>- Audio Track Selection<br>- Customizable UI | - Speed adjustment<br>- Aspect Fill |
 | **Picture-in-Picture**  | ❌                | ✅             |
 | **TLS Support**         | 1.1, 1.2 [3]     | 1.1, 1.2, 1.3 |
-| **[Airplay Audio Output](https://support.apple.com/en-us/102357)** | 🟡 [4] | ✅ |
+| **[Airplay Audio Output](https://support.apple.com/en-us/102357)** | 🔶 [4] | ✅ |
 
 **Notes**
 
 [1] HDR to SDR Tonemapping on Swiftfin (VLCKit) may have colorspace accuracy variations depending on content and device configuration.
 
-[2] In Native (AVKit), HDR playback works regardless of DirectPlay or MP4 container format. However, HDR to SDR Tonemapping requires DirectPlaying compatible MP4 files and may require Dolby Vision Profiles 5 & 8 for full support.
+[2] In Native (AVKit), HDR to SDR Tonemapping requires Direct Playing compatible MP4 files and may require Dolby Vision Profiles 5 & 8 for full support.
 
 [3] Swiftfin (VLCKit) does not support TLS 1.3.
 
@@ -31,19 +31,25 @@ Swiftfin offers two player options: Swiftfin (VLCKit) and Native (AVKit). The Sw
 
 | Container | Swiftfin (VLCKit) | Native (AVKit) |
 |-----------|-------------------|----------------|
-| **AVI**   | ✅                | 🟡 Limited support |
+| **AVI**   | ✅                | 🔶 [1]         |
 | **FLV**   | ✅                | ❌             |
 | **M4V**   | ✅                | ✅             |
 | **MKV**   | ✅                | ❌             |
 | **MOV**   | ✅                | ✅             |
 | **MP4**   | ✅                | ✅             |
-| **MPEG-TS** | ✅              | 🟡 Limited support |
-| **TS**    | ✅                | 🟡 Limited support |
+| **MPEG-TS** | ✅              | 🔶 [2]         |
+| **TS**    | ✅                | 🔶 [3]         |
 | **3G2**   | ✅                | ✅             |
 | **3GP**   | ✅                | ✅             |
 | **WebM**  | ✅                | ❌             |
 
 **Notes**
+
+[1] AVI has limited support in Native (AVKit).
+
+[2] MPEG-TS has limited support in Native (AVKit).
+
+[3] TS has limited support in Native (AVKit).
 
 - Unsupported containers will require transcoding or remuxing to play.
 
@@ -68,7 +74,7 @@ Swiftfin offers two player options: Swiftfin (VLCKit) and Native (AVKit). The Sw
 | **MLP**       | ❌                | ❌             |
 | **Nellymoser**| ✅                | ❌             |
 | **Opus**      | ✅                | ❌             |
-| **PCM**       | ✅                | 🟡 Limited support |
+| **PCM**       | ✅                | 🔶 [1]         |
 | **Speex**     | ✅                | ❌             |
 | **TrueHD**    | ❌                | ❌             |
 | **Vorbis**    | ✅                | ❌             |
@@ -77,6 +83,10 @@ Swiftfin offers two player options: Swiftfin (VLCKit) and Native (AVKit). The Sw
 | **WMA Lossless**| ✅              | ❌             |
 | **WMA Pro**   | ✅                | ❌             |
 
+**Notes**
+
+[1] PCM has limited support in Native (AVKit).
+
 - Audio track selection is not currently supported in Native (AVKit) due to issues with HLS file incompatibilities.
 
 ---
@@ -84,16 +94,26 @@ Swiftfin offers two player options: Swiftfin (VLCKit) and Native (AVKit). The Sw
 ## Video Support
 
 | Video Codec | Swiftfin (VLCKit) | Native (AVKit) |
-|-------------|-------------------|----------------|
-| **AV1**     | ✅                | 🟡 Limited support |
-| **H.264**   | ✅                | ✅             |
-| **H.265**   | ✅                | ✅             |
-| **MPEG-2**  | ✅                | ❌             |
-| **MPEG-4**  | ✅                | ✅             |
-| **VP8**     | ✅                | ❌             |
-| **VP9**     | ✅                | ❌             |
+|------------------------------------------------------------------------------------------------|-------------------|----------------|
+| [H.261](https://en.wikipedia.org/wiki/H.261)                                                   | ✅                | ✅             |
+| [MPEG-4 Part 2/SP](https://en.wikipedia.org/wiki/DivX)                                         | ✅                | 🔶 [1]         |
+| [MPEG-4 Part 2/ASP](https://en.wikipedia.org/wiki/MPEG-4_Part_2#Advanced_Simple_Profile_(ASP)) | ✅                | 🔶 [1]         |
+| [H.264 8Bit](https://caniuse.com/#feat=mpeg4)                                                  | ✅                | ✅             |
+| [H.264 10Bit](https://caniuse.com/#feat=mpeg4)                                                 | ✅                | ✅             |
+| [H.265 8Bit](https://caniuse.com/#feat=hevc)                                                   | ✅                | 🔶 [2]         |
+| [H.265 10Bit](https://caniuse.com/#feat=hevc)                                                  | ✅                | 🔶 [2]         |
+| [VP9](https://developer.mozilla.org/en-US/docs/Web/Media/Formats/Video_codecs#VP9)             | ✅                | ❌             |
+| [AV1](https://developer.mozilla.org/en-US/docs/Web/Media/Formats/Video_codecs#AV1)             | ✅                | 🔶 [3]         |
 
-- AV1 is disabled by default but can be enabled for Native (AVKit) using Custom Device Profiles. Enabling AV1 may result in a [poor experience for SOCs prior to A17](https://en.wikipedia.org/wiki/Apple_A17).
+**Notes**
+
+[1] MPEG-4 Part 2 support may vary depending on encoding parameters and iOS version.
+
+[2] HEVC decoding is supported on Apple devices with the A8X chip or newer and at least iOS 14. HEVC is only supported in MP4, M4V, and MOV containers.
+
+[3] AV1 is disabled by default but can be enabled for Native (AVKit) using Custom Device Profiles. Enabling AV1 may result in a poor experience for SOCs prior to A17. AV1 is enabled by default for Swiftfin (VLCKit).
+
+- Unsupported video formats will require transcoding or remuxing to play.
 
 ---
 
@@ -103,17 +123,19 @@ Swiftfin offers two player options: Swiftfin (VLCKit) and Native (AVKit). The Sw
 |----------------|-------------------|----------------|
 | **ASS**        | ✅                | ❌             |
 | **CC_DEC**     | ✅                | ✅             |
-| **DVBSub**     | ✅                | ❌             |
-| **DVDSub**     | ✅                | ❌             |
-| **PGSSub**     | ✅                | ❌             |
+| **DVBSub**     | ✅                | 🔶 [1]         |
+| **DVDSub**     | ✅                | 🔶 [1]         |
+| **PGSSub**     | ✅                | 🔶 [1]         |
 | **SRT**        | ✅                | ❌             |
 | **SSA**        | ✅                | ❌             |
 | **Teletext**   | ✅                | ❌             |
 | **TTML**       | ✅                | ✅             |
 | **VTT**        | ✅                | ✅             |
-| **XSub**       | ✅                | ❌             |
+| **XSub**       | ✅                | 🔶 [1]         |
 
 **Notes**
+
+[1] Subtitle format require server-side encoding for Native (AVKit) playback.
 
 - Subtitle track selection is not currently supported in Native (AVKit) due to issues with HLS file incompatibilities.
 
@@ -124,17 +146,21 @@ Swiftfin offers two player options: Swiftfin (VLCKit) and Native (AVKit). The Sw
 | Format | Swiftfin (VLCKit) | Native (AVKit) |
 |--------|-------------------|----------------|
 | **Dolby Vision Profile 5** | ❌             | ✅             |
-| **Dolby Vision Profile 8** | ❌             | 🟡 Compatible devices only |
-| **Dolby Vision Profile 10** | ❌            | 🟡 Requires AV1 |
+| **Dolby Vision Profile 8** | ❌             | 🔶 [1]         |
+| **Dolby Vision Profile 10** | ❌            | 🔶 [2]         |
 | **HDR10** | ❌                              | ✅             |
-| **HDR10+** | ❌                             | 🟡 Limited support |
+| **HDR10+** | ❌                             | 🔶 [3]         |
 | **HLG** | ❌                                | ❌             |
 
 **Notes**
 
-- HDR10+ support in Native (AVKit) is limited to certain devices, such as the Apple TV 4K (3rd Generation) and recent iPhones and iPads with compatible hardware.
+[1] Dolby Vision Profile 8 support is limited to compatible devices only.
+
+[2] Dolby Vision Profile 10 requires AV1 to be enabled.
+
+[3] HDR10+ support is limited to certain devices, such as the Apple TV 4K (3rd Generation) and recent iPhones and iPads with compatible hardware.
+
 - HLG (Hybrid Log-Gamma) support in Native (AVKit) is limited and not currently supported in Swiftin.
-- Dolby Vision Profile 10 requires AV1 to be enabled to work in Native (AVKit).
 - Swiftfin (VLCKit) does not support HDR playback natively. HDR content may play back without the intended high dynamic range effect.
 
 --- 
@@ -144,7 +170,7 @@ Swiftfin offers two player options: Swiftfin (VLCKit) and Native (AVKit). The Sw
 Swiftfin track selection is limited by compatibility with each player. In testing, as of Swiftfin 1.3, the following interactions have been tested.
 
 ✅ Working correctly </br>
-🟡 Partially working with limitations </br>
+🔶 Partially working with limitations </br>
 ❌ Not working
 
 ## Swiftfin Player
@@ -152,12 +178,12 @@ Swiftfin track selection is limited by compatibility with each player. In testin
 | File Configuration                                       | DirectPlay | Transcode | Notes |
 |---------------------------------------------------------|------------|-----------|------------------------------------------------|
 | Internal Audio                                          | ✅         | ✅        |                                                |
-| Internal Audio + Internal Subtitles                    | ✅         | 🟡        | - Subtitles do not work if Non-External *(DVDSUB)* |
+| Internal Audio + Internal Subtitles                    | ✅         | 🔶        | - Subtitles do not work if Non-External *(DVDSUB)* |
 | Internal Audio + External Subtitles                    | ✅         | ✅        |                                                |
-| Internal Audio + Internal Subtitles + External Subtitles | ✅         | 🟡        | - Subtitles do not work if Non-External *(DVDSUB)* |
-| Multiple Internal Audio + Multiple Internal Subtitles  | ✅         | 🟡        | - Subtitles do not work if Non-External *(DVDSUB)* |
+| Internal Audio + Internal Subtitles + External Subtitles | ✅         | 🔶        | - Subtitles do not work if Non-External *(DVDSUB)* |
+| Multiple Internal Audio + Multiple Internal Subtitles  | ✅         | 🔶        | - Subtitles do not work if Non-External *(DVDSUB)* |
 | Multiple Internal Audio + Multiple External Subtitles  | ✅         | ✅        |                                                |
-| Multiple Internal Audio + Internal Subtitles + External Subtitles | ✅ | 🟡 | - Subtitles do not work if Non-External *(DVDSUB)* |
+| Multiple Internal Audio + Internal Subtitles + External Subtitles | ✅ | 🔶 | - Subtitles do not work if Non-External *(DVDSUB)* |
 | External Audio + Internal Audio + External Subtitles   | ✅         | ✅        | - Cannot play external audio track if transcoding is required </br> - Subtitles do not work if Non-External *(DVDSUB)* |
 | External Audio + Internal Audio + Internal Subtitles   | ✅         | ✅        | - Cannot play external audio track if transcoding is required </br> - Subtitles do not work if Non-External *(DVDSUB)* |
 | External Audio + Internal Audio + Internal Subtitles + External Subtitles | ✅ | ✅ | - Cannot play external audio track if transcoding is required </br> - Subtitles do not work if Non-External *(DVDSUB)* |
@@ -167,15 +193,15 @@ Swiftfin track selection is limited by compatibility with each player. In testin
 | File Configuration                                      | DirectPlay | Transcode | Notes |
 |--------------------------------------------------------|------------|-----------|------------------------------------------------|
 | Internal Audio                                         | ✅         | ✅        |                                                |
-| Internal Audio + Internal Subtitles                   | 🟡         | ❌        | - The default audio track will played </br> - subtitles cannot be selected. |
-| Internal Audio + External Subtitles                   | 🟡         | ❌        | - The default audio track will played </br> - subtitles cannot be selected. |
-| Internal Audio + Internal Subtitles + External Subtitles | 🟡      | ❌        | - The default audio track will played </br> - subtitles cannot be selected. |
-| Multiple Internal Audio + Multiple Internal Subtitles | 🟡         | ❌        | - The default audio track will played </br> - subtitles cannot be selected. |
-| Multiple Internal Audio + Multiple External Subtitles | 🟡         | ❌        | - The default audio track will played </br> - subtitles cannot be selected. |
-| Multiple Internal Audio + Internal Subtitles + External Subtitles | 🟡 | ❌ | - The default audio track will played </br> - subtitles cannot be selected. |
-| External Audio + Internal Audio + External Subtitles  | 🟡         | ❌        | - The default audio track will played </br> - subtitles cannot be selected. |
-| External Audio + Internal Audio + Internal Subtitles  | 🟡         | ❌        | - The default audio track will played </br> - subtitles cannot be selected. |
-| External Audio + Internal Audio + Internal Subtitles + External Subtitles | 🟡 | ❌ | - The default audio track will played </br> - subtitles cannot be selected. |
+| Internal Audio + Internal Subtitles                   | 🔶         | ❌        | - The default audio track will played </br> - subtitles cannot be selected. |
+| Internal Audio + External Subtitles                   | 🔶         | ❌        | - The default audio track will played </br> - subtitles cannot be selected. |
+| Internal Audio + Internal Subtitles + External Subtitles | 🔶      | ❌        | - The default audio track will played </br> - subtitles cannot be selected. |
+| Multiple Internal Audio + Multiple Internal Subtitles | 🔶         | ❌        | - The default audio track will played </br> - subtitles cannot be selected. |
+| Multiple Internal Audio + Multiple External Subtitles | 🔶         | ❌        | - The default audio track will played </br> - subtitles cannot be selected. |
+| Multiple Internal Audio + Internal Subtitles + External Subtitles | 🔶 | ❌ | - The default audio track will played </br> - subtitles cannot be selected. |
+| External Audio + Internal Audio + External Subtitles  | 🔶         | ❌        | - The default audio track will played </br> - subtitles cannot be selected. |
+| External Audio + Internal Audio + Internal Subtitles  | 🔶         | ❌        | - The default audio track will played </br> - subtitles cannot be selected. |
+| External Audio + Internal Audio + Internal Subtitles + External Subtitles | 🔶 | ❌ | - The default audio track will played </br> - subtitles cannot be selected. |
 
 --- 
 
@@ -183,5 +209,7 @@ Swiftfin track selection is limited by compatibility with each player. In testin
 
 | Feature | Swiftfin (VLCKit) | Native (AVKit) | Notes |
 |-------------|-------------------|----------------|----------------|
-| **External Display Support** | 🟡        | ✅        | Swiftfin Player can only be mirrored. As a result, the player will retain the source device dimensions. |
+| **External Display Support** | 🔶        | ✅        | Swiftfin Player can only be mirrored. As a result, the player will retain the source device dimensions. |
+| **Energy Consumption** | 🔶        | ✅        | Swiftfin Player will use a software decoder if the media cannot be handled by iOS natively. This results in higher power consumption. |
 
+---


### PR DESCRIPTION
### Summary

Update the video player documentation to better mirror https://jellyfin.org/docs/general/clients/codec-support/#video-compatibility.

1. Changes 🟡 to 🔶. This is not necessary but it mirrors Jellyfin's main documentation 🤷‍♂️.
2. Adds a note about power consumption and VLC.
3. Better mirrors our device profiles in code (Subtitles that are encoded, H.261, etc). I have not tested this for documentation but if we have this enabled in code it should be mirrored in documentation.
4. Moves some comments from inline to under the table.
5. Validated the Video formats to include depth. I have just mirrored what we have in our device profiles.

This is all based on the previous work of others in creating our profiles. Unfortunately, Apple doesn't seem to _have_ a simple table of AVKit and supported formats so I'm leaning a lot of testing and recording but this is far from foolproof.

I've made a note to review this after https://github.com/jellyfin/Swiftfin/pull/1581 as I suspect things may change.