### PR TITLE
[iOS/tvOS] Fix user icons not changing between servers

### DIFF
--- a/Shared/Components/CenteredLazyVGrid.swift
+++ b/Shared/Components/CenteredLazyVGrid.swift
@@ -111,6 +111,11 @@ extension CenteredLazyVGrid {
         let minimum: CGFloat
         let spacing: CGFloat
 
+        private var enumeratedId: KeyPath<EnumeratedSequence<Data>.Element, ID> {
+            let element = \EnumeratedSequence<Data>.Element.element
+            return element.appending(path: id)
+        }
+
         private var columnCount: Int? {
             let elementSizeAndWidth = elementSize.width + spacing
             guard elementSizeAndWidth > 0 else { return nil }
@@ -142,7 +147,7 @@ extension CenteredLazyVGrid {
             )]
 
             LazyVGrid(columns: columns, spacing: spacing) {
-                ForEach(Array(data.enumerated()), id: \.offset) { offset, element in
+                ForEach(Array(data.enumerated()), id: enumeratedId) { offset, element in
                     content(element)
                         .trackingSize($elementSize)
                         .offset(x: elementXOffset(for: offset))
@@ -165,6 +170,11 @@ extension CenteredLazyVGrid {
         let data: Data
         let id: KeyPath<Data.Element, ID>
         let spacing: CGFloat
+
+        private var enumeratedId: KeyPath<EnumeratedSequence<Data>.Element, ID> {
+            let element = \EnumeratedSequence<Data>.Element.element
+            return element.appending(path: id)
+        }
 
         /// Calculates the x offset for elements in
         /// the last row of the grid to be centered.
@@ -193,7 +203,7 @@ extension CenteredLazyVGrid {
             )
 
             LazyVGrid(columns: columns, spacing: spacing) {
-                ForEach(Array(data.enumerated()), id: \.offset) { offset, element in
+                ForEach(Array(data.enumerated()), id: enumeratedId) { offset, element in
                     content(element)
                         .trackingSize($elementSize)
                         .offset(x: elementXOffset(for: offset))


### PR DESCRIPTION
Currently if you are connected to multiple servers and switch between them, your user icons don't change. It's a little confusing since if you're not paying attention to the user names it looks like you haven't switched servers:

https://github.com/user-attachments/assets/cfd1c131-aec9-457e-8686-589d6a9b6ed2

This also happens if you have multiple users in each server, so if you have 2 in one, and 3 in the other, the first 2 icons will stay the same as you swap between them.

The issue was that the ForEaches used to display the images was using the users' index in the list as their ID. The fix is to use the ID keypath that the views already have.