### PR TITLE
Pin `Transmission` and fix severe hang

### DIFF
--- a/PreferencesView/Package.swift
+++ b/PreferencesView/Package.swift
@@ -5,8 +5,8 @@ import PackageDescription
 let package = Package(
     name: "PreferencesView",
     platforms: [
-        .iOS(.v15),
-        .tvOS(.v15),
+        .iOS(.v16),
+        .tvOS(.v16),
     ],
     products: [
         .library(

--- a/PreferencesView/Sources/PreferencesView/UIPreferencesHostingController.swift
+++ b/PreferencesView/Sources/PreferencesView/UIPreferencesHostingController.swift
@@ -83,11 +83,7 @@ public class UIPreferencesHostingController: UIHostingController<AnyView> {
 
     var _orientations: UIInterfaceOrientationMask = .all {
         didSet {
-            if #available(iOS 16, *) {
-                setNeedsUpdateOfSupportedInterfaceOrientations()
-            } else {
-                AppRotationUtility.lockOrientation(_orientations)
-            }
+            setNeedsUpdateOfSupportedInterfaceOrientations()
         }
     }
 
@@ -95,7 +91,9 @@ public class UIPreferencesHostingController: UIHostingController<AnyView> {
         _orientations
     }
 
-    override public var shouldAutorotate: Bool { true }
+    override public var shouldAutorotate: Bool {
+        true
+    }
 
     // MARK: Defer Edges
 
@@ -116,7 +114,6 @@ public class UIPreferencesHostingController: UIHostingController<AnyView> {
     override public var prefersHomeIndicatorAutoHidden: Bool {
         _prefersHomeIndicatorAutoHidden
     }
-
     #endif
 
     #if os(tvOS)
@@ -143,27 +140,3 @@ public class UIPreferencesHostingController: UIHostingController<AnyView> {
     }
     #endif
 }
-
-// TODO: remove after iOS 15 support removed
-
-#if os(iOS)
-enum AppRotationUtility {
-
-    static func lockOrientation(_ orientationLock: UIInterfaceOrientationMask) {
-
-        guard UIDevice.current.userInterfaceIdiom == .phone else { return }
-
-        let rotateOrientation: UIInterfaceOrientation
-
-        switch orientationLock {
-        case .landscape:
-            rotateOrientation = .landscapeRight
-        default:
-            rotateOrientation = .portrait
-        }
-
-        UIDevice.current.setValue(rotateOrientation.rawValue, forKey: "orientation")
-        UINavigationController.attemptRotationToDeviceOrientation()
-    }
-}
-#endif

--- a/PreferencesView/Sources/PreferencesView/ViewExtensions.swift
+++ b/PreferencesView/Sources/PreferencesView/ViewExtensions.swift
@@ -8,6 +8,21 @@
 
 import SwiftUI
 
+public extension UIInterfaceOrientationMask {
+    var displayTitle: String {
+        switch self {
+        case .all: "All Orientations"
+        case .allButUpsideDown: "All But Upside Down"
+        case .portrait: "Portrait"
+        case .portraitUpsideDown: "Portrait Upside Down"
+        case .landscape: "Landscape"
+        case .landscapeLeft: "Landscape Left"
+        case .landscapeRight: "Landscape Right"
+        default: "Unknown"
+        }
+    }
+}
+
 public extension View {
 
     #if os(iOS)

--- a/Shared/Components/WithObservedObject.swift
+++ b/Shared/Components/WithObservedObject.swift
@@ -8,9 +8,12 @@
 
 import SwiftUI
 
+// TODO: Causes severe hangs - actually probably not the best idea
+//       - object identifier equatable works okay, test more
+
 /// A view that observes an `ObservableObject` and provides its value to a content closure.
 /// Use whenever the object is derived in a context where `@ObservedObject` cannot be used directly.
-struct WithObservedObject<Value: ObservableObject, Content: View>: View {
+struct WithObservedObject<Value: ObservableObject, Content: View>: View, Equatable {
 
     @ObservedObject
     private var value: Value
@@ -27,5 +30,9 @@ struct WithObservedObject<Value: ObservableObject, Content: View>: View {
 
     var body: some View {
         content(value)
+    }
+
+    static func == (lhs: WithObservedObject<Value, Content>, rhs: WithObservedObject<Value, Content>) -> Bool {
+        ObjectIdentifier(lhs.value) == ObjectIdentifier(rhs.value)
     }
 }

--- a/Swiftfin.xcodeproj/project.pbxproj
+++ b/Swiftfin.xcodeproj/project.pbxproj
@@ -1302,8 +1302,8 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/nathantannar4/Transmission";
 			requirement = {
-				kind = upToNextMajorVersion;
-				minimumVersion = 2.4.5;
+				kind = exactVersion;
+				version = 2.4.5;
 			};
 		};
 		E176EBDC2D050067009F4CF1 /* XCRemoteSwiftPackageReference "swift-identified-collections" */ = {

--- a/Swiftfin.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Swiftfin.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -285,8 +285,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/nathantannar4/Transmission",
       "state" : {
-        "revision" : "e59132a2b8c3ed8b94a098ddb79aa0b89d180642",
-        "version" : "2.5.16"
+        "revision" : "2da5049d33111238ad4cb979ebce783af9586cef",
+        "version" : "2.4.5"
       }
     },
     {


### PR DESCRIPTION
Part of #1709 but not closing for now.

During development I used the `2.4.5` version of Transmission, pinning now as updating [past this version](https://github.com/jellyfin/Swiftfin/commit/e7d65fc423be1609c12f5de89c45d388b6a35819#diff-848025bfcbf263b40f46f4a2547f764c1261a2445d0fbfd4eb9717c6bd9403bbR287-L289) makes me experience the issue every time. I'll test some more and possibly make a POC to file an issue if needs be.

Part of the issue is also a severe hang with my `WithObservedObject` view.