### PR TITLE
Cleanup

### DIFF
--- a/Shared/Coordinators/Navigation/NavigationRoute/NavigationRoute+Item.swift
+++ b/Shared/Coordinators/Navigation/NavigationRoute/NavigationRoute+Item.swift
@@ -220,7 +220,7 @@ extension NavigationRoute {
                 viewModel: viewModel,
                 imageInfo: imageInfo
             )
-            .environment(\.isEditing, true)
+            .isEditing(true)
         }
     }
 
@@ -267,7 +267,7 @@ extension NavigationRoute {
                 viewModel: viewModel,
                 remoteImageInfo: remoteImageInfo
             )
-            .environment(\.isEditing, false)
+            .isEditing(false)
         }
     }
 

--- a/Shared/Coordinators/Navigation/NavigationRoute/NavigationRoute+Settings.swift
+++ b/Shared/Coordinators/Navigation/NavigationRoute/NavigationRoute+Settings.swift
@@ -85,9 +85,10 @@ extension NavigationRoute {
         }
     }
 
-    static func editServer(server: ServerState) -> NavigationRoute {
+    static func editServer(server: ServerState, isEditing: Bool = false) -> NavigationRoute {
         NavigationRoute(id: "editServer") {
             EditServerView(server: server)
+                .isEditing(isEditing)
         }
     }
 

--- a/Shared/Coordinators/Navigation/NavigationRoute/NavigationRoute+User.swift
+++ b/Shared/Coordinators/Navigation/NavigationRoute/NavigationRoute+User.swift
@@ -18,16 +18,6 @@ extension NavigationRoute {
         ConnectToServerView()
     }
 
-    static func editServerFromSelectUser(server: ServerState) -> NavigationRoute {
-        NavigationRoute(
-            id: "editServerFromSelectUser",
-            style: .sheet
-        ) {
-            EditServerView(server: server)
-                .environment(\.isEditing, true)
-        }
-    }
-
     static func quickConnect(quickConnect: QuickConnect) -> NavigationRoute {
         NavigationRoute(
             id: "quickConnectView",

--- a/Shared/Extensions/ViewExtensions/ViewExtensions.swift
+++ b/Shared/Extensions/ViewExtensions/ViewExtensions.swift
@@ -257,6 +257,14 @@ extension View {
         return copy
     }
 
+    func isEditing(_ isEditing: Bool) -> some View {
+        environment(\.isEditing, isEditing)
+    }
+
+    func isSelected(_ isSelected: Bool) -> some View {
+        environment(\.isSelected, isSelected)
+    }
+
     /// - Important: Do not use this to add or remove a view from the view heirarchy.
     ///              Use a conditional statement instead.
     @inlinable

--- a/Swiftfin tvOS/Views/ItemView/Components/ActionButtonHStack/ActionButtonHStack.swift
+++ b/Swiftfin tvOS/Views/ItemView/Components/ActionButtonHStack/ActionButtonHStack.swift
@@ -106,7 +106,7 @@ extension ItemView {
                     viewModel.send(.toggleIsPlayed)
                 }
                 .foregroundStyle(.purple)
-                .environment(\.isSelected, isCheckmarkSelected)
+                .isSelected(isCheckmarkSelected)
                 .frame(minWidth: 100, maxWidth: .infinity)
 
                 // MARK: Toggle Favorite
@@ -121,7 +121,7 @@ extension ItemView {
                     viewModel.send(.toggleIsFavorite)
                 }
                 .foregroundStyle(.pink)
-                .environment(\.isSelected, isHeartSelected)
+                .isSelected(isHeartSelected)
                 .frame(minWidth: 100, maxWidth: .infinity)
 
                 // MARK: Watch a Trailer

--- a/Swiftfin tvOS/Views/ItemView/Components/ItemSubtitleSearchView/ItemSubtitleSearchView.swift
+++ b/Swiftfin tvOS/Views/ItemView/Components/ItemSubtitleSearchView/ItemSubtitleSearchView.swift
@@ -166,8 +166,8 @@ struct ItemSubtitleSearchView: View {
                     selectedSubtitles.toggle(value: subtitleID)
                 }
                 .foregroundStyle(isSelected ? .primary : .secondary, .secondary)
-                .environment(\.isSelected, isSelected)
-                .environment(\.isEditing, true)
+                .isSelected(isSelected)
+                .isEditing(true)
             }
         }
     }

