### PR TITLE
Remove id guard

### DIFF
--- a/Shared/Extensions/JellyfinAPI/BaseItemDto/BaseItemDto.swift
+++ b/Shared/Extensions/JellyfinAPI/BaseItemDto/BaseItemDto.swift
@@ -511,10 +511,6 @@ extension BaseItemDto {
         let response = try await userSession.client.send(request)
         let newItem = response.value
 
-        guard newItem.id == id else {
-            throw JellyfinAPIError("Mismatching item IDs")
-        }
-
         return newItem
     }
 }

--- a/Shared/Extensions/JellyfinAPI/BaseItemDto/BaseItemDto.swift
+++ b/Shared/Extensions/JellyfinAPI/BaseItemDto/BaseItemDto.swift
@@ -509,8 +509,11 @@ extension BaseItemDto {
 
         let request = Paths.getItem(itemID: id, userID: userSession.user.id)
         let response = try await userSession.client.send(request)
-        let newItem = response.value
+        
+        // A check against `id` would typically be done, but a plugin
+        // may have provided `self` or the response item and may not
+        // be invariant over `id`.
 
-        return newItem
+        return response.value
     }
 }


### PR DESCRIPTION
So this is an edge case. But i have a plugin that uses an external search engine. And ids might not
match, breaking swiftfin search for me

I know this is an edge case but i don’t think removing the guard is in anyway harmful.

And if there's a mismatch i would say it would be intentional like my case