### PR TITLE
[iOS/tvOS] Fix subtitle size

### DIFF
--- a/Shared/Services/SwiftfinDefaults.swift
+++ b/Shared/Services/SwiftfinDefaults.swift
@@ -237,7 +237,7 @@ extension Defaults.Keys {
 
             static let subtitleColor: Key<Color> = UserKey("subtitleColor", default: .white)
             static let subtitleFontName: Key<String> = UserKey("subtitleFontName", default: UIFont.systemFont(ofSize: 14).fontName)
-            static let subtitleSize: Key<Int> = UserKey("subtitleSize", default: 16)
+            static let subtitleSize: Key<Int> = UserKey("subtitleSize", default: 9)
         }
 
         enum Transition {

--- a/Shared/ViewModels/VideoPlayerViewModel.swift
+++ b/Shared/ViewModels/VideoPlayerViewModel.swift
@@ -70,7 +70,7 @@ final class VideoPlayerViewModel: ViewModel {
             configuration.audioIndex = .absolute(selectedAudioStreamIndex)
         }
         configuration.subtitleIndex = .absolute(selectedSubtitleStreamIndex)
-        configuration.subtitleSize = .absolute(Defaults[.VideoPlayer.Subtitle.subtitleSize])
+        configuration.subtitleSize = .absolute(25 - Defaults[.VideoPlayer.Subtitle.subtitleSize])
         configuration.subtitleColor = .absolute(Defaults[.VideoPlayer.Subtitle.subtitleColor].uiColor)
 
         if let font = UIFont(name: Defaults[.VideoPlayer.Subtitle.subtitleFontName], size: 0) {

--- a/Swiftfin/Views/VideoPlayer/LiveVideoPlayer.swift
+++ b/Swiftfin/Views/VideoPlayer/LiveVideoPlayer.swift
@@ -195,7 +195,7 @@ struct LiveVideoPlayer: View {
             videoPlayerManager.proxy.setSubtitleDelay(.ticks(newValue))
         }
         .onChange(of: subtitleSize) { newValue in
-            videoPlayerManager.proxy.setSubtitleSize(.absolute(24 - newValue))
+            videoPlayerManager.proxy.setSubtitleSize(.absolute(25 - newValue))
         }
         .onChange(of: videoPlayerManager.currentViewModel) { newViewModel in
             guard let newViewModel else { return }

--- a/Swiftfin/Views/VideoPlayer/VideoPlayer.swift
+++ b/Swiftfin/Views/VideoPlayer/VideoPlayer.swift
@@ -232,7 +232,7 @@ struct VideoPlayer: View {
             videoPlayerManager.proxy.setSubtitleDelay(.ticks(newValue))
         }
         .onChange(of: subtitleSize) { newValue in
-            videoPlayerManager.proxy.setSubtitleSize(.absolute(24 - newValue))
+            videoPlayerManager.proxy.setSubtitleSize(.absolute(25 - newValue))
         }
         .onChange(of: videoPlayerManager.currentViewModel) { newViewModel in
             guard let newViewModel else { return }


### PR DESCRIPTION
Fixes #1633 

The subtitle size setting is supposed to be inverted when fed to VLC, since VLCKit uses larger subtitle size numbers to mean smaller text (I think the text's height is 1/x of the screen's height), but when the subtitle size was set in the video player VM, it wasn't correctly inverted like it was in the .onChange in the actual View. This way the actual subtitles were (almost?) always the wrong size.

Additionally, I changed both locations from "24 - ..." to "25 - ..." so the range of actual VLC subtitle sizes would be 1-24 not 0-23, because 0 font size has strange behavior.

After making those changes I think 16 is a little big, so I lowered the default size to 9, which is the same size 16 used to be

Related to this, we might want to lower the maximum size presented in settings to something like 20-22 since at the highest sizes the text totally fills the screen and gets truncated to the point of being unreadable.