### PR TITLE
[iOS/tvOS] Fix corner radius performance regression

### DIFF
--- a/Shared/Extensions/ViewExtensions/ViewExtensions.swift
+++ b/Shared/Extensions/ViewExtensions/ViewExtensions.swift
@@ -168,17 +168,26 @@ extension View {
     func cornerRadius(
         _ radius: CGFloat,
         corners: RectangleCorner = .allCorners,
-        style: RoundedCornerStyle = .circular
+        style: RoundedCornerStyle = .circular,
+        container: Bool = false,
     ) -> some View {
-        let shape = UnevenRoundedRectangle(
-            topLeadingRadius: corners.contains(.topLeft) ? radius : 0,
-            bottomLeadingRadius: corners.contains(.bottomLeft) ? radius : 0,
-            bottomTrailingRadius: corners.contains(.bottomRight) ? radius : 0,
-            topTrailingRadius: corners.contains(.topRight) ? radius : 0,
-            style: style
-        )
+        if corners == .allCorners {
+            let shape = RoundedRectangle(cornerRadius: radius, style: style)
 
-        clipShape(shape)
+            clipShape(shape)
+                .if(container) { $0.containerShape(shape) }
+        } else {
+            let shape = UnevenRoundedRectangle(
+                topLeadingRadius: corners.contains(.topLeft) ? radius : 0,
+                bottomLeadingRadius: corners.contains(.bottomLeft) ? radius : 0,
+                bottomTrailingRadius: corners.contains(.bottomRight) ? radius : 0,
+                topTrailingRadius: corners.contains(.topRight) ? radius : 0,
+                style: style
+            )
+
+            clipShape(shape)
+                .if(container) { $0.containerShape(shape) }
+        }
     }
 
     /// Apply a corner radius as a ratio of a view's side
@@ -193,16 +202,7 @@ extension View {
             OnSizeChangedModifier { size in
                 let radius = size[keyPath: side] * ratio
 
-                let shape = UnevenRoundedRectangle(
-                    topLeadingRadius: corners.contains(.topLeft) ? radius : 0,
-                    bottomLeadingRadius: corners.contains(.bottomLeft) ? radius : 0,
-                    bottomTrailingRadius: corners.contains(.bottomRight) ? radius : 0,
-                    topTrailingRadius: corners.contains(.topRight) ? radius : 0,
-                    style: style
-                )
-
-                self.clipShape(shape)
-                    .containerShape(shape)
+                self.cornerRadius(radius, corners: corners, style: style, container: true)
             }
         )
     }

--- a/Shared/Extensions/ViewExtensions/ViewExtensions.swift
+++ b/Shared/Extensions/ViewExtensions/ViewExtensions.swift
@@ -171,6 +171,8 @@ extension View {
         style: RoundedCornerStyle = .circular,
         container: Bool = false,
     ) -> some View {
+        // Note: UnevenRoundedRectangle with all equal radii performs worse than RoundedRectangle
+        //       due to internal use of UIBezierPath.
         if corners == .allCorners {
             let shape = RoundedRectangle(cornerRadius: radius, style: style)
 


### PR DESCRIPTION
I noticed that scrolling on my iPad was pretty choppy, and I saw that the refactoring in #1617 lost the use of `RoundedRectangle` when all the corner radii were the same. I know that the previous bezier path method of rounding corners was dropped with iOS 15 compatibility, but as far as I can tell the new `UnevenRoundedRectangle` is just a convenience wrapper in terms of performance.

Unfortunately due to the type checker I couldn't get it as compact as I'd like.