### PR TITLE
[iOS/tvOS] Fix subtitle font setting not working

### DIFF
--- a/Shared/ViewModels/VideoPlayerViewModel.swift
+++ b/Shared/ViewModels/VideoPlayerViewModel.swift
@@ -73,7 +73,7 @@ final class VideoPlayerViewModel: ViewModel {
         configuration.subtitleSize = .absolute(25 - Defaults[.VideoPlayer.Subtitle.subtitleSize])
         configuration.subtitleColor = .absolute(Defaults[.VideoPlayer.Subtitle.subtitleColor].uiColor)
 
-        if let font = UIFont(name: Defaults[.VideoPlayer.Subtitle.subtitleFontName], size: 0) {
+        if let font = UIFont(name: Defaults[.VideoPlayer.Subtitle.subtitleFontName], size: 1) {
             configuration.subtitleFont = .absolute(font)
         }
 


### PR DESCRIPTION
Fixes #1122 

For some reason UIFont(name: , size:) always returns Helvetica if the size is zero, even for nonsense font names, since the subtitle size isn't set by the UIFont, just picking a positive number makes it properly get the right font