### PR TITLE
Fix Calendar Localizations

### DIFF
--- a/Shared/Extensions/JellyfinAPI/DayOfWeek.swift
+++ b/Shared/Extensions/JellyfinAPI/DayOfWeek.swift
@@ -11,7 +11,7 @@ import JellyfinAPI
 
 extension DayOfWeek {
 
-    var displayTitle: String? {
+    var displayTitle: String {
         let newLineRemoved = rawValue.replacingOccurrences(of: "\n", with: "")
 
         /// The enum is in English so validation must be done against a calendar in English

--- a/Shared/Extensions/JellyfinAPI/DynamicDayOfWeek.swift
+++ b/Shared/Extensions/JellyfinAPI/DynamicDayOfWeek.swift
@@ -14,19 +14,19 @@ extension DynamicDayOfWeek {
     var displayTitle: String {
         switch self {
         case .sunday:
-            DayOfWeek.sunday.displayTitle ?? self.rawValue
+            DayOfWeek.sunday.displayTitle
         case .monday:
-            DayOfWeek.monday.displayTitle ?? self.rawValue
+            DayOfWeek.monday.displayTitle
         case .tuesday:
-            DayOfWeek.tuesday.displayTitle ?? self.rawValue
+            DayOfWeek.tuesday.displayTitle
         case .wednesday:
-            DayOfWeek.wednesday.displayTitle ?? self.rawValue
+            DayOfWeek.wednesday.displayTitle
         case .thursday:
-            DayOfWeek.thursday.displayTitle ?? self.rawValue
+            DayOfWeek.thursday.displayTitle
         case .friday:
-            DayOfWeek.friday.displayTitle ?? self.rawValue
+            DayOfWeek.friday.displayTitle
         case .saturday:
-            DayOfWeek.saturday.displayTitle ?? self.rawValue
+            DayOfWeek.saturday.displayTitle
         case .everyday:
             L10n.everyday
         case .weekday:

--- a/Swiftfin/Views/AdminDashboardView/ServerTasks/AddTaskTriggerView/Components/DayOfWeekRow.swift
+++ b/Swiftfin/Views/AdminDashboardView/ServerTasks/AddTaskTriggerView/Components/DayOfWeekRow.swift
@@ -27,7 +27,7 @@ extension AddTaskTriggerView {
                 )
             ) {
                 ForEach(DayOfWeek.allCases, id: \.self) { day in
-                    Text(day.displayTitle ?? L10n.unknown)
+                    Text(day.displayTitle)
                         .tag(day)
                 }
             }

--- a/Swiftfin/Views/AdminDashboardView/ServerUsers/ServerUserSettings/ServerUserAccessSchedule/EditAccessScheduleView/Components/EditAccessScheduleRow.swift
+++ b/Swiftfin/Views/AdminDashboardView/ServerUsers/ServerUserSettings/ServerUserAccessSchedule/EditAccessScheduleView/Components/EditAccessScheduleRow.swift
@@ -50,7 +50,7 @@ extension EditAccessScheduleView {
             HStack {
                 VStack(alignment: .leading) {
                     if let dayOfWeek = schedule.dayOfWeek {
-                        Text(dayOfWeek.rawValue)
+                        Text(dayOfWeek.displayTitle)
                             .fontWeight(.semibold)
                     }
 

--- a/Swiftfin/Views/ItemEditorView/ItemMetadata/EditMetadataView/Components/Sections/SeriesSection.swift
+++ b/Swiftfin/Views/ItemEditorView/ItemMetadata/EditMetadataView/Components/Sections/SeriesSection.swift
@@ -87,7 +87,7 @@ extension EditMetadataView {
         private var airDaysView: some View {
             ForEach(DayOfWeek.allCases, id: \.self) { field in
                 Toggle(
-                    field.displayTitle ?? L10n.unknown,
+                    field.displayTitle,
                     isOn: $item.airDays
                         .coalesce([])
                         .contains(field)


### PR DESCRIPTION
### Summary

Resolves: https://github.com/jellyfin/Swiftfin/issues/1731

We were localizing the calendar that we queried our `DayOfWeek` against. So, "Monday" would get queried against Spanish, German, etc. and always return nil. Since our enum is in English coming from Jellyfin, I forced the calendar we query against to always be English so we will always get matches.

If something goes wrong, I also fall back to the enum text in English instead of `Unknown`.

Since the `DisplayTitle` is always present now, I've cleaned up the spots where we included a fallback

### Old

<img width="322" height="343" alt="Screenshot 2025-09-24 at 08 11 13" src="https://github.com/user-attachments/assets/5f9fdc63-7668-4e38-b571-126dc6ae34b1" />

### New

<img width="321" height="345" alt="Screenshot 2025-09-24 at 08 09 31" src="https://github.com/user-attachments/assets/6affce47-3250-40f9-9b7f-b01e226edc78" />
