### PR TITLE
Change one instance of "ratings" string for "parentalRating"

### DIFF
--- a/Swiftfin/Views/AdminDashboardView/ServerUsers/ServerUserDetailsView/ServerUserDetailsView.swift
+++ b/Swiftfin/Views/AdminDashboardView/ServerUsers/ServerUserDetailsView/ServerUserDetailsView.swift
@@ -106,7 +106,7 @@ struct ServerUserDetailsView: View {
             }
 
             Section(L10n.parentalControls) {
-                ChevronButton(L10n.ratings) {
+                ChevronButton(L10n.parentalRating) {
                     router.route(to: .userParentalRatings(viewModel: viewModel))
                 }
                 ChevronButton(L10n.accessSchedules) {


### PR DESCRIPTION
Changes the string "Ratings" in the parental controls menu to instead use "Parental rating". Mostly for consistency for translated strings, because other places the "ratings" string is used are for the score ratings rather than age rating, which is a different word in some languages.