### PR TITLE
[iOS] Fix audio/subtitle tracks not changing

### DIFF
--- a/Swiftfin/Views/VideoPlayerContainerView/PlaybackControls/Components/NavigationBar/ActionButtons/AudioActionButton.swift
+++ b/Swiftfin/Views/VideoPlayerContainerView/PlaybackControls/Components/NavigationBar/ActionButtons/AudioActionButton.swift
@@ -55,7 +55,8 @@ extension VideoPlayer.PlaybackControls.NavigationBar.ActionButtons {
                 }
                 .videoPlayerActionButtonTransition()
                 .assign(playbackItem.$selectedAudioStreamIndex, to: $selectedAudioStreamIndex)
-                .backport.onChange(of: selectedAudioStreamIndex) { _, newValue in
+                .backport
+                .onChange(of: selectedAudioStreamIndex) { _, newValue in
                     playbackItem.selectedAudioStreamIndex = newValue
                 }
             }

--- a/Swiftfin/Views/VideoPlayerContainerView/PlaybackControls/Components/NavigationBar/ActionButtons/AudioActionButton.swift
+++ b/Swiftfin/Views/VideoPlayerContainerView/PlaybackControls/Components/NavigationBar/ActionButtons/AudioActionButton.swift
@@ -55,6 +55,9 @@ extension VideoPlayer.PlaybackControls.NavigationBar.ActionButtons {
                 }
                 .videoPlayerActionButtonTransition()
                 .assign(playbackItem.$selectedAudioStreamIndex, to: $selectedAudioStreamIndex)
+                .backport.onChange(of: selectedAudioStreamIndex) { _, newValue in
+                    playbackItem.selectedAudioStreamIndex = newValue
+                }
             }
         }
     }

--- a/Swiftfin/Views/VideoPlayerContainerView/PlaybackControls/Components/NavigationBar/ActionButtons/SubtitleActionButton.swift
+++ b/Swiftfin/Views/VideoPlayerContainerView/PlaybackControls/Components/NavigationBar/ActionButtons/SubtitleActionButton.swift
@@ -55,7 +55,8 @@ extension VideoPlayer.PlaybackControls.NavigationBar.ActionButtons {
                 }
                 .videoPlayerActionButtonTransition()
                 .assign(playbackItem.$selectedSubtitleStreamIndex, to: $selectedSubtitleStreamIndex)
-                .backport.onChange(of: selectedSubtitleStreamIndex) { _, newValue in
+                .backport
+                .onChange(of: selectedSubtitleStreamIndex) { _, newValue in
                     playbackItem.selectedSubtitleStreamIndex = newValue
                 }
             }

--- a/Swiftfin/Views/VideoPlayerContainerView/PlaybackControls/Components/NavigationBar/ActionButtons/SubtitleActionButton.swift
+++ b/Swiftfin/Views/VideoPlayerContainerView/PlaybackControls/Components/NavigationBar/ActionButtons/SubtitleActionButton.swift
@@ -55,6 +55,9 @@ extension VideoPlayer.PlaybackControls.NavigationBar.ActionButtons {
                 }
                 .videoPlayerActionButtonTransition()
                 .assign(playbackItem.$selectedSubtitleStreamIndex, to: $selectedSubtitleStreamIndex)
+                .backport.onChange(of: selectedSubtitleStreamIndex) { _, newValue in
+                    playbackItem.selectedSubtitleStreamIndex = newValue
+                }
             }
         }
     }


### PR DESCRIPTION
Fixes #1711 

Audio and subtitle tracks were connected to the selection UI from the item to the UI, but not the other way, so changing the track in UI did nothing. This just connects the SwiftUI State to the item via onChange. 

I thought it would be possible to modify .assign() to make it optionally two-way but I don't think that's possible going from Binding -> Published