### PR TITLE
[iOS] Limit maximum subtitle size

### DIFF
--- a/Swiftfin/Views/SettingsView/VideoPlayerSettingsView/Components/Sections/SubtitleSection.swift
+++ b/Swiftfin/Views/SettingsView/VideoPlayerSettingsView/Components/Sections/SubtitleSection.swift
@@ -30,7 +30,7 @@ extension VideoPlayerSettingsView {
                 BasicStepper(
                     L10n.subtitleSize,
                     value: $subtitleSize,
-                    range: 1 ... 24,
+                    range: 1 ... 20,
                     step: 1
                 )
 


### PR DESCRIPTION
Belated piece of the fix for #1111. 

This just reduces the largest subtitle size option so you can't make the subtitles unreadably big. See [this for images](https://github.com/jellyfin/Swiftfin/issues/1111#issuecomment-3130849616). Now the biggest subtitle size is comparable to .body text at the largest accessibility size.