--- a/Swiftfin tvOS/Views/SelectUserView/Components/ServerSelectionMenu.swift
+++ b/Swiftfin tvOS/Views/SelectUserView/Components/ServerSelectionMenu.swift
@@ -81,7 +81,10 @@ extension SelectUserView {
                 Section {
                     if let selectedServer {
                         Button(L10n.editServer, systemImage: "server.rack") {
-                            router.route(to: .editServerFromSelectUser(server: selectedServer))
+                            router.route(
+                                to: .editServer(server: selectedServer, isEditing: true),
+                                style: .sheet
+                            )
                         }
                     }
 

--- a/Swiftfin tvOS/Views/SelectUserView/SelectUserView.swift
+++ b/Swiftfin tvOS/Views/SelectUserView/SelectUserView.swift
@@ -158,7 +158,7 @@ struct SelectUserView: View {
                 selectedUsers.insert(user)
                 isPresentingConfirmDeleteUsers = true
             }
-            .environment(\.isSelected, selectedUsers.contains(user))
+            .isSelected(selectedUsers.contains(user))
         }
     }
 
@@ -203,7 +203,7 @@ struct SelectUserView: View {
                 .scrollIfLargerThanContainer(padding: 100)
                 .scrollViewOffset($scrollViewOffset)
             }
-            .environment(\.isEditing, isEditingUsers)
+            .isEditing(isEditingUsers)
 
             SelectUserBottomBar(
                 isEditing: $isEditingUsers,

--- a/Swiftfin/Components/LetterPickerBar/LetterPickerBar.swift
+++ b/Swiftfin/Components/LetterPickerBar/LetterPickerBar.swift
@@ -27,7 +27,7 @@ struct LetterPickerBar: View {
                     size: LetterPickerBar.size,
                     viewModel: viewModel
                 )
-                .environment(\.isSelected, viewModel.currentFilters.letter.contains(filterLetter))
+                .isSelected(viewModel.currentFilters.letter.contains(filterLetter))
             }
 
             Spacer()

--- a/Swiftfin/Components/NavigationBarFilterDrawer/NavigationBarFilterDrawer.swift
+++ b/Swiftfin/Components/NavigationBarFilterDrawer/NavigationBarFilterDrawer.swift
@@ -33,7 +33,7 @@ struct NavigationBarFilterDrawer: View {
                         }
                     } label: {
                         FilterDrawerButton(systemName: "line.3.horizontal.decrease.circle.fill")
-                            .environment(\.isSelected, true)
+                            .isSelected(true)
                     }
                 }
 

--- a/Swiftfin/Views/AdminDashboardView/ServerDevices/DevicesView/DevicesView.swift
+++ b/Swiftfin/Views/AdminDashboardView/ServerDevices/DevicesView/DevicesView.swift
@@ -141,8 +141,8 @@ struct DevicesView: View {
                         selectedDevices.insert(id)
                         isPresentingDeleteConfirmation = true
                     }
-                    .environment(\.isEditing, isEditing)
-                    .environment(\.isSelected, selectedDevices.contains(device.id ?? ""))
+                    .isEditing(isEditing)
+                    .isSelected(selectedDevices.contains(device.id ?? ""))
                     .listRowInsets(.edgeInsets)
                 }
             }

--- a/Swiftfin/Views/AdminDashboardView/ServerUsers/ServerUserSettings/ServerUserAccessSchedule/EditAccessScheduleView/EditAccessScheduleView.swift
+++ b/Swiftfin/Views/AdminDashboardView/ServerUsers/ServerUserSettings/ServerUserAccessSchedule/EditAccessScheduleView/EditAccessScheduleView.swift
@@ -156,8 +156,8 @@ struct EditAccessScheduleView: View {
                         selectedSchedules = [schedule]
                         isPresentingDeleteConfirmation = true
                     }
