### PR TITLE
[iOS] Invert subtitle size for new video player

### DIFF
--- a/Shared/Objects/MediaPlayerManager/MediaPlayerProxy/MediaPlayerProxy+VLC.swift
+++ b/Shared/Objects/MediaPlayerManager/MediaPlayerProxy/MediaPlayerProxy+VLC.swift
@@ -137,7 +137,7 @@ extension VLCMediaPlayerProxy {
                 configuration.subtitleIndex = .absolute(mediaSource.defaultSubtitleStreamIndex ?? -1)
             }
 
-            configuration.subtitleSize = .absolute(Defaults[.VideoPlayer.Subtitle.subtitleSize])
+            configuration.subtitleSize = .absolute(25 - Defaults[.VideoPlayer.Subtitle.subtitleSize])
             configuration.subtitleColor = .absolute(Defaults[.VideoPlayer.Subtitle.subtitleColor].uiColor)
 
             if let font = UIFont(name: Defaults[.VideoPlayer.Subtitle.subtitleFontName], size: 0) {
@@ -217,7 +217,7 @@ extension VLCMediaPlayerProxy {
                     .backport
                     .onChange(of: subtitleSize) { _, newValue in
                         if let proxy = proxy as? MediaPlayerSubtitleConfigurable {
-                            proxy.setSubtitleFontSize(newValue)
+                            proxy.setSubtitleFontSize(25 - newValue)
                         }
                     }
             }


### PR DESCRIPTION
Similar to #1658, invert subtitle size when giving them to VLCKit. That PR wasn't merged when work on #1581 started