### PR TITLE
[iOS] CinematicScrollView: Replace UIScreen bounds with GeometryReader

### DIFF
--- a/Swiftfin/Views/ItemView/ScrollViews/CinematicScrollView.swift
+++ b/Swiftfin/Views/ItemView/ScrollViews/CinematicScrollView.swift
@@ -42,13 +42,15 @@ extension ItemView {
 
             let bottomColor = viewModel.item.blurHash(for: imageType)?.averageLinearColor ?? Color.secondarySystemFill
 
-            ImageView(viewModel.item.imageSource(
-                imageType,
-                maxWidth: UIScreen.main.bounds.width
-            ))
-            .aspectRatio(usePrimaryImage ? (2 / 3) : 1.77, contentMode: .fill)
-            .frame(height: UIScreen.main.bounds.height * 0.6)
-            .bottomEdgeGradient(bottomColor: bottomColor)
+            GeometryReader { proxy in
+                ImageView(viewModel.item.imageSource(
+                    imageType,
+                    maxWidth: proxy.size.width
+                ))
+                .aspectRatio(usePrimaryImage ? (2 / 3) : 1.77, contentMode: .fill)
+                .frame(width: proxy.size.width, height: proxy.size.height * 0.6)
+                .bottomEdgeGradient(bottomColor: bottomColor)
+            }
         }
 
         var body: some View {


### PR DESCRIPTION
Part of #1503's task replacing uses of UIScreen bounds.

The overall appearance is not significantly changed for either backdrop or poster images, and this incidentally fixes backdrop images being too low res and poster images extending too far down and obscuring the genre/year text.

<details><summary>Before & After (Backdrop)</summary>

<img src="https://github.com/user-attachments/assets/c5251f18-38b9-42e8-9a43-b86c96fc3eee" width="400">

<img src="https://github.com/user-attachments/assets/79c597b8-2f8f-47d7-a75c-8935edf71a29" width="400">

</details>


<details><summary>Before & After (Poster)</summary>

<img src="https://github.com/user-attachments/assets/a098bd7e-96aa-4b9d-bd88-8cf7212c5695" width="400">

<img src="https://github.com/user-attachments/assets/22efb15b-4d75-4e19-afb0-3357e2a3c00c" width="400">

</details>

