### PR TITLE
Only log failed CoreStoreLogger assertions

### DIFF
--- a/Shared/Logging/SwiftfinCorestoreLogger.swift
+++ b/Shared/Logging/SwiftfinCorestoreLogger.swift
@@ -55,16 +55,15 @@ struct SwiftfinCorestoreLogger: CoreStoreLogger {
         lineNumber: Int,
         functionName: StaticString
     ) {
-        if !condition() {
-            logger.critical(
-                "\(message())",
-                metadata: nil,
-                source: "Corestore",
-                file: fileName.description,
-                function: functionName.description,
-                line: UInt(lineNumber)
-            )
-        }
+        guard !condition() else { return }
+        logger.critical(
+            "\(message())",
+            metadata: nil,
+            source: "Corestore",
+            file: fileName.description,
+            function: functionName.description,
+            line: UInt(lineNumber)
+        )
     }
 }
 

--- a/Shared/Logging/SwiftfinCorestoreLogger.swift
+++ b/Shared/Logging/SwiftfinCorestoreLogger.swift
@@ -55,14 +55,16 @@ struct SwiftfinCorestoreLogger: CoreStoreLogger {
         lineNumber: Int,
         functionName: StaticString
     ) {
-        logger.critical(
-            "\(message())",
-            metadata: nil,
-            source: "Corestore",
-            file: fileName.description,
-            function: functionName.description,
-            line: UInt(lineNumber)
-        )
+        if !condition() {
+            logger.critical(
+                "\(message())",
+                metadata: nil,
+                source: "Corestore",
+                file: fileName.description,
+                function: functionName.description,
+                line: UInt(lineNumber)
+            )
+        }
     }
 }
 


### PR DESCRIPTION
Currently the console is full of critical logs from CoreStore because assertions are logged whether it's true or false. This just wraps the logger call so it only logs places where the assertion actually fails.

For reference, [here's a call to assert inside CoreStore](https://github.com/JohnEstropia/CoreStore/blob/104def4611b8f8c2067903b589d01d198d51e6d6/Sources/DataStack%2BQuerying.swift#L145).