### PR TITLE
Fix Incorrect Icon for Subtitles

### DIFF
--- a/Swiftfin/Views/VideoPlayerContainerView/PlaybackControls/Components/NavigationBar/ActionButtons/SubtitleActionButton.swift
+++ b/Swiftfin/Views/VideoPlayerContainerView/PlaybackControls/Components/NavigationBar/ActionButtons/SubtitleActionButton.swift
@@ -23,9 +23,9 @@ extension VideoPlayer.PlaybackControls.NavigationBar.ActionButtons {
 
         private var systemImage: String {
             if selectedSubtitleStreamIndex == nil {
-                VideoPlayerActionButton.audio.secondarySystemImage
+                VideoPlayerActionButton.subtitles.secondarySystemImage
             } else {
-                VideoPlayerActionButton.audio.systemImage
+                VideoPlayerActionButton.subtitles.systemImage
             }
         }
 


### PR DESCRIPTION
closes #1748

<img width="365" height="822" alt="Simulator Screenshot - iPhone 17 Pro - 2025-09-29 at 18 52 08" src="https://github.com/user-attachments/assets/7df364d7-8e81-45e8-9d2a-9f50c3717db1" />
