### PR TITLE
Handle `.show` `UserView`s Recursively

### DIFF
--- a/Shared/Extensions/JellyfinAPI/BaseItemDto/BaseItemDto+LibraryParent.swift
+++ b/Shared/Extensions/JellyfinAPI/BaseItemDto/BaseItemDto+LibraryParent.swift
@@ -33,9 +33,8 @@ extension BaseItemDto: LibraryParent {
     }
 
     var isRecursiveCollection: Bool {
-        if let collectionType, [.tvshows, .boxsets].contains(collectionType) {
-            return false
-        }
-        return true
+        guard let collectionType, libraryType != .userView else { return true }
+
+        return ![.tvshows, .boxsets].contains(collectionType)
     }
 }


### PR DESCRIPTION
### Summary

Resolves: #1631 

When a user chooses to group two libraries together by Type in their `User Settings > Home`, this creates a `UserView`. So, we have Libraries which are `CollectionFolder`s and we have grouped Libraries by Type, which are `UserView`.

Currently, these show as empty in Swiftfin. This is because the `CollectionTypes` are set based on the grouping type. So, TV Shows specifically are set to `isRecursiveCollection` == `False`. This is correct for `CollectionFolder`s but causes `UserView`s to show as empty.

This only impacts `UserView` which are `Shows`.

<details>

<summary>Ungrouped Libraries</summary>

**Jellyfin-Web:**

Settings:
<img width="1470" height="795" alt="Screenshot 2025-07-15 at 13 15 33" src="https://github.com/user-attachments/assets/a0988a98-5e26-4621-b5af-c83e1b681874" />

Libraries:
<img width="1470" height="794" alt="Screenshot 2025-07-15 at 13 15 51" src="https://github.com/user-attachments/assets/64f4f684-3ad4-42c7-b2ab-264b3c3030ff" />

**Swiftfin:**

https://github.com/user-attachments/assets/4b7e9117-ae08-4b7e-9cc2-c23bf7d71e60

</details>

<details>

<summary>Grouped Libraries</summary>

**Jellyfin-Web:**

Settings:
<img width="1470" height="796" alt="Screenshot 2025-07-15 at 13 16 47" src="https://github.com/user-attachments/assets/58b0b652-047a-4578-90ac-bb3a2b1dd5e9" />

Libraries:
<img width="1470" height="798" alt="Screenshot 2025-07-15 at 13 16 58" src="https://github.com/user-attachments/assets/3275c46c-957f-4a59-864b-324ea8cb9966" />

**Swiftfin:**

https://github.com/user-attachments/assets/85a59950-5af0-4d88-8446-b7a65db14e7a

</details>