### PR TITLE
[iOS] VoiceOver-only button to toggle player overlay

### DIFF
--- a/Shared/Components/VideoPlayer.swift
+++ b/Shared/Components/VideoPlayer.swift
@@ -66,6 +66,17 @@ struct VideoPlayer: View {
         .onSceneDidEnterBackground {
             manager.set(playbackRequestStatus: .paused)
         }
+        .overlay {
+            Rectangle()
+                .hidden()
+                .accessibilityRepresentation {
+                    Button {
+                        containerState.accessibilityToggleOverlay()
+                    } label: {
+                        Text("Toggle Overlay")
+                    }
+                }
+        }
     }
 
     var body: some View {

--- a/Shared/Objects/VideoPlayerContainerState.swift
+++ b/Shared/Objects/VideoPlayerContainerState.swift
@@ -68,6 +68,11 @@ class VideoPlayerContainerState: ObservableObject {
     @Published
     var isGuestSupplement: Bool = false
 
+    func accessibilityToggleOverlay() {
+        isPresentingOverlay.toggle()
+        timer.stop()
+    }
+
     // TODO: rename isPresentingPlaybackControls
     @Published
     var isPresentingOverlay: Bool = false {

--- a/Shared/Objects/VideoPlayerContainerState.swift
+++ b/Shared/Objects/VideoPlayerContainerState.swift
@@ -40,22 +40,12 @@ class VideoPlayerContainerState: ObservableObject {
             return
         }
 
-        if isPresentingOverlay && !isPresentingSupplement {
+        guard isPresentingSupplement else {
             isPresentingPlaybackControls = true
             return
         }
 
-        if isCompact {
-            if isPresentingSupplement {
-                if !isPresentingPlaybackControls {
-                    isPresentingPlaybackControls = true
-                }
-            } else {
-                isPresentingPlaybackControls = false
-            }
-        } else {
-            isPresentingPlaybackControls = false
-        }
+        isPresentingPlaybackControls = isCompact
     }
 
     @Published


### PR DESCRIPTION
Fixes #1733 

This adds an invisible voiceover-only button to the VideoPlayer which toggles the overlay and keeps it visible rather than fading it out in a couple seconds. I also simplified `setPlaybackControlsVisibility` since I noticed some redundant ifs and stuff