### PR TITLE
[iOS] Remove UIScreen from CompactLogo & CompactPoster views

### DIFF
--- a/Swiftfin/Views/ItemView/ScrollViews/CompactLogoScrollView.swift
+++ b/Swiftfin/Views/ItemView/ScrollViews/CompactLogoScrollView.swift
@@ -36,7 +36,7 @@ extension ItemView {
             GeometryReader { proxy in
                 if proxy.size.height.isZero { EmptyView() }
                 else {
-                    ImageView(viewModel.item.imageSource(.backdrop, maxWidth: proxy.size.height * 0.70 * 1.77))
+                    ImageView(viewModel.item.imageSource(.backdrop, maxWidth: 1320))
                         .aspectRatio(1.77, contentMode: .fill)
                         .frame(width: proxy.size.width, height: proxy.size.height * 0.70, alignment: .top)
                         .bottomEdgeGradient(bottomColor: bottomColor)

--- a/Swiftfin/Views/ItemView/ScrollViews/CompactLogoScrollView.swift
+++ b/Swiftfin/Views/ItemView/ScrollViews/CompactLogoScrollView.swift
@@ -38,7 +38,7 @@ extension ItemView {
                 else {
                     ImageView(viewModel.item.imageSource(.backdrop, maxWidth: proxy.size.height * 0.70 * 1.77))
                         .aspectRatio(1.77, contentMode: .fill)
-                        .frame(height: proxy.size.height * 0.70, alignment: .top)
+                        .frame(width: proxy.size.width, height: proxy.size.height * 0.70, alignment: .top)
                         .bottomEdgeGradient(bottomColor: bottomColor)
                 }
             }

--- a/Swiftfin/Views/ItemView/ScrollViews/CompactLogoScrollView.swift
+++ b/Swiftfin/Views/ItemView/ScrollViews/CompactLogoScrollView.swift
@@ -36,7 +36,7 @@ extension ItemView {
             GeometryReader { proxy in
                 if proxy.size.height.isZero { EmptyView() }
                 else {
-                    ImageView(viewModel.item.imageSource(.backdrop, maxWidth: proxy.size.width))
+                    ImageView(viewModel.item.imageSource(.backdrop, maxWidth: proxy.size.height * 0.70 * 1.77))
                         .aspectRatio(1.77, contentMode: .fill)
                         .frame(height: proxy.size.height * 0.70, alignment: .top)
                         .bottomEdgeGradient(bottomColor: bottomColor)

--- a/Swiftfin/Views/ItemView/ScrollViews/CompactLogoScrollView.swift
+++ b/Swiftfin/Views/ItemView/ScrollViews/CompactLogoScrollView.swift
@@ -33,10 +33,15 @@ extension ItemView {
 
             let bottomColor = viewModel.item.blurHash(for: .backdrop)?.averageLinearColor ?? Color.secondarySystemFill
 
-            ImageView(viewModel.item.imageSource(.backdrop, maxHeight: UIScreen.main.bounds.height * 0.35))
-                .aspectRatio(1.77, contentMode: .fill)
-                .frame(height: UIScreen.main.bounds.height * 0.35)
-                .bottomEdgeGradient(bottomColor: bottomColor)
+            GeometryReader { proxy in
+                if proxy.size.height.isZero { EmptyView() }
+                else {
+                    ImageView(viewModel.item.imageSource(.backdrop, maxWidth: proxy.size.width))
+                        .aspectRatio(1.77, contentMode: .fill)
+                        .frame(height: proxy.size.height * 0.70, alignment: .top)
+                        .bottomEdgeGradient(bottomColor: bottomColor)
+                }
+            }
         }
 
         var body: some View {

--- a/Swiftfin/Views/ItemView/ScrollViews/CompactLogoScrollView.swift
+++ b/Swiftfin/Views/ItemView/ScrollViews/CompactLogoScrollView.swift
@@ -34,13 +34,10 @@ extension ItemView {
             let bottomColor = viewModel.item.blurHash(for: .backdrop)?.averageLinearColor ?? Color.secondarySystemFill
 
             GeometryReader { proxy in
-                if proxy.size.height.isZero { EmptyView() }
-                else {
-                    ImageView(viewModel.item.imageSource(.backdrop, maxWidth: 1320))
-                        .aspectRatio(1.77, contentMode: .fill)
-                        .frame(width: proxy.size.width, height: proxy.size.height * 0.70, alignment: .top)
-                        .bottomEdgeGradient(bottomColor: bottomColor)
-                }
+                ImageView(viewModel.item.imageSource(.backdrop, maxWidth: 1320))
+                    .aspectRatio(1.77, contentMode: .fill)
+                    .frame(width: proxy.size.width, height: proxy.size.height * 0.70, alignment: .top)
+                    .bottomEdgeGradient(bottomColor: bottomColor)
             }
         }
 

--- a/Swiftfin/Views/ItemView/ScrollViews/CompactPortraitScrollView.swift
+++ b/Swiftfin/Views/ItemView/ScrollViews/CompactPortraitScrollView.swift
@@ -30,6 +30,7 @@ extension ItemView {
         }
 
         private func withHeaderImageItem(
+            maxWidth: CGFloat,
             @ViewBuilder content: @escaping (ImageSource, Color) -> some View
         ) -> some View {
 
@@ -45,7 +46,7 @@ extension ItemView {
 
             let imageType: ImageType = item.type == .episode ? .primary : .backdrop
             let bottomColor = item.blurHash(for: imageType)?.averageLinearColor ?? Color.secondarySystemFill
-            let imageSource = item.imageSource(imageType, maxWidth: UIScreen.main.bounds.width)
+            let imageSource = item.imageSource(imageType, maxWidth: maxWidth)
 
             return content(imageSource, bottomColor)
                 .id(imageSource.url?.hashValue)
@@ -54,11 +55,16 @@ extension ItemView {
 
         @ViewBuilder
         private var headerView: some View {
-            withHeaderImageItem { imageSource, bottomColor in
-                ImageView(imageSource)
-                    .aspectRatio(1.77, contentMode: .fill)
-                    .frame(height: UIScreen.main.bounds.height * 0.35)
-                    .bottomEdgeGradient(bottomColor: bottomColor)
+            GeometryReader { proxy in
+                if proxy.size.height.isZero { EmptyView() }
+                else {
+                    withHeaderImageItem(maxWidth: proxy.size.width) { imageSource, bottomColor in
+                        ImageView(imageSource)
+                            .aspectRatio(1.77, contentMode: .fill)
+                            .frame(height: proxy.size.height * 0.78)
+                            .bottomEdgeGradient(bottomColor: bottomColor)
+                    }
+                }
             }
         }
 
@@ -119,6 +125,7 @@ extension ItemView.CompactPosterScrollView {
 
                 Text(viewModel.item.displayTitle)
                     .font(.title2)
+                    .lineLimit(2)
                     .fontWeight(.semibold)
                     .foregroundColor(.white)
 

--- a/Swiftfin/Views/ItemView/ScrollViews/CompactPortraitScrollView.swift
+++ b/Swiftfin/Views/ItemView/ScrollViews/CompactPortraitScrollView.swift
@@ -58,7 +58,7 @@ extension ItemView {
             GeometryReader { proxy in
                 if proxy.size.height.isZero { EmptyView() }
                 else {
-                    withHeaderImageItem(maxWidth: proxy.size.width) { imageSource, bottomColor in
+                    withHeaderImageItem(maxWidth: proxy.size.height * 0.78 * 1.77) { imageSource, bottomColor in
                         ImageView(imageSource)
                             .aspectRatio(1.77, contentMode: .fill)
                             .frame(height: proxy.size.height * 0.78)

--- a/Swiftfin/Views/ItemView/ScrollViews/CompactPortraitScrollView.swift
+++ b/Swiftfin/Views/ItemView/ScrollViews/CompactPortraitScrollView.swift
@@ -55,14 +55,11 @@ extension ItemView {
         @ViewBuilder
         private var headerView: some View {
             GeometryReader { proxy in
-                if proxy.size.height.isZero { EmptyView() }
-                else {
-                    withHeaderImageItem { imageSource, bottomColor in
-                        ImageView(imageSource)
-                            .aspectRatio(1.77, contentMode: .fill)
-                            .frame(width: proxy.size.width, height: proxy.size.height * 0.78, alignment: .top)
-                            .bottomEdgeGradient(bottomColor: bottomColor)
-                    }
+                withHeaderImageItem { imageSource, bottomColor in
+                    ImageView(imageSource)
+                        .aspectRatio(1.77, contentMode: .fill)
+                        .frame(width: proxy.size.width, height: proxy.size.height * 0.78, alignment: .top)
+                        .bottomEdgeGradient(bottomColor: bottomColor)
                 }
             }
         }

--- a/Swiftfin/Views/ItemView/ScrollViews/CompactPortraitScrollView.swift
+++ b/Swiftfin/Views/ItemView/ScrollViews/CompactPortraitScrollView.swift
@@ -30,7 +30,6 @@ extension ItemView {
         }
 
         private func withHeaderImageItem(
-            maxWidth: CGFloat,
             @ViewBuilder content: @escaping (ImageSource, Color) -> some View
         ) -> some View {
 
@@ -46,7 +45,7 @@ extension ItemView {
 
             let imageType: ImageType = item.type == .episode ? .primary : .backdrop
             let bottomColor = item.blurHash(for: imageType)?.averageLinearColor ?? Color.secondarySystemFill
-            let imageSource = item.imageSource(imageType, maxWidth: maxWidth)
+            let imageSource = item.imageSource(imageType, maxWidth: 1320)
 
             return content(imageSource, bottomColor)
                 .id(imageSource.url?.hashValue)
@@ -58,7 +57,7 @@ extension ItemView {
             GeometryReader { proxy in
                 if proxy.size.height.isZero { EmptyView() }
                 else {
-                    withHeaderImageItem(maxWidth: proxy.size.height * 0.78 * 1.77) { imageSource, bottomColor in
+                    withHeaderImageItem { imageSource, bottomColor in
                         ImageView(imageSource)
                             .aspectRatio(1.77, contentMode: .fill)
                             .frame(width: proxy.size.width, height: proxy.size.height * 0.78, alignment: .top)

--- a/Swiftfin/Views/ItemView/ScrollViews/CompactPortraitScrollView.swift
+++ b/Swiftfin/Views/ItemView/ScrollViews/CompactPortraitScrollView.swift
@@ -61,7 +61,7 @@ extension ItemView {
                     withHeaderImageItem(maxWidth: proxy.size.height * 0.78 * 1.77) { imageSource, bottomColor in
                         ImageView(imageSource)
                             .aspectRatio(1.77, contentMode: .fill)
-                            .frame(height: proxy.size.height * 0.78)
+                            .frame(width: proxy.size.width, height: proxy.size.height * 0.78, alignment: .top)
                             .bottomEdgeGradient(bottomColor: bottomColor)
                     }
                 }


### PR DESCRIPTION
More UIScreen replacement changes from #1503 

I made the backdrop images consistent in resolution between the two views and also fixed CompactPoster's title growing off the screen for really long titles. Otherwise it's visually identical


~I could also make these use static sizes, but an image that's sharp on a new Pro Max phone would be too large and get aliased on an SE~

Picked a static width of 1320, which is the width of the 16PM.

  <details><summary>Before & After (Poster)</summary>

  <img src="https://github.com/user-attachments/assets/ebe0159c-c6a4-4e47-9689-2cdd9a8a430f" width="400">

  <img src="https://github.com/user-attachments/assets/a9597213-1092-43aa-850b-dc018051f7d8" width="400">

  </details>


  <details><summary>Before & After (Logo)</summary>

  <img src="https://github.com/user-attachments/assets/c91e1eac-ee8e-4c4f-a46a-3c992cff2e21" width="400">

  <img src="https://github.com/user-attachments/assets/41506e90-4e0f-414f-9240-a4c55ce5ca77" width="400">

  </details>
