### PR TITLE
Remove Non-Media Tracks from Video Player Dropdown

### DIFF
--- a/Shared/Extensions/JellyfinAPI/MediaStream.swift
+++ b/Shared/Extensions/JellyfinAPI/MediaStream.swift
@@ -224,9 +224,6 @@ extension [MediaStream] {
 
         let subtitleInternal = internalTracks.filter { $0.type == .subtitle }
 
-        // TODO: Do we need this for other media types? I think movies/shows we only care about video, audio, and subtitles.
-        let otherInternal = internalTracks.filter { $0.type != .video && $0.type != .audio && $0.type != .subtitle }
-
         if playMethod == .transcode {
             // Only include the first video and first audio track for transcode.
             let videoInternal = internalTracks.filter { $0.type == .video }
@@ -240,12 +237,11 @@ extension [MediaStream] {
             }
 
             orderedInternal += subtitleInternal
-            orderedInternal += otherInternal
         } else {
             let videoInternal = internalTracks.filter { $0.type == .video }
             let audioInternal = internalTracks.filter { $0.type == .audio }
 
-            orderedInternal = videoInternal + audioInternal + subtitleInternal + otherInternal
+            orderedInternal = videoInternal + audioInternal + subtitleInternal
         }
 
         var newInternalTracks: [MediaStream] = []


### PR DESCRIPTION
### Summary

Resolves: https://github.com/jellyfin/Swiftfin/issues/1652

When we last fixed the media track offsets, I left a `TODO` about whether we need non-media tracks. The answer is no. When an image is embedded into the video, we must ignore this track and its index for tracks to align appropriately. Now only taking Video, Audio, and Subtitles.

If we do need Other types later (I cannot think of what would require this) we would likely want a video track offset and an other track offset.