### PR TITLE
Disable Liquid Glass/New Design Language

### DIFF
--- a/Swiftfin tvOS/Resources/Info.plist
+++ b/Swiftfin tvOS/Resources/Info.plist
@@ -36,5 +36,7 @@
 	</array>
 	<key>UIUserInterfaceStyle</key>
 	<string>Dark</string>
+    <key>UIDesignRequiresCompatibility</key>
+    <true/>
 </dict>
 </plist>

--- a/Swiftfin/Resources/Info.plist
+++ b/Swiftfin/Resources/Info.plist
@@ -96,5 +96,7 @@ network.</string>
 		<string>UIInterfaceOrientationLandscapeLeft</string>
 		<string>UIInterfaceOrientationLandscapeRight</string>
 	</array>
+    <key>UIDesignRequiresCompatibility</key>
+    <true/>
 </dict>
 </plist>


### PR DESCRIPTION
With the '26 OSes just a little over a month away I started testing against them and have noticed many UI inconsistencies and issues. Disabling the new design language will minimize the scope of work that needs to be done prior to their release.

Note: the app crashes on tvOS 26 once you navigate to the search tab so this change also prevents that.