### PR TITLE
`PlayButton` Cleanup

### DIFF
--- a/Swiftfin tvOS/Views/ItemView/Components/PlayButton/PlayButton.swift
+++ b/Swiftfin tvOS/Views/ItemView/Components/PlayButton/PlayButton.swift
@@ -6,16 +6,13 @@
 // Copyright (c) 2025 Jellyfin & Jellyfin Contributors
 //
 
-import Factory
 import JellyfinAPI
+import Logging
 import SwiftUI
 
 extension ItemView {
 
     struct PlayButton: View {
-
-        @Injected(\.logService)
-        private var logger
 
         @Router
         private var router
@@ -25,6 +22,16 @@ extension ItemView {
 
         @FocusState
         private var isFocused: Bool
+
+        private let logger = Logger.swiftfin()
+
+        // MARK: - Dialog States
+
+        @State
+        private var isPresentingResume = false
+
+        @State
+        private var error: Error?
 
         // MARK: - Media Sources
 
@@ -38,14 +45,40 @@ extension ItemView {
             mediaSources.count > 1
         }
 
+        // MARK: - Validation
+
+        private var isValid: Bool {
+            viewModel.playButtonItem != nil
+        }
+
         // MARK: - Title
 
         private var title: String {
-            if let seriesViewModel = viewModel as? SeriesItemViewModel {
-                return seriesViewModel.playButtonItem?.seasonEpisodeLabel ?? L10n.play
+            if let seriesViewModel = viewModel as? SeriesItemViewModel,
+               let seasonEpisodeLabel = seriesViewModel.playButtonItem?.seasonEpisodeLabel
+            {
+                return seasonEpisodeLabel
+            } else if let playButtonLabel = viewModel.playButtonItem?.playButtonLabel {
+                return playButtonLabel
             } else {
-                return viewModel.playButtonItem?.playButtonLabel ?? L10n.play
+                return L10n.play
             }
+
+            // TODO: For use with `MarqueeText` on the `PlayButton`
+
+            /* if let sourceLabel = viewModel.selectedMediaSource?.displayTitle,
+                viewModel.item.mediaSources?.count ?? 0 > 1
+             {
+                 return sourceLabel
+             } else if let seriesViewModel = viewModel as? SeriesItemViewModel,
+                       let seasonEpisodeLabel = seriesViewModel.playButtonItem?.seasonEpisodeLabel
+             {
+                 return seasonEpisodeLabel
+             } else if let playButtonLabel = viewModel.playButtonItem?.playButtonLabel {
+                 return playButtonLabel
+             } else {
+                 return L10n.play
+             } */
         }
 
         // MARK: - Body
@@ -65,33 +98,26 @@ extension ItemView {
 
         private var playButton: some View {
             Button {
-                if let playButtonItem = viewModel.playButtonItem,
-                   let selectedMediaSource = viewModel.selectedMediaSource
-                {
-                    router.route(
-                        to: .videoPlayer(manager: OnlineVideoPlayerManager(
-                            item: playButtonItem,
-                            mediaSource: selectedMediaSource
-                        ))
-                    )
+                if viewModel.playButtonItem?.userData?.playbackPositionTicks == 0 {
+                    playContent()
                 } else {
-                    logger.error("No media source available")
+                    isPresentingResume = true
                 }
             } label: {
                 HStack(spacing: 15) {
                     Image(systemName: "play.fill")
-                        .foregroundColor(viewModel.playButtonItem == nil ? Color(UIColor.secondaryLabel) : Color.black)
+                        .foregroundColor(!isValid ? Color(UIColor.secondaryLabel) : Color.black)
                         .font(.title3)
 
                     Text(title)
-                        .foregroundStyle(viewModel.playButtonItem == nil ? Color(UIColor.secondaryLabel) : Color.black)
+                        .foregroundStyle(!isValid ? Color(UIColor.secondaryLabel) : Color.black)
                         .fontWeight(.semibold)
                 }
                 .padding(20)
                 .frame(width: multipleVersions ? 320 : 440, height: 100, alignment: .center)
                 .background {
                     if isFocused {
-                        viewModel.playButtonItem == nil ? Color.secondarySystemFill : Color.white
+                        !isValid ? Color.secondarySystemFill : Color.white
                     } else {
                         Color.white
                             .opacity(0.5)
@@ -99,32 +125,46 @@ extension ItemView {
                 }
                 .cornerRadius(10)
             }
+            .disabled(!isValid)
             .focused($isFocused)
             .buttonStyle(.card)
-            .contextMenu {
-                if viewModel.playButtonItem != nil,
-                   viewModel.item.userData?.playbackPositionTicks ?? 0 > 0
-                {
-                    Button {
-                        if var playButtonItem = viewModel.playButtonItem,
-                           let selectedMediaSource = viewModel.selectedMediaSource
-                        {
-                            /// Reset playback to the beginning
-                            playButtonItem.userData?.playbackPositionTicks = 0
-
-                            router.route(
-                                to: .videoPlayer(manager: OnlineVideoPlayerManager(
-                                    item: playButtonItem,
-                                    mediaSource: selectedMediaSource
-                                ))
-                            )
-                        } else {
-                            logger.error("No media source available")
-                        }
-                    } label: {
-                        Label(L10n.playFromBeginning, systemImage: "gobackward")
-                    }
+            .alert(viewModel.item.displayTitle, isPresented: $isPresentingResume) {
+                Button(L10n.resume) {
+                    playContent()
                 }
+
+                Button(L10n.playFromBeginning) {
+                    playContent(restart: true)
+                }
+
+                Button(L10n.cancel, role: .cancel) {
+                    isPresentingResume = false
+                }
+            }
+            .errorMessage($error)
+        }
+
+        // MARK: - Play Content
+
+        private func playContent(restart: Bool = false) {
+            if var playButtonItem = viewModel.playButtonItem,
+               let selectedMediaSource = viewModel.selectedMediaSource
+            {
+                if restart {
+                    playButtonItem.userData?.playbackPositionTicks = 0
+                }
+
+                router.route(
+                    to: .videoPlayer(
+                        manager: OnlineVideoPlayerManager(
+                            item: playButtonItem,
+                            mediaSource: selectedMediaSource
+                        )
+                    )
+                )
+            } else {
+                logger.error("No media source available")
+                error = JellyfinAPIError("No media source available")
             }
         }
     }


### PR DESCRIPTION
### Summary

The primary goal of this PR was to move the `PlayButton` to use the new logger. While I was there, I moved some repetitive items into a shared `func`. I also was finding that the context menu for resuming wasn't very intuitive. I frankly forgot that's how I set this up so I had to look at the code to remember where the resume button was. Instead, I am mirroring what other apps do and, on a resumable item, I am prompting the user via an alert for Resume, Play From Beginning, or Cancel.

On iOS, I think this is about a net neutral. It's more up-front and will result in more people being aware that we have a Play From Beginning functionality but appearance wise it's about the same. tvOS, IMO, this looks much better and works well.

Finally, as a last bit of cleanup, I removed the usages of `playbuttonitem == nil` and used a single var for `isValid`. Also, I added in the logic we'd need for `MarqueeText` to display the selected `mediaSource` once https://github.com/jellyfin/Swiftfin/pull/1634 is complete. This isn't a requirement and I can remove it if we either don't want it or feel like this should look different in a final version. All of the logic is there and commented out with a TODO for later.

The logger should also now use the correct logger usage for both iOS and tvOS along with producing an error message alert if there is ever an issue so the user is more aware if there isn't a valid media source.

### Videos

**iOS**

https://github.com/user-attachments/assets/21cfc0d0-de2a-4f2e-82c3-68590c2ba3fe


**tvOS**

https://github.com/user-attachments/assets/db7cfc8c-99ab-4e5e-941d-0912076f31dd
