### PR TITLE
[iOS] Hide elements in ItemView & PosterButton from voiceover

### DIFF
--- a/Swiftfin/Components/PosterButton.swift
+++ b/Swiftfin/Components/PosterButton.swift
@@ -63,6 +63,7 @@ struct PosterButton<Item: Poster>: View {
                 .backport
                 .matchedTransitionSource(id: "item", in: namespace)
                 .posterShadow()
+                .accessibilityElement(children: .ignore)
 
             label
                 .eraseToAnyView()

--- a/Swiftfin/Views/ItemView/ScrollViews/CinematicScrollView.swift
+++ b/Swiftfin/Views/ItemView/ScrollViews/CinematicScrollView.swift
@@ -53,6 +53,7 @@ extension ItemView {
                     .aspectRatio(usePrimaryImage ? (2 / 3) : 1.77, contentMode: .fill)
                     .frame(width: proxy.size.width, height: proxy.size.height * 0.6)
                     .bottomEdgeGradient(bottomColor: bottomColor)
+                    .accessibilityHidden(true)
                 }
             }
         }
@@ -114,6 +115,8 @@ extension ItemView.CinematicScrollView {
                             }
                             .aspectRatio(contentMode: .fit)
                             .frame(height: 100, alignment: .bottom)
+                            .accessibilityElement(children: .ignore)
+                            .accessibilityLabel(viewModel.item.displayTitle)
                     }
 
                     DotHStack {

--- a/Swiftfin/Views/ItemView/ScrollViews/CinematicScrollView.swift
+++ b/Swiftfin/Views/ItemView/ScrollViews/CinematicScrollView.swift
@@ -115,8 +115,7 @@ extension ItemView.CinematicScrollView {
                             }
                             .aspectRatio(contentMode: .fit)
                             .frame(height: 100, alignment: .bottom)
-                            .accessibilityElement(children: .ignore)
-                            .accessibilityLabel(viewModel.item.displayTitle)
+                            .accessibilityHidden(true)
                     }
 
                     DotHStack {

--- a/Swiftfin/Views/ItemView/ScrollViews/CompactLogoScrollView.swift
+++ b/Swiftfin/Views/ItemView/ScrollViews/CompactLogoScrollView.swift
@@ -38,6 +38,7 @@ extension ItemView {
                     .aspectRatio(1.77, contentMode: .fill)
                     .frame(width: proxy.size.width, height: proxy.size.height * 0.70, alignment: .top)
                     .bottomEdgeGradient(bottomColor: bottomColor)
+                    .accessibilityHidden(true)
             }
         }
 
@@ -103,6 +104,8 @@ extension ItemView.CompactLogoScrollView {
                     }
                     .aspectRatio(contentMode: .fit)
                     .frame(height: 70, alignment: .bottom)
+                    .accessibilityElement(children: .ignore)
+                    .accessibilityLabel(viewModel.item.displayTitle)
 
                 DotHStack {
                     if let firstGenre = viewModel.item.genres?.first {

--- a/Swiftfin/Views/ItemView/ScrollViews/CompactLogoScrollView.swift
+++ b/Swiftfin/Views/ItemView/ScrollViews/CompactLogoScrollView.swift
@@ -104,8 +104,7 @@ extension ItemView.CompactLogoScrollView {
                     }
                     .aspectRatio(contentMode: .fit)
                     .frame(height: 70, alignment: .bottom)
-                    .accessibilityElement(children: .ignore)
-                    .accessibilityLabel(viewModel.item.displayTitle)
+                    .accessibilityHidden(true)
 
                 DotHStack {
                     if let firstGenre = viewModel.item.genres?.first {

--- a/Swiftfin/Views/ItemView/ScrollViews/CompactPortraitScrollView.swift
+++ b/Swiftfin/Views/ItemView/ScrollViews/CompactPortraitScrollView.swift
@@ -126,6 +126,7 @@ extension ItemView.CompactPosterScrollView {
                     .lineLimit(2)
                     .fontWeight(.semibold)
                     .foregroundColor(.white)
+                    .accessibilityHidden(true)
 
                 DotHStack {
                     if viewModel.item.type == .person {

--- a/Swiftfin/Views/ItemView/ScrollViews/CompactPortraitScrollView.swift
+++ b/Swiftfin/Views/ItemView/ScrollViews/CompactPortraitScrollView.swift
@@ -61,6 +61,7 @@ extension ItemView {
                         .aspectRatio(1.77, contentMode: .fill)
                         .frame(width: proxy.size.width, height: proxy.size.height * 0.78, alignment: .top)
                         .bottomEdgeGradient(bottomColor: bottomColor)
+                        .accessibilityHidden(true)
                 }
             }
         }

--- a/Swiftfin/Views/ItemView/ScrollViews/iPadOSCinematicScrollView.swift
+++ b/Swiftfin/Views/ItemView/ScrollViews/iPadOSCinematicScrollView.swift
@@ -122,8 +122,7 @@ extension ItemView.iPadOSCinematicScrollView {
                         }
                         .aspectRatio(contentMode: .fit)
                         .frame(maxWidth: geometry.size.width * 0.4, maxHeight: 130, alignment: .bottomLeading)
-                        .accessibilityElement(children: .ignore)
-                        .accessibilityLabel(viewModel.item.displayTitle)
+                        .accessibilityHidden(true)
 
                         ItemView.OverviewView(item: viewModel.item)
                             .overviewLineLimit(3)

--- a/Swiftfin/Views/ItemView/ScrollViews/iPadOSCinematicScrollView.swift
+++ b/Swiftfin/Views/ItemView/ScrollViews/iPadOSCinematicScrollView.swift
@@ -59,6 +59,7 @@ extension ItemView {
                 ImageView(imageSource)
                     .aspectRatio(1.77, contentMode: .fill)
                     .bottomEdgeGradient(bottomColor: bottomColor)
+                    .accessibilityHidden(true)
             }
         }
 
@@ -121,6 +122,8 @@ extension ItemView.iPadOSCinematicScrollView {
                         }
                         .aspectRatio(contentMode: .fit)
                         .frame(maxWidth: geometry.size.width * 0.4, maxHeight: 130, alignment: .bottomLeading)
+                        .accessibilityElement(children: .ignore)
+                        .accessibilityLabel(viewModel.item.displayTitle)
 
                         ItemView.OverviewView(item: viewModel.item)
                             .overviewLineLimit(3)


### PR DESCRIPTION
#1737 

This hides the backdrop image in item views from VO, gives the logo images accessibility labels, and disables OCR on poster images.

For some reason the logo images sometimes still got their text read out even though I tried ignoring their contents with accessibilityElement(), so I've hidden them since the navigation title already contains the item's title anyway.

Demo:

https://github.com/user-attachments/assets/7420fc52-d459-49d4-8431-8b5a3b38a8ff