### PR TITLE
[iOS & tvOS] Fetch correct server from SwiftfinStore when updating server info

### DIFF
--- a/Shared/SwiftfinStore/SwiftfinStore+ServerState.swift
+++ b/Shared/SwiftfinStore/SwiftfinStore+ServerState.swift
@@ -81,7 +81,7 @@ extension ServerState {
 
     func updateServerInfo() async throws {
         guard let server = try? SwiftfinStore.dataStack.fetchOne(
-            From<ServerModel>()
+            From<ServerModel>().where(Where(\.$id == id))
         ) else { return }
 
         let publicInfo = try await getPublicSystemInfo()


### PR DESCRIPTION
When ServerState objects get updated info from the remote server, the ServerModel fetched from SwiftfinStore didn't have its id specified, so updateServerInfo would always update the one server with the info from whatever server Swiftfin most recently updated its info for. This doesn't have any effect when Swiftfin is only connected to one server, but when another server is added, it causes glitches in the server selection screen because two servers will sometimes share an ID.

Fixes #1619 