### PR TITLE
`Stateful` Macro - `ActiveSessionsViewModel`

### DIFF
--- a/Shared/ViewModels/AdminDashboard/ActiveSessionsViewModel.swift
+++ b/Shared/ViewModels/AdminDashboard/ActiveSessionsViewModel.swift
@@ -13,105 +13,57 @@ import OrderedCollections
 import SwiftUI
 
 @MainActor
-final class ActiveSessionsViewModel: ViewModel, Stateful {
+@Stateful
+final class ActiveSessionsViewModel: ViewModel {
 
-    // MARK: - Action
-
-    enum Action: Equatable {
+    @CasePathable
+    enum Action {
         case refresh
         case backgroundRefresh
-    }
 
-    // MARK: - BackgroundState
+        var transition: Transition {
+            .loop(.refreshing)
+        }
+    }
 
     enum BackgroundState: Hashable {
         case backgroundRefreshing
     }
 
-    // MARK: - State
-
-    enum State: Hashable {
-        case content
-        case error(JellyfinAPIError)
+    enum State {
         case initial
+        case error
+        case refreshing
     }
 
     @Published
     var activeWithinSeconds: Int? = 900 {
         didSet {
-            send(.refresh)
+            refresh()
         }
     }
 
     @Published
     var showSessionType: ActiveSessionFilter = .all {
         didSet {
-            send(.refresh)
+            refresh()
         }
     }
 
     @Published
-    var backgroundStates: Set<BackgroundState> = []
-    @Published
     var sessions: OrderedDictionary<String, BindingBox<SessionInfoDto?>> = [:]
-    @Published
-    var state: State = .initial
 
-    private var sessionTask: AnyCancellable?
+    @Function(\Action.Cases.refresh)
+    private func _refresh() async throws {
+        try await updateSessions()
+    }
 
-    func respond(to action: Action) -> State {
-        switch action {
-        case .backgroundRefresh:
-            sessionTask?.cancel()
+    @Function(\Action.Cases.backgroundRefresh)
+    private func _backgroundRefresh() async throws {
+        backgroundStates.insert(.backgroundRefreshing)
+        defer { backgroundStates.remove(.backgroundRefreshing) }
 
-            sessionTask = Task { [weak self] in
-                await MainActor.run {
-                    let _ = self?.backgroundStates.insert(.backgroundRefreshing)
-                }
-
-                do {
-                    try await self?.updateSessions()
-                } catch {
-                    guard let self else { return }
-                    await MainActor.run {
-                        self.state = .error(.init(error.localizedDescription))
-                    }
-                }
-
-                await MainActor.run {
-                    let _ = self?.backgroundStates.remove(.backgroundRefreshing)
-                }
-            }
-            .asAnyCancellable()
-
-            return state
-        case .refresh:
-            sessionTask?.cancel()
-
-            sessionTask = Task { [weak self] in
-                await MainActor.run {
-                    self?.state = .initial
-                }
-
-                do {
-                    try await self?.updateSessions()
-
-                    guard let self else { return }
-
-                    await MainActor.run {
-                        self.state = .content
-                    }
-                } catch {
-                    guard let self else { return }
-                    await MainActor.run {
-                        self.state = .error(.init(error.localizedDescription))
-                    }
-                }
-            }
-            .asAnyCancellable()
-
-            return .initial
-        }
+        try await updateSessions()
     }
 
     // MARK: - updateSessions
@@ -153,45 +105,43 @@ final class ActiveSessionsViewModel: ViewModel, Stateful {
                 )
             }
 
-        await MainActor.run {
-            for id in removedSessionIDs {
-                let t = sessions[id]
-                sessions[id] = nil
-                t?.value = nil
+        for id in removedSessionIDs {
+            let t = sessions[id]
+            sessions[id] = nil
+            t?.value = nil
+        }
+
+        for id in existingIDs {
+            sessions[id]?.value = filteredSessions.first(where: { $0.id == id })
+        }
+
+        for session in newSessions {
+            guard let id = session.value?.id else { continue }
+
+            sessions[id] = session
+        }
+
+        sessions.sort { x, y in
+            let xs = x.value.value
+            let ys = y.value.value
+
+            let isPlaying0 = xs?.nowPlayingItem != nil
+            let isPlaying1 = ys?.nowPlayingItem != nil
+
+            if isPlaying0 && !isPlaying1 {
+                return true
+            } else if !isPlaying0 && isPlaying1 {
+                return false
             }
 
-            for id in existingIDs {
-                sessions[id]?.value = filteredSessions.first(where: { $0.id == id })
+            if xs?.userName != ys?.userName {
+                return (xs?.userName ?? "") < (ys?.userName ?? "")
             }
 
-            for session in newSessions {
-                guard let id = session.value?.id else { continue }
-
-                sessions[id] = session
-            }
-
-            sessions.sort { x, y in
-                let xs = x.value.value
-                let ys = y.value.value
-
-                let isPlaying0 = xs?.nowPlayingItem != nil
-                let isPlaying1 = ys?.nowPlayingItem != nil
-
-                if isPlaying0 && !isPlaying1 {
-                    return true
-                } else if !isPlaying0 && isPlaying1 {
-                    return false
-                }
-
-                if xs?.userName != ys?.userName {
-                    return (xs?.userName ?? "") < (ys?.userName ?? "")
-                }
-
-                if isPlaying0 && isPlaying1 {
-                    return (xs?.nowPlayingItem?.name ?? "") < (ys?.nowPlayingItem?.name ?? "")
-                } else {
-                    return (xs?.lastActivityDate ?? Date.now) > (ys?.lastActivityDate ?? Date.now)
-                }
+            if isPlaying0 && isPlaying1 {
+                return (xs?.nowPlayingItem?.name ?? "") < (ys?.nowPlayingItem?.name ?? "")
+            } else {
+                return (xs?.lastActivityDate ?? Date.now) > (ys?.lastActivityDate ?? Date.now)
             }
         }
     }

--- a/Swiftfin/Views/AdminDashboardView/ActiveSessions/ActiveSessionsView/ActiveSessionsView.swift
+++ b/Swiftfin/Views/AdminDashboardView/ActiveSessions/ActiveSessionsView/ActiveSessionsView.swift
@@ -57,7 +57,7 @@ struct ActiveSessionsView: View {
     private func errorView(with error: some Error) -> some View {
         ErrorView(error: error)
             .onRetry {
-                viewModel.send(.refresh)
+                viewModel.refresh()
             }
     }
 
@@ -67,11 +67,11 @@ struct ActiveSessionsView: View {
     var body: some View {
         ZStack {
             switch viewModel.state {
-            case .content:
-                contentView
-            case let .error(error):
-                errorView(with: error)
+            case .error:
+                viewModel.error.map { errorView(with: $0) }
             case .initial:
+                contentView
+            case .refreshing:
                 DelayedProgressView()
             }
         }
@@ -94,14 +94,14 @@ struct ActiveSessionsView: View {
             .foregroundStyle(accentColor)
         }
         .onFirstAppear {
-            viewModel.send(.refresh)
+            viewModel.refresh()
         }
         .onReceive(timer) { _ in
             guard !isFiltersPresented else { return }
-            viewModel.send(.backgroundRefresh)
+            viewModel.backgroundRefresh()
         }
         .refreshable {
-            viewModel.send(.refresh)
+            viewModel.refresh()
         }
     }
 
@@ -117,25 +117,25 @@ struct ActiveSessionsView: View {
             .tag(nil as Int?)
 
             Label(
-                300.formatted(.hourMinute),
+                Duration.seconds(300).formatted(.units(allowed: [.hours, .minutes])),
                 systemImage: "clock"
             )
             .tag(300 as Int?)
 
             Label(
-                900.formatted(.hourMinute),
+                Duration.seconds(900).formatted(.units(allowed: [.hours, .minutes])),
                 systemImage: "clock"
             )
             .tag(900 as Int?)
 
             Label(
-                1800.formatted(.hourMinute),
+                Duration.seconds(1800).formatted(.units(allowed: [.hours, .minutes])),
                 systemImage: "clock"
             )
             .tag(1800 as Int?)
 
             Label(
-                3600.formatted(.hourMinute),
+                Duration.seconds(3600).formatted(.units(allowed: [.hours, .minutes])),
                 systemImage: "clock"
             )
             .tag(3600 as Int?)
@@ -143,7 +143,7 @@ struct ActiveSessionsView: View {
             Text(L10n.lastSeen)
 
             if let activeWithinSeconds = viewModel.activeWithinSeconds {
-                Text(Double(activeWithinSeconds).formatted(.hourMinute))
+                Text(Duration.seconds(activeWithinSeconds).formatted(.units(allowed: [.hours, .minutes])))
             } else {
                 Text(L10n.all)
             }


### PR DESCRIPTION
### Summary

This is the first PR starting to migrate `ViewModels` to use the new `Stateful` macro. This may not be entirely correct so I wanted to start with one `ViewModel` to iron out any quirks before I move to work in batches.

### Other Items

1. `.hourMinute` has been deprecated so I've moved the View to use Duration instead.
2. This `ViewModel` uses `refresh` and `backgroundRefresh`. I believe we can get away with just the single `refresh` but I wanted to leave this as intact as possible. Let me know if you would prefer I remove the `backgroundRefresh`.