-                    .environment(\.isEditing, isEditing)
-                    .environment(\.isSelected, selectedSchedules.contains(schedule))
+                    .isEditing(isEditing)
+                    .isSelected(selectedSchedules.contains(schedule))
                 }
             }
         }

--- a/Swiftfin/Views/AdminDashboardView/ServerUsers/ServerUserSettings/ServerUserAccessTags/EditServerUserAccessTagsView/EditServerUserAccessTagsView.swift
+++ b/Swiftfin/Views/AdminDashboardView/ServerUsers/ServerUserSettings/ServerUserAccessTags/EditServerUserAccessTagsView/EditServerUserAccessTagsView.swift
@@ -158,8 +158,8 @@ struct EditServerUserAccessTagsView: View {
             selectedTags = [tag]
             isPresentingDeleteConfirmation = true
         }
-        .environment(\.isEditing, isEditing)
-        .environment(\.isSelected, selectedTags.contains(tag))
+        .isEditing(isEditing)
+        .isSelected(selectedTags.contains(tag))
     }
 
     // MARK: - Content View

--- a/Swiftfin/Views/AdminDashboardView/ServerUsers/ServerUserSettings/ServerUserDeviceAccessView/ServerUserDeviceAccessView.swift
+++ b/Swiftfin/Views/AdminDashboardView/ServerUsers/ServerUserSettings/ServerUserDeviceAccessView/ServerUserDeviceAccessView.swift
@@ -114,8 +114,8 @@ struct ServerUserDeviceAccessView: View {
                                 tempPolicy.enabledDevices?.append(device.id!)
                             }
                         }
-                        .environment(\.isEditing, true)
-                        .environment(\.isSelected, tempPolicy.enabledDevices?.contains(device.id ?? "") == true)
+                        .isEditing(true)
+                        .isSelected(tempPolicy.enabledDevices?.contains(device.id ?? "") == true)
                     }
                 }
             }

--- a/Swiftfin/Views/AdminDashboardView/ServerUsers/ServerUsersView/Components/ServerUsersRow.swift
+++ b/Swiftfin/Views/AdminDashboardView/ServerUsers/ServerUsersView/Components/ServerUsersRow.swift
@@ -83,8 +83,8 @@ extension ServerUsersView {
                     )
                 )
                 .environment(\.isEnabled, userActive)
-                .environment(\.isEditing, isEditing)
-                .environment(\.isSelected, isSelected)
+                .isEditing(isEditing)
+                .isSelected(isSelected)
             }
             .frame(width: 60, height: 60)
         }

--- a/Swiftfin/Views/AdminDashboardView/ServerUsers/ServerUsersView/ServerUsersView.swift
+++ b/Swiftfin/Views/AdminDashboardView/ServerUsers/ServerUsersView/ServerUsersView.swift
@@ -187,8 +187,8 @@ struct ServerUsersView: View {
                             selectedUsers.insert(userID)
                             isPresentingDeleteConfirmation = true
                         }
-                        .environment(\.isEditing, isEditing)
-                        .environment(\.isSelected, selectedUsers.contains(userID))
+                        .isEditing(isEditing)
+                        .isSelected(selectedUsers.contains(userID))
                         .listRowInsets(.edgeInsets)
                     }
                 }

--- a/Swiftfin/Views/ItemEditorView/ItemMetadata/EditItemElementView/EditItemElementView.swift
+++ b/Swiftfin/Views/ItemEditorView/ItemMetadata/EditItemElementView/EditItemElementView.swift
@@ -226,8 +226,8 @@ struct EditItemElementView<Element: Hashable>: View {
                             isPresentingDeleteConfirmation = true
                         }
                     )
