### PR TITLE
[iOS] Stop iOS native player calling sendStartReport twice

### DIFF
--- a/Swiftfin/Views/VideoPlayer/NativeVideoPlayer.swift
+++ b/Swiftfin/Views/VideoPlayer/NativeVideoPlayer.swift
@@ -171,8 +171,6 @@ class UINativeVideoPlayerViewController: AVPlayerViewController {
 
     private func play() {
         player?.play()
-
-        videoPlayerManager.sendStartReport()
     }
 
     private func stop() {


### PR DESCRIPTION
### Summary

Resolves: iOS native player is calling sendStartReport twice which then causes app to continue sending progress report `sendProgressReport()` even after video playback is closed. This also causes server side transcoding job to continue endlessly.

VideoPlayerManager `onStateUpdated` method handles start report `sendStartReport()`, no need to send it from NativeVideoPlayer module too.

I have no means of testing tvOS, therefore I haven't touched the code there although it seems similar. Also I have no knowledge of LiveNativeVideoPlayer, so I left it untouched too.