### PR TITLE
[tvOS] Fix ChevronButton Title Alignment

### DIFF
--- a/Shared/Components/ChevronButton.swift
+++ b/Shared/Components/ChevronButton.swift
@@ -79,10 +79,15 @@ extension ChevronButton {
 
         let label: Label
         let action: () -> Void
+        let hasIcon: Bool
 
         var body: some View {
             Button(action: action) {
-                label
+                if hasIcon {
+                    label
+                } else {
+                    label.labelStyle(.titleOnly)
+                }
             }
             .foregroundStyle(.primary, .secondary)
         }

--- a/Shared/Components/ChevronButton.swift
+++ b/Shared/Components/ChevronButton.swift
@@ -109,7 +109,8 @@ extension ChevronButton {
         self.innerContent = { label in
             ButtonContentView(
                 label: label,
-                action: action
+                action: action,
+                hasIcon: true
             )
         }
     }
@@ -127,7 +128,8 @@ extension ChevronButton {
         self.innerContent = { label in
             ButtonContentView(
                 label: label,
-                action: action
+                action: action,
+                hasIcon: true
             )
         }
     }
@@ -147,7 +149,8 @@ extension ChevronButton where Icon == EmptyView, Subtitle == Text {
         self.innerContent = { label in
             ButtonContentView(
                 label: label,
-                action: action
+                action: action,
+                hasIcon: false
             )
         }
     }
@@ -164,7 +167,8 @@ extension ChevronButton where Icon == EmptyView, Subtitle == Text {
         self.innerContent = { label in
             ButtonContentView(
                 label: label,
-                action: action
+                action: action,
+                hasIcon: false
             )
         }
     }
@@ -183,7 +187,8 @@ extension ChevronButton where Icon == EmptyView, Subtitle == EmptyView {
         self.innerContent = { label in
             ButtonContentView(
                 label: label,
-                action: action
+                action: action,
+                hasIcon: false
             )
         }
     }
@@ -206,7 +211,8 @@ extension ChevronButton where Icon == Image, Subtitle == Text {
         self.innerContent = { label in
             ButtonContentView(
                 label: label,
-                action: action
+                action: action,
+                hasIcon: true
             )
         }
     }
@@ -224,7 +230,8 @@ extension ChevronButton where Icon == Image, Subtitle == Text {
         self.innerContent = { label in
             ButtonContentView(
                 label: label,
-                action: action
+                action: action,
+                hasIcon: true
             )
         }
     }
@@ -244,7 +251,8 @@ extension ChevronButton where Icon == Image, Subtitle == Text {
         self.innerContent = { label in
             ButtonContentView(
                 label: label,
-                action: action
+                action: action,
+                hasIcon: true
             )
         }
     }
@@ -262,7 +270,8 @@ extension ChevronButton where Icon == Image, Subtitle == Text {
         self.innerContent = { label in
             ButtonContentView(
                 label: label,
-                action: action
+                action: action,
+                hasIcon: true
             )
         }
     }
@@ -284,7 +293,8 @@ extension ChevronButton where Icon == Image, Subtitle == EmptyView {
         self.innerContent = { label in
             ButtonContentView(
                 label: label,
-                action: action
+                action: action,
+                hasIcon: true
             )
         }
     }
@@ -303,7 +313,8 @@ extension ChevronButton where Icon == Image, Subtitle == EmptyView {
         self.innerContent = { label in
             ButtonContentView(
                 label: label,
-                action: action
+                action: action,
+                hasIcon: true
             )
         }
     }


### PR DESCRIPTION
On tvOS the `EmptyView` for the icon is pushing the title to the right so it looks strange compared to the other buttons.

Not the cleanest solution around so suggestions are welcome.

| Before | After |
|--------|--------|
| <img width="763" height="516" alt="Screenshot 2025-08-13 at 5 13 03 PM" src="https://github.com/user-attachments/assets/1ed53959-9d30-45c2-b207-1adbc495fdfb" /> | <img width="765" height="522" alt="Screenshot 2025-08-13 at 5 14 42 PM" src="https://github.com/user-attachments/assets/5eef6fa6-9c71-4fce-91f0-5e566e290467" /> | 

