### PR TITLE
[tvOS & iOS] Fix navigation to server edit screen

### DIFF
--- a/Swiftfin tvOS/Views/SelectUserView/Components/ServerSelectionMenu.swift
+++ b/Swiftfin tvOS/Views/SelectUserView/Components/ServerSelectionMenu.swift
@@ -81,7 +81,7 @@ extension SelectUserView {
                 Section {
                     if let selectedServer {
                         Button(L10n.editServer, systemImage: "server.rack") {
-                            router.route(to: .editServer(server: selectedServer))
+                            router.route(to: .editServerFromSelectUser(server: selectedServer))
                         }
                     }
 

--- a/Swiftfin/Views/SelectUserView/Components/ServerSelectionMenu.swift
+++ b/Swiftfin/Views/SelectUserView/Components/ServerSelectionMenu.swift
@@ -44,7 +44,7 @@ extension SelectUserView {
 
                     if let selectedServer {
                         Button(L10n.editServer, systemImage: "server.rack") {
-                            router.route(to: .editServer(server: selectedServer))
+                            router.route(to: .editServerFromSelectUser(server: selectedServer))
                         }
                     }
                 }


### PR DESCRIPTION
Re-fixes #1221 after a regression.

The `editServerFromSelectUser` route sets the `.isEditing` env variable true and allows server deletion from the edit view.