### PR TITLE
Remove landscape options from info.plist

### DIFF
--- a/Swiftfin/Resources/Info.plist
+++ b/Swiftfin/Resources/Info.plist
@@ -87,14 +87,12 @@ network.</string>
 	<key>UISupportedInterfaceOrientations</key>
 	<array>
 		<string>UIInterfaceOrientationPortrait</string>
-		<string>UIInterfaceOrientationLandscapeRight</string>
-		<string>UIInterfaceOrientationLandscapeLeft</string>
 	</array>
 	<key>UISupportedInterfaceOrientations~ipad</key>
 	<array>
-		<string>UIInterfaceOrientationPortrait</string>
 		<string>UIInterfaceOrientationLandscapeLeft</string>
 		<string>UIInterfaceOrientationLandscapeRight</string>
+		<string>UIInterfaceOrientationPortrait</string>
 	</array>
 </dict>
 </plist>


### PR DESCRIPTION
Potentially fixes #1622

After updating to a newer build a few weeks ago I did have a session that allowed landscape but I haven't been able to reproduce. Maybe the app got into a wonky state and checked this rather than the programmatic settings.