### PR TITLE
Keep updateServerInfo on main thread

### DIFF
--- a/Shared/SwiftfinStore/SwiftfinStore+ServerState.swift
+++ b/Shared/SwiftfinStore/SwiftfinStore+ServerState.swift
@@ -79,6 +79,7 @@ extension ServerState {
         return ImageSource(url: client.fullURL(with: request))
     }
 
+    @MainActor
     func updateServerInfo() async throws {
         guard let server = try? SwiftfinStore.dataStack.fetchOne(
             From<ServerModel>().where(Where(\.$id == id))


### PR DESCRIPTION
Noticed errors in the log from the StoredServer CoreStore object being accessed and `fetchOne` being called outside main. updateServerInfo is called from a Task in `ServerCheckViewModel` so it's off the main thread.