### PR TITLE
[iOS/tvOS] Use Marquee in Playbutton to show media source

### DIFF
--- a/Swiftfin tvOS/Views/ItemView/Components/PlayButton/PlayButton.swift
+++ b/Swiftfin tvOS/Views/ItemView/Components/PlayButton/PlayButton.swift
@@ -46,31 +46,27 @@ extension ItemView {
         // MARK: - Title
 
         private var title: String {
-            if let seriesViewModel = viewModel as? SeriesItemViewModel,
-               let seasonEpisodeLabel = seriesViewModel.playButtonItem?.seasonEpisodeLabel
+
+            /// Use the Media Source name if there is more than one Media Source
+            if let sourceLabel = viewModel.selectedMediaSource?.displayTitle,
+               viewModel.item.mediaSources?.count ?? 0 > 1
+            {
+                return sourceLabel
+
+                /// Use the Season/Episode label for the Series ItemView
+            } else if let seriesViewModel = viewModel as? SeriesItemViewModel,
+                      let seasonEpisodeLabel = seriesViewModel.playButtonItem?.seasonEpisodeLabel
             {
                 return seasonEpisodeLabel
+
+                /// Use a Play/Resume label for single Media Source items that are not Series
             } else if let playButtonLabel = viewModel.playButtonItem?.playButtonLabel {
                 return playButtonLabel
+
+                /// Fallback to a generic `Play` label
             } else {
                 return L10n.play
             }
-
-            // TODO: For use with `MarqueeText` on the `PlayButton`
-
-            /* if let sourceLabel = viewModel.selectedMediaSource?.displayTitle,
-                viewModel.item.mediaSources?.count ?? 0 > 1
-             {
-                 return sourceLabel
-             } else if let seriesViewModel = viewModel as? SeriesItemViewModel,
-                       let seasonEpisodeLabel = seriesViewModel.playButtonItem?.seasonEpisodeLabel
-             {
-                 return seasonEpisodeLabel
-             } else if let playButtonLabel = viewModel.playButtonItem?.playButtonLabel {
-                 return playButtonLabel
-             } else {
-                 return L10n.play
-             } */
         }
 
         // MARK: - Body
@@ -95,13 +91,13 @@ extension ItemView {
                 HStack(spacing: 15) {
                     Image(systemName: "play.fill")
                         .font(.title3)
+                        .padding(.trailing, 4)
 
-                    // TODO: Use `MarqueeText`
-                    Text(title)
+                    Marquee(title, animateWhenFocused: true)
                         .fontWeight(.semibold)
                 }
                 .foregroundStyle(isEnabled ? .black : Color(UIColor.secondaryLabel))
-                .padding(20)
+                .padding(23)
                 .frame(width: multipleVersions ? 320 : 440, height: 100, alignment: .center)
                 .background {
                     if isFocused {

--- a/Swiftfin tvOS/Views/ItemView/Components/PlayButton/PlayButton.swift
+++ b/Swiftfin tvOS/Views/ItemView/Components/PlayButton/PlayButton.swift
@@ -46,16 +46,9 @@ extension ItemView {
         // MARK: - Title
 
         private var title: String {
-
-            /// Use the Media Source name if there is more than one Media Source
-            if let sourceLabel = viewModel.selectedMediaSource?.displayTitle,
-               viewModel.item.mediaSources?.count ?? 0 > 1
-            {
-                return sourceLabel
-
-                /// Use the Season/Episode label for the Series ItemView
-            } else if let seriesViewModel = viewModel as? SeriesItemViewModel,
-                      let seasonEpisodeLabel = seriesViewModel.playButtonItem?.seasonEpisodeLabel
+            /// Use the Season/Episode label for the Series ItemView
+            if let seriesViewModel = viewModel as? SeriesItemViewModel,
+               let seasonEpisodeLabel = seriesViewModel.playButtonItem?.seasonEpisodeLabel
             {
                 return seasonEpisodeLabel
 
@@ -67,6 +60,18 @@ extension ItemView {
             } else {
                 return L10n.play
             }
+        }
+
+        // MARK: - Media Source
+
+        private var source: String? {
+            guard let sourceLabel = viewModel.selectedMediaSource?.displayTitle,
+                  viewModel.item.mediaSources?.count ?? 0 > 1
+            else {
+                return nil
+            }
+
+            return sourceLabel
         }
 
         // MARK: - Body
@@ -93,8 +98,15 @@ extension ItemView {
                         .font(.title3)
                         .padding(.trailing, 4)
 
-                    Marquee(title, animateWhenFocused: true)
-                        .fontWeight(.semibold)
+                    VStack(alignment: .leading) {
+                        Text(title)
+                            .fontWeight(.semibold)
+
+                        if let source = source {
+                            Marquee(source, animateWhenFocused: true)
+                                .font(.caption)
+                        }
+                    }
                 }
                 .foregroundStyle(isEnabled ? .black : Color(UIColor.secondaryLabel))
                 .padding(23)

--- a/Swiftfin tvOS/Views/ItemView/Components/PlayButton/PlayButton.swift
+++ b/Swiftfin tvOS/Views/ItemView/Components/PlayButton/PlayButton.swift
@@ -102,14 +102,15 @@ extension ItemView {
                         Text(title)
                             .fontWeight(.semibold)
 
-                        if let source = source {
+                        if let source {
                             Marquee(source, animateWhenFocused: true)
                                 .font(.caption)
+                                .frame(maxWidth: 250)
                         }
                     }
                 }
                 .foregroundStyle(isEnabled ? .black : Color(UIColor.secondaryLabel))
-                .padding(23)
+                .padding(20)
                 .frame(width: multipleVersions ? 320 : 440, height: 100, alignment: .center)
                 .background {
                     if isFocused {

--- a/Swiftfin/Views/ItemView/Components/PlayButton.swift
+++ b/Swiftfin/Views/ItemView/Components/PlayButton.swift
@@ -77,23 +77,21 @@ extension ItemView {
                     HStack {
                         Image(systemName: "play.fill")
                             .font(.system(size: 20))
-                            .padding(.horizontal, 3)
 
                         VStack(alignment: .leading) {
                             Text(title)
                                 .font(.callout)
                                 .fontWeight(.semibold)
 
-                            if let source = source {
+                            if let source {
                                 Marquee(source, speed: 40, delay: 3, fade: 5)
                                     .font(.caption)
                                     .fontWeight(.medium)
+                                    .frame(maxWidth: 150)
                             }
                         }
-                        .padding(.trailing, 3)
                     }
                     .foregroundStyle(isEnabled ? accentColor.overlayColor : Color(UIColor.secondaryLabel))
-                    .padding(.horizontal, 10)
                 }
             }
             .contextMenu {

--- a/Swiftfin/Views/ItemView/Components/PlayButton.swift
+++ b/Swiftfin/Views/ItemView/Components/PlayButton.swift
@@ -26,7 +26,7 @@ extension ItemView {
 
         private let logger = Logger.swiftfin()
 
-        // MARK: - ddd
+        // MARK: - Validation
 
         private var isEnabled: Bool {
             viewModel.selectedMediaSource != nil
@@ -35,16 +35,9 @@ extension ItemView {
         // MARK: - Title
 
         private var title: String {
-
-            /// Use the Media Source name if there is more than one Media Source
-            if let sourceLabel = viewModel.selectedMediaSource?.displayTitle,
-               viewModel.item.mediaSources?.count ?? 0 > 1
-            {
-                return sourceLabel
-
-                /// Use the Season/Episode label for the Series ItemView
-            } else if let seriesViewModel = viewModel as? SeriesItemViewModel,
-                      let seasonEpisodeLabel = seriesViewModel.playButtonItem?.seasonEpisodeLabel
+            /// Use the Season/Episode label for the Series ItemView
+            if let seriesViewModel = viewModel as? SeriesItemViewModel,
+               let seasonEpisodeLabel = seriesViewModel.playButtonItem?.seasonEpisodeLabel
             {
                 return seasonEpisodeLabel
 
@@ -56,6 +49,18 @@ extension ItemView {
             } else {
                 return L10n.play
             }
+        }
+
+        // MARK: - Media Source
+
+        private var source: String? {
+            guard let sourceLabel = viewModel.selectedMediaSource?.displayTitle,
+                  viewModel.item.mediaSources?.count ?? 0 > 1
+            else {
+                return nil
+            }
+
+            return sourceLabel
         }
 
         // MARK: - Body
@@ -74,10 +79,18 @@ extension ItemView {
                             .font(.system(size: 20))
                             .padding(.horizontal, 3)
 
-                        Marquee(title, speed: 40, delay: 3, fade: 5)
-                            .font(.callout)
-                            .fontWeight(.semibold)
-                            .padding(.trailing, 3)
+                        VStack(alignment: .leading) {
+                            Text(title)
+                                .font(.callout)
+                                .fontWeight(.semibold)
+
+                            if let source = source {
+                                Marquee(source, speed: 40, delay: 3, fade: 5)
+                                    .font(.caption)
+                                    .fontWeight(.medium)
+                            }
+                        }
+                        .padding(.trailing, 3)
                     }
                     .foregroundStyle(isEnabled ? accentColor.overlayColor : Color(UIColor.secondaryLabel))
                     .padding(.horizontal, 10)

--- a/Swiftfin/Views/ItemView/Components/PlayButton.swift
+++ b/Swiftfin/Views/ItemView/Components/PlayButton.swift
@@ -87,11 +87,12 @@ extension ItemView {
                                 Marquee(source, speed: 40, delay: 3, fade: 5)
                                     .font(.caption)
                                     .fontWeight(.medium)
-                                    .frame(maxWidth: 150)
+                                    .frame(maxWidth: 175)
                             }
                         }
                     }
                     .foregroundStyle(isEnabled ? accentColor.overlayColor : Color(UIColor.secondaryLabel))
+                    .padding(.horizontal, 5)
                 }
             }
             .contextMenu {

--- a/Swiftfin/Views/ItemView/Components/PlayButton.swift
+++ b/Swiftfin/Views/ItemView/Components/PlayButton.swift
@@ -35,31 +35,27 @@ extension ItemView {
         // MARK: - Title
 
         private var title: String {
-            if let seriesViewModel = viewModel as? SeriesItemViewModel,
-               let seasonEpisodeLabel = seriesViewModel.playButtonItem?.seasonEpisodeLabel
+
+            /// Use the Media Source name if there is more than one Media Source
+            if let sourceLabel = viewModel.selectedMediaSource?.displayTitle,
+               viewModel.item.mediaSources?.count ?? 0 > 1
+            {
+                return sourceLabel
+
+                /// Use the Season/Episode label for the Series ItemView
+            } else if let seriesViewModel = viewModel as? SeriesItemViewModel,
+                      let seasonEpisodeLabel = seriesViewModel.playButtonItem?.seasonEpisodeLabel
             {
                 return seasonEpisodeLabel
+
+                /// Use a Play/Resume label for single Media Source items that are not Series
             } else if let playButtonLabel = viewModel.playButtonItem?.playButtonLabel {
                 return playButtonLabel
+
+                /// Fallback to a generic `Play` label
             } else {
                 return L10n.play
             }
-
-            // TODO: For use with `MarqueeText` on the `PlayButton`
-
-            /* if let sourceLabel = viewModel.selectedMediaSource?.displayTitle,
-                viewModel.item.mediaSources?.count ?? 0 > 1
-             {
-                 return sourceLabel
-             } else if let seriesViewModel = viewModel as? SeriesItemViewModel,
-                       let seasonEpisodeLabel = seriesViewModel.playButtonItem?.seasonEpisodeLabel
-             {
-                 return seasonEpisodeLabel
-             } else if let playButtonLabel = viewModel.playButtonItem?.playButtonLabel {
-                 return playButtonLabel
-             } else {
-                 return L10n.play
-             } */
         }
 
         // MARK: - Body
@@ -76,13 +72,15 @@ extension ItemView {
                     HStack {
                         Image(systemName: "play.fill")
                             .font(.system(size: 20))
+                            .padding(.horizontal, 3)
 
-                        // TODO: Use `MarqueeText`
-                        Text(title)
+                        Marquee(title, speed: 40, delay: 3, fade: 5)
                             .font(.callout)
                             .fontWeight(.semibold)
+                            .padding(.trailing, 3)
                     }
                     .foregroundStyle(isEnabled ? accentColor.overlayColor : Color(UIColor.secondaryLabel))
+                    .padding(.horizontal, 10)
                 }
             }
             .contextMenu {

--- a/Swiftfin/Views/ItemView/ScrollViews/CompactPortraitScrollView.swift
+++ b/Swiftfin/Views/ItemView/ScrollViews/CompactPortraitScrollView.swift
@@ -181,7 +181,7 @@ extension ItemView.CompactPosterScrollView {
 
                     if viewModel.presentPlayButton {
                         ItemView.PlayButton(viewModel: viewModel)
-                            .frame(width: 130, height: 40)
+                            .frame(width: 130, height: 45)
                     }
 
                     Spacer()


### PR DESCRIPTION
This finishes off the last part of the Help Wanted item for showing the currently selected media source in the PlayButton using the Marquee component. Thanks to @JPKribs for most of this PR, I adjusted the padding and speeds a bit.

<details><summary>iOS</summary>
<p>

<img width="1170" height="413" alt="phone fit copy" src="https://github.com/user-attachments/assets/cb4b4b3c-f03e-4c8e-9846-0134463a295f" />

https://github.com/user-attachments/assets/8c55a958-502e-475c-8d11-cb16bd700ec2

</p>
</details> 

<details><summary>tvOS</summary>
<p>

<img width="537" height="300" alt="tv fit" src="https://github.com/user-attachments/assets/27bab0ec-3a3e-4966-a67d-7319c00cc1db" />

https://github.com/user-attachments/assets/90209dae-984b-46da-a08a-239d1a890946

</p>
</details> 