-                    .environment(\.isEditing, isEditing)
-                    .environment(\.isSelected, selectedElements.contains(element))
+                    .isEditing(isEditing)
+                    .isSelected(selectedElements.contains(element))
                     .listRowInsets(.edgeInsets)
                 }
                 .onMove { source, destination in

--- a/Swiftfin/Views/ItemEditorView/ItemSubtitles/ItemSubtitleSearchView/ItemSubtitleSearchView.swift
+++ b/Swiftfin/Views/ItemEditorView/ItemSubtitles/ItemSubtitleSearchView/ItemSubtitleSearchView.swift
@@ -152,8 +152,8 @@ struct ItemSubtitleSearchView: View {
                     selectedSubtitles.toggle(value: subtitleID)
                 }
                 .foregroundStyle(isSelected ? .primary : .secondary, .secondary)
-                .environment(\.isSelected, isSelected)
-                .environment(\.isEditing, true)
+                .isSelected(isSelected)
+                .isEditing(true)
             }
         }
     }

--- a/Swiftfin/Views/ItemEditorView/ItemSubtitles/ItemSubtitlesView.swift
+++ b/Swiftfin/Views/ItemEditorView/ItemSubtitles/ItemSubtitlesView.swift
@@ -209,8 +209,8 @@ struct ItemSubtitlesView: View {
                                 selectedSubtitles = [subtitle]
                                 isPresentingDeleteConfirmation = true
                             }
-                            .environment(\.isSelected, selectedSubtitles.contains(subtitle))
-                            .environment(\.isEditing, isEditing)
+                            .isSelected(selectedSubtitles.contains(subtitle))
+                            .isEditing(isEditing)
                         }
                     }
                 }

--- a/Swiftfin/Views/ItemView/Components/ActionButtonHStack/ActionButtonHStack.swift
+++ b/Swiftfin/Views/ItemView/Components/ActionButtonHStack/ActionButtonHStack.swift
@@ -69,7 +69,7 @@ extension ItemView {
                         UIDevice.impact(.light)
                         viewModel.send(.toggleIsPlayed)
                     }
-                    .environment(\.isSelected, isCheckmarkSelected)
+                    .isSelected(isCheckmarkSelected)
                     .if(isCheckmarkSelected) { item in
                         item
                             .foregroundStyle(
@@ -94,7 +94,7 @@ extension ItemView {
                     UIDevice.impact(.light)
                     viewModel.send(.toggleIsFavorite)
                 }
-                .environment(\.isSelected, isHeartSelected)
+                .isSelected(isHeartSelected)
                 .if(isHeartSelected) { item in
                     item
                         .foregroundStyle(Color.red)

--- a/Swiftfin/Views/SelectUserView/Components/ServerSelectionMenu.swift
+++ b/Swiftfin/Views/SelectUserView/Components/ServerSelectionMenu.swift
@@ -44,7 +44,10 @@ extension SelectUserView {
 
                     if let selectedServer {
                         Button(L10n.editServer, systemImage: "server.rack") {
-                            router.route(to: .editServerFromSelectUser(server: selectedServer))
+                            router.route(
+                                to: .editServer(server: selectedServer, isEditing: true),
+                                style: .sheet
+                            )
                         }
                     }
                 }

--- a/Swiftfin/Views/SelectUserView/SelectUserView.swift
+++ b/Swiftfin/Views/SelectUserView/SelectUserView.swift
@@ -259,7 +259,7 @@ struct SelectUserView: View {
         } onDelete: {
             delete(user: user)
         }
-        .environment(\.isSelected, selectedUsers.contains(user))
+        .isSelected(selectedUsers.contains(user))
     }
 
     // MARK: - iPad Grid Content View
@@ -347,7 +347,7 @@ struct SelectUserView: View {
                 } onDelete: {
                     delete(user: user)
                 }
-                .environment(\.isSelected, selectedUsers.contains(user))
+                .isSelected(selectedUsers.contains(user))
                 .swipeActions {
                     if !isEditingUsers {
                         Button(
@@ -388,7 +388,7 @@ struct SelectUserView: View {
                 }
             }
             .animation(.linear(duration: 0.1), value: userListDisplayType)
-            .environment(\.isEditing, isEditingUsers)
+            .isEditing(isEditingUsers)
             .frame(maxHeight: .infinity)
             .mask {
                 VStack(spacing: 0) {


### PR DESCRIPTION
- Have `editServer` take `isEditing` parameter, with `.sheet` transition style from select user.
- `isEditing` and `isSelected` environment wrappers since these are commonly used.