### PR TITLE
Add episode-focused media navigator

### DIFF
--- a/Shared/Objects/LibraryGroupingType.swift
+++ b/Shared/Objects/LibraryGroupingType.swift
@@ -1,0 +1,32 @@
+//
+// Swiftfin is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, you can obtain one at https://mozilla.org/MPL/2.0/.
+//
+// Copyright (c) 2025 Jellyfin & Jellyfin Contributors
+//
+
+enum LibraryGroupingType: String, CaseIterable, Displayable, Storable, SystemImageable {
+
+    case group
+    case ungrouped
+
+    // TODO: localize
+    var displayTitle: String {
+        switch self {
+        case .group:
+            "Group"
+        case .ungrouped:
+            "Ungroup"
+        }
+    }
+
+    var systemImage: String {
+        switch self {
+        case .group:
+            "rectangle.3.group.fill"
+        case .ungrouped:
+            "rectangle.3.group"
+        }
+    }
+}

--- a/Shared/ViewModels/LibraryViewModel/ItemLibraryViewModel.swift
+++ b/Shared/ViewModels/LibraryViewModel/ItemLibraryViewModel.swift
@@ -19,7 +19,9 @@ final class ItemLibraryViewModel: PagingLibraryViewModel<BaseItemDto> {
 
     override func get(page: Int) async throws -> [BaseItemDto] {
 
-        let parameters = itemParameters(for: page)
+        var parameters = itemParameters(for: page)
+        parameters.includeItemTypes = [.episode]
+        parameters.isRecursive = true
         let request = Paths.getItemsByUserID(userID: userSession.user.id, parameters: parameters)
         let response = try await userSession.client.send(request)
 

--- a/Swiftfin/Views/PagingLibraryView/Components/LibraryViewTypeToggle.swift
+++ b/Swiftfin/Views/PagingLibraryView/Components/LibraryViewTypeToggle.swift
@@ -23,15 +23,19 @@ extension PagingLibraryView {
         private var posterType: PosterDisplayType
         @Binding
         private var viewType: LibraryDisplayType
+        @Binding
+        private var grouping: LibraryGroupingType
 
         init(
             posterType: Binding<PosterDisplayType>,
             viewType: Binding<LibraryDisplayType>,
+            grouping: Binding<LibraryGroupingType>,
             listColumnCount: Binding<Int>
         ) {
             self._listColumnCount = listColumnCount
             self._posterType = posterType
             self._viewType = viewType
+            self._grouping = grouping
         }
 
         var body: some View {
@@ -77,6 +81,28 @@ extension PagingLibraryView {
                             Label(L10n.list, systemImage: "checkmark")
                         } else {
                             Label(L10n.list, systemImage: "square.fill.text.grid.1x2")
+                        }
+                    }
+                }
+
+                Section("Grouping") {
+                    Button {
+                        grouping = .group
+                    } label: {
+                        if grouping == .group {
+                            Label("Group", systemImage: "checkmark")
+                        } else {
+                            Label("Group", systemImage: "rectangle.3.group.fill")
+                        }
+                    }
+
+                    Button {
+                        grouping = .ungrouped
+                    } label: {
+                        if grouping == .ungrouped {
+                            Label("Ungrouped", systemImage: "checkmark")
+                        } else {
+                            Label("Ungrouped", systemImage: "rectangle.3.group")
                         }
                     }
                 }

--- a/Swiftfin/Views/PagingLibraryView/PagingLibraryView.swift
+++ b/Swiftfin/Views/PagingLibraryView/PagingLibraryView.swift
@@ -74,6 +74,10 @@ struct PagingLibraryView<Element: Poster>: View {
     @StoredValue
     private var posterType: PosterDisplayType
 
+    // TODO: @StoredValue
+    @State
+    private var grouping: LibraryGroupingType = LibraryGroupingType.group
+
     @StateObject
     private var collectionVGridProxy: CollectionVGridProxy = .init()
     @StateObject
@@ -453,12 +457,14 @@ struct PagingLibraryView<Element: Poster>: View {
                 LibraryViewTypeToggle(
                     posterType: $posterType,
                     viewType: $displayType,
+                    grouping: $grouping,
                     listColumnCount: $listColumnCount
                 )
             } else {
                 LibraryViewTypeToggle(
                     posterType: $defaultPosterType,
                     viewType: $defaultDisplayType,
+                    grouping: $grouping,
                     listColumnCount: $defaultListColumnCount
                 )
             }


### PR DESCRIPTION
In Jellyfin's web UI the user can chose between various sections when navigating media. There's "series", "recommended", and "episodes" - among others.

Jellyfin's web UI also has a user setting for controlling the default section of a library.

This makes Jellyfin great for episodal video where episodes are more "important" than the series themselves - such as for TV shows or internet video.

Today, Swiftfin only really supports the "series" section (as in, the media tab only shows collections and so on). 

This PR aims to change that by adding an option to show episodes of a library, no matter their parent. As a first step I'd like to show the absolute bare minimum code needed to get this done (breaking other features in the process) just to clearly show the intent / use case.

If the developers think it's a good idea, I'd be willing to put together actual code, with some guidance.

Before:

Series are shown.

<img width="476" height="953" alt="image" src="https://github.com/user-attachments/assets/c88b0e7e-9a92-427f-8ef7-a9d6aefd6ab5" />

After:

Episodes are shown. One example way to control the section would be through the "more" / "kebab" button.

<img width="464" height="947" alt="image" src="https://github.com/user-attachments/assets/6b24bb6e-b388-455d-8156-d6c740b37440" />
