### PR TITLE
[tvOS] Fix crash when editing server from user selection

### DIFF
--- a/Swiftfin tvOS/Views/ServerDetailView.swift
+++ b/Swiftfin tvOS/Views/ServerDetailView.swift
@@ -78,7 +78,7 @@ struct EditServerView: View {
                 } header: {
                     L10n.url.text
                 } footer: {
-                    if !viewModel.userSession.server.isVersionCompatible {
+                    if !viewModel.server.isVersionCompatible {
                         Label(
                             L10n.serverVersionWarning(JellyfinClient.sdkVersion.majorMinor.description),
                             systemImage: "exclamationmark.circle.fill"


### PR DESCRIPTION
The tvOS EditServerView shows the server version compatibility warning based on the current session, which is nil when not signed in so it always crashes when opening the edit view from the user selection screen. 

This changes the check to be the same as [in iOS](https://github.com/jellyfin/Swiftfin/blob/1b07876db47e013e2257bb51377510b19f4a983f/Swiftfin/Views/EditServerView.swift#L62)