### PR TITLE
Add session seed recovery flow for tvOS logout issue

### DIFF
--- a/Shared/Coordinators/Root/RootItem.swift
+++ b/Shared/Coordinators/Root/RootItem.swift
@@ -32,6 +32,10 @@ struct RootItem: Identifiable {
         MainTabView()
     }
 
+    static let sessionRestore = RootItem(id: "sessionRestore") {
+        SessionRestoreView()
+    }
+
     static let selectUser = RootItem(id: "selectUser") {
         NavigationInjectionView(coordinator: .init()) {
             SelectUserView()

--- a/Shared/Coordinators/Root/RootView.swift
+++ b/Shared/Coordinators/Root/RootView.swift
@@ -28,6 +28,10 @@ struct RootView: View {
                 RootItem.mainTab.content
             }
 
+            if rootCoordinator.root.id == RootItem.sessionRestore.id {
+                RootItem.sessionRestore.content
+            }
+
             if rootCoordinator.root.id == RootItem.selectUser.id {
                 RootItem.selectUser.content
             }

--- a/Shared/Extensions/JellyfinAPI/BaseItemDto/BaseItemDto.swift
+++ b/Shared/Extensions/JellyfinAPI/BaseItemDto/BaseItemDto.swift
@@ -509,7 +509,7 @@ extension BaseItemDto {
 
         let request = Paths.getItem(itemID: id, userID: userSession.user.id)
         let response = try await userSession.client.send(request)
-        
+
         // A check against `id` would typically be done, but a plugin
         // may have provided `self` or the response item and may not
         // be invariant over `id`.

--- a/Shared/Models/SessionSeed.swift
+++ b/Shared/Models/SessionSeed.swift
@@ -1,0 +1,60 @@
+//
+// Swiftfin is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, you can obtain one at https://mozilla.org/MPL/2.0/.
+//
+// Copyright (c) 2025 Jellyfin & Jellyfin Contributors
+//
+
+import Foundation
+
+/// Minimal, non-purgeable data needed to rebuild a signed-in session after the CoreData store is lost.
+struct SessionSeed: Codable, Hashable {
+
+    enum CodingKeys: String, CodingKey {
+        case userID
+        case serverID
+        case username
+        case serverName
+        case currentServerURL
+        case serverURLs
+        case accessPolicyRawValue
+        case pinHint
+        case updatedAt
+    }
+
+    let userID: String
+    let serverID: String
+    var username: String
+    var serverName: String
+    var currentServerURL: URL
+    var serverURLs: [URL]
+    var accessPolicyRawValue: String
+    var pinHint: String?
+    var updatedAt: Date
+
+    init(
+        userID: String,
+        serverID: String,
+        username: String,
+        serverName: String,
+        currentServerURL: URL,
+        serverURLs: [URL],
+        accessPolicyRawValue: String,
+        pinHint: String?
+    ) {
+        self.userID = userID
+        self.serverID = serverID
+        self.username = username
+        self.serverName = serverName
+        self.currentServerURL = currentServerURL
+        self.serverURLs = serverURLs
+        self.accessPolicyRawValue = accessPolicyRawValue
+        self.pinHint = pinHint
+        self.updatedAt = Date()
+    }
+
+    mutating func touch() {
+        updatedAt = Date()
+    }
+}

--- a/Shared/Services/SessionRestorationService.swift
+++ b/Shared/Services/SessionRestorationService.swift
@@ -1,0 +1,188 @@
+//
+// Swiftfin is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, you can obtain one at https://mozilla.org/MPL/2.0/.
+//
+// Copyright (c) 2025 Jellyfin & Jellyfin Contributors
+//
+
+import CoreStore
+import Defaults
+import Factory
+import Foundation
+import JellyfinAPI
+import Logging
+import Pulse
+
+actor SessionRestorationService {
+
+    struct RestorationSummary {
+        let restoredUserIDs: [String]
+        let failedUserIDs: [String]
+    }
+
+    private enum RestorationError: Error {
+        case missingAccessToken
+        case invalidServerURL
+    }
+
+    private let seedStore: SessionSeedStore
+    private let keychain: KeychainStoring
+    private let logger = Logger.swiftfin()
+
+    init(seedStore: SessionSeedStore, keychain: KeychainStoring) {
+        self.seedStore = seedStore
+        self.keychain = keychain
+    }
+
+    func migrateExistingSeeds() {
+        do {
+            let storedUsers = try SwiftfinStore.dataStack.fetchAll(From<UserModel>())
+
+            for storedUser in storedUsers {
+                guard let storedServer = storedUser.server else { continue }
+                let userState = storedUser.state
+                let serverState = storedServer.state
+                seedStore.upsert(user: userState, server: serverState)
+            }
+        } catch {
+            logger.error("Failed migrating existing session seeds: \(error.localizedDescription)")
+        }
+
+        seedStore.purgeMissingKeychainEntries()
+    }
+
+    func needsRestoration() -> Bool {
+        do {
+            let userCount = try SwiftfinStore.dataStack.fetchCount(From<UserModel>())
+            return userCount == 0 && seedStore.hasSeeds
+        } catch {
+            logger.error("Unable to inspect CoreStore for restoration need: \(error.localizedDescription)")
+            return false
+        }
+    }
+
+    func restoreSessions() async -> RestorationSummary {
+        let seeds = seedStore.seeds()
+        guard !seeds.isEmpty else {
+            return RestorationSummary(restoredUserIDs: [], failedUserIDs: [])
+        }
+
+        var restored: [String] = []
+        var failed: [String] = []
+
+        for seed in seeds {
+            do {
+                try await restore(seed: seed)
+                restored.append(seed.userID)
+            } catch {
+                failed.append(seed.userID)
+                handleRestorationFailure(for: seed, error: error)
+            }
+        }
+
+        return RestorationSummary(restoredUserIDs: restored, failedUserIDs: failed)
+    }
+
+    private func restore(seed: SessionSeed) async throws {
+        guard let accessToken = keychain.string(for: accessTokenKey(for: seed.userID)) else {
+            throw RestorationError.missingAccessToken
+        }
+
+        let currentURL = seed.currentServerURL
+
+        let client = JellyfinClient(
+            configuration: .swiftfinConfiguration(
+                url: currentURL,
+                accessToken: accessToken
+            ),
+            sessionConfiguration: .swiftfin,
+            sessionDelegate: URLSessionProxyDelegate(logger: NetworkLogger.swiftfin())
+        )
+
+        async let userResponse = client.send(Paths.getCurrentUser)
+        async let systemResponse = client.send(Paths.getPublicSystemInfo)
+
+        let (userResult, systemResult) = try await (userResponse, systemResponse)
+
+        let userData = userResult.value
+        let publicInfo = systemResult.value
+
+        try SwiftfinStore.dataStack.perform { transaction in
+            let server = try transaction.fetchOne(From<ServerModel>().where(\.$id == seed.serverID))
+                ?? transaction.create(Into<ServerModel>())
+
+            server.id = seed.serverID
+            server.name = publicInfo.serverName ?? seed.serverName
+            server.currentURL = currentURL
+            server.urls = Set(seed.serverURLs).union([currentURL])
+
+            let storedUser = try transaction.fetchOne(From<UserModel>().where(\.$id == seed.userID))
+                ?? transaction.create(Into<UserModel>())
+
+            storedUser.id = seed.userID
+            storedUser.username = userData.name ?? seed.username
+            storedUser.server = server
+        }
+
+        guard let storedUser = try SwiftfinStore.dataStack.fetchOne(From<UserModel>().where(\.$id == seed.userID)),
+              let storedServer = storedUser.server
+        else {
+            throw JellyfinAPIError("Unable to fetch restored user or server from CoreStore")
+        }
+
+        let userState = storedUser.state
+        let serverState = storedServer.state
+
+        userState.accessToken = accessToken
+        userState.data = userData
+
+        if let policy = UserAccessPolicy(rawValue: seed.accessPolicyRawValue) {
+            userState.accessPolicy = policy
+        } else {
+            userState.accessPolicy = .none
+        }
+
+        if let pinHint = seed.pinHint {
+            userState.pinHint = pinHint
+        }
+
+        StoredValues[.Server.publicInfo(id: serverState.id)] = publicInfo
+
+        seedStore.upsert(user: userState, server: serverState)
+    }
+
+    private func handleRestorationFailure(for seed: SessionSeed, error: Error) {
+        logger.error("Failed restoring session for user \(seed.userID): \(error.localizedDescription)")
+        seedStore.delete(userID: seed.userID)
+
+        keychain.delete(accessTokenKey(for: seed.userID))
+        keychain.delete(pinKey(for: seed.userID))
+
+        if case let .signedIn(userID) = Defaults[.lastSignedInUserID],
+           userID == seed.userID
+        {
+            Defaults[.lastSignedInUserID] = .signedOut
+        }
+    }
+
+    private func accessTokenKey(for userID: String) -> String {
+        "\(userID)-accessToken"
+    }
+
+    private func pinKey(for userID: String) -> String {
+        "\(userID)-pin"
+    }
+}
+
+extension Container {
+
+    var sessionRestorationService: Factory<SessionRestorationService> {
+        self {
+            SessionRestorationService(
+                seedStore: self.sessionSeedStore(),
+                keychain: self.keychainService()
+            )
+        }.singleton
+    }
+}

--- a/Shared/Services/SessionSeedStore.swift
+++ b/Shared/Services/SessionSeedStore.swift
@@ -1,0 +1,208 @@
+//
+// Swiftfin is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, you can obtain one at https://mozilla.org/MPL/2.0/.
+//
+// Copyright (c) 2025 Jellyfin & Jellyfin Contributors
+//
+
+import CoreStore
+import Defaults
+import Factory
+import Foundation
+import KeychainSwift
+import Logging
+
+protocol KeychainStoring {
+    @discardableResult
+    func storeData(_ value: Data, for key: String, access: KeychainSwiftAccessOptions?) -> Bool
+    func data(for key: String) -> Data?
+    func string(for key: String) -> String?
+    @discardableResult
+    func storeString(_ value: String, for key: String, access: KeychainSwiftAccessOptions?) -> Bool
+    @discardableResult
+    func delete(_ key: String) -> Bool
+}
+
+extension KeychainStoring {
+    @discardableResult
+    func storeData(_ value: Data, for key: String) -> Bool {
+        storeData(value, for: key, access: nil)
+    }
+
+    @discardableResult
+    func storeString(_ value: String, for key: String) -> Bool {
+        storeString(value, for: key, access: nil)
+    }
+}
+
+extension KeychainSwift: KeychainStoring {
+
+    func storeData(_ value: Data, for key: String, access: KeychainSwiftAccessOptions?) -> Bool {
+        set(value, forKey: key, withAccess: access)
+    }
+
+    func data(for key: String) -> Data? {
+        getData(key)
+    }
+
+    func string(for key: String) -> String? {
+        get(key)
+    }
+
+    func storeString(_ value: String, for key: String, access: KeychainSwiftAccessOptions?) -> Bool {
+        set(value, forKey: key, withAccess: access)
+    }
+}
+
+final class SessionSeedStore {
+
+    private enum Constants {
+        static let seedKeyPrefix = "sessionSeed-"
+    }
+
+    private let encoder: JSONEncoder
+    private let decoder: JSONDecoder
+    private let keychain: KeychainStoring
+    private let logger = Logger.swiftfin()
+
+    init(keychain: KeychainStoring) {
+        self.keychain = keychain
+
+        let encoder = JSONEncoder()
+        encoder.dateEncodingStrategy = .iso8601
+        encoder.outputFormatting = [.sortedKeys]
+        self.encoder = encoder
+
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+        self.decoder = decoder
+    }
+
+    var hasSeeds: Bool {
+        !userIDs.isEmpty
+    }
+
+    var userIDs: [String] {
+        Defaults[.sessionSeedUserIDs]
+    }
+
+    func seed(for userID: String) -> SessionSeed? {
+        guard let data = keychain.data(for: key(for: userID)) else { return nil }
+        do {
+            return try decoder.decode(SessionSeed.self, from: data)
+        } catch {
+            logger.error("Unable to decode seed for user \(userID): \(error.localizedDescription)")
+            return nil
+        }
+    }
+
+    func seeds() -> [SessionSeed] {
+        userIDs.compactMap { seed(for: $0) }
+    }
+
+    func upsert(seed: SessionSeed) {
+        var seedToStore = seed
+        seedToStore.touch()
+
+        do {
+            let data = try encoder.encode(seedToStore)
+            let stored = keychain.storeData(
+                data,
+                for: key(for: seedToStore.userID),
+                access: .accessibleAfterFirstUnlockThisDeviceOnly
+            )
+
+            if stored {
+                updateUserIDs(inserting: seedToStore.userID)
+            } else {
+                logger.error("Failed to store session seed for user \(seedToStore.userID)")
+            }
+        } catch {
+            logger.error("Failed to encode session seed for user \(seed.userID): \(error.localizedDescription)")
+        }
+    }
+
+    func upsert(user: UserState, server: ServerState) {
+        guard let seed = makeSeed(user: user, server: server) else { return }
+        upsert(seed: seed)
+    }
+
+    func upsertAllUsers(of server: ServerState) {
+        for userID in server.userIDs {
+            guard let storedUser = try? SwiftfinStore.dataStack.fetchOne(From<UserModel>().where(\.$id == userID)) else {
+                continue
+            }
+
+            upsert(user: storedUser.state, server: server)
+        }
+    }
+
+    func delete(userID: String) {
+        keychain.delete(key(for: userID))
+        updateUserIDs(removing: userID)
+    }
+
+    func purgeMissingKeychainEntries() {
+        let ids = userIDs
+        let filtered = ids.filter { keychain.data(for: key(for: $0)) != nil }
+        if filtered.count != ids.count {
+            Defaults[.sessionSeedUserIDs] = filtered
+        }
+    }
+
+    private func key(for userID: String) -> String {
+        "\(Constants.seedKeyPrefix)\(userID)"
+    }
+
+    private func updateUserIDs(inserting userID: String) {
+        var set = Set(Defaults[.sessionSeedUserIDs])
+        set.insert(userID)
+        Defaults[.sessionSeedUserIDs] = Array(set).sorted()
+    }
+
+    private func updateUserIDs(removing userID: String) {
+        var set = Set(Defaults[.sessionSeedUserIDs])
+        if set.remove(userID) != nil {
+            Defaults[.sessionSeedUserIDs] = Array(set).sorted()
+        }
+    }
+
+    private func makeSeed(user: UserState, server: ServerState) -> SessionSeed? {
+        guard let currentURL = userPreferredServerURL(server: server) else {
+            logger.error("Unable to determine current server URL when creating seed for user \(user.id)")
+            return nil
+        }
+
+        let serverURLs = server.urls
+            .map(\.absoluteString)
+            .sorted()
+            .compactMap(URL.init(string:))
+
+        let pinHint = user.pinHint.isEmpty ? nil : user.pinHint
+
+        return SessionSeed(
+            userID: user.id,
+            serverID: server.id,
+            username: user.username,
+            serverName: server.name,
+            currentServerURL: currentURL,
+            serverURLs: serverURLs,
+            accessPolicyRawValue: user.accessPolicy.rawValue,
+            pinHint: pinHint
+        )
+    }
+
+    private func userPreferredServerURL(server: ServerState) -> URL? {
+        server.urls.first { $0 == server.currentURL } ?? server.currentURL
+    }
+}
+
+extension Container {
+
+    var sessionSeedStore: Factory<SessionSeedStore> {
+        self {
+            SessionSeedStore(keychain: self.keychainService())
+        }.singleton
+    }
+}

--- a/Shared/Services/SwiftfinDefaults.swift
+++ b/Shared/Services/SwiftfinDefaults.swift
@@ -84,6 +84,7 @@ extension Defaults.Keys {
     static let backgroundSignOutInterval: Key<TimeInterval> = AppKey("backgroundSignOutInterval", default: 3600)
     static let backgroundTimeStamp: Key<Date> = AppKey("backgroundTimeStamp", default: Date.now)
     static let lastSignedInUserID: Key<UserSignInState> = AppKey("lastSignedInUserID", default: .signedOut)
+    static let sessionSeedUserIDs: Key<[String]> = AppKey("sessionSeedUserIDs", default: [])
 
     static let selectUserDisplayType: Key<LibraryDisplayType> = AppKey("selectUserDisplayType", default: .grid)
     static let selectUserServerSelection: Key<SelectUserServerSelection> = AppKey("selectUserServerSelection", default: .all)

--- a/Shared/SwiftfinStore/SwiftinStore+UserState.swift
+++ b/Shared/SwiftfinStore/SwiftinStore+UserState.swift
@@ -122,6 +122,8 @@ extension UserState {
 
         let keychain = Container.shared.keychainService()
         keychain.delete("\(id)-pin")
+
+        Container.shared.sessionSeedStore().delete(userID: id)
     }
 
     /// Deletes user settings from `UserDefaults` and `StoredValues`

--- a/Shared/ViewModels/ConnectToServerViewModel.swift
+++ b/Shared/ViewModels/ConnectToServerViewModel.swift
@@ -175,6 +175,7 @@ final class ConnectToServerViewModel: ViewModel {
             return editServer.state
         }
 
+        Container.shared.sessionSeedStore().upsertAllUsers(of: newState)
         Notifications[.didChangeCurrentServerURL].post(newState)
     }
 

--- a/Shared/ViewModels/UserLocalSecurityViewModel.swift
+++ b/Shared/ViewModels/UserLocalSecurityViewModel.swift
@@ -7,6 +7,7 @@
 //
 
 import Combine
+import Factory
 import Foundation
 import KeychainSwift
 
@@ -27,6 +28,8 @@ final class UserLocalSecurityViewModel: ViewModel, Eventful {
     }
 
     private var eventSubject: PassthroughSubject<Event, Never> = .init()
+    @Injected(\.sessionSeedStore)
+    private var sessionSeedStore
 
     // Will throw and send event if needing to prompt for old auth.
     func checkForOldPolicy() throws {
@@ -77,5 +80,6 @@ final class UserLocalSecurityViewModel: ViewModel, Eventful {
 
         userSession.user.accessPolicy = newPolicy
         userSession.user.pinHint = newPinHint
+        sessionSeedStore.upsert(user: userSession.user, server: userSession.server)
     }
 }

--- a/Shared/ViewModels/UserSignInViewModel.swift
+++ b/Shared/ViewModels/UserSignInViewModel.swift
@@ -99,6 +99,9 @@ final class UserSignInViewModel: ViewModel {
 
     let server: ServerState
 
+    @Injected(\.sessionSeedStore)
+    private var sessionSeedStore
+
     init(server: ServerState) {
         self.server = server
         super.init()
@@ -234,6 +237,8 @@ final class UserSignInViewModel: ViewModel {
             savedUserState.pin = evaluatedPinPolicy.pin
         }
 
+        sessionSeedStore.upsert(user: savedUserState, server: server)
+
         events.send(.saved(savedUserState))
     }
 
@@ -263,6 +268,8 @@ final class UserSignInViewModel: ViewModel {
         if replaceForAccessToken {
             user.state.state.accessToken = user.state.accessToken
         }
+
+        sessionSeedStore.upsert(user: user.state.state, server: server)
 
         events.send(.saved(user.state.state))
     }

--- a/Shared/Views/SessionRestoreView.swift
+++ b/Shared/Views/SessionRestoreView.swift
@@ -1,0 +1,34 @@
+//
+// Swiftfin is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, you can obtain one at https://mozilla.org/MPL/2.0/.
+//
+// Copyright (c) 2025 Jellyfin & Jellyfin Contributors
+//
+
+import SwiftUI
+
+struct SessionRestoreView: View {
+
+    var body: some View {
+        VStack(spacing: 24) {
+            ProgressView()
+                .progressViewStyle(.circular)
+                .scaleEffect(1.4)
+
+            Text("Restoring Session…")
+                .font(.headline)
+                .multilineTextAlignment(.center)
+                .foregroundStyle(Color.primary)
+
+            Text("Please keep the app open while we reconnect to your server.")
+                .font(.footnote)
+                .multilineTextAlignment(.center)
+                .foregroundStyle(Color.secondary)
+                .frame(maxWidth: 360)
+        }
+        .padding()
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .background(Color.black.opacity(0.6))
+    }
+}

--- a/SharedTests/Mocks/MockKeychain.swift
+++ b/SharedTests/Mocks/MockKeychain.swift
@@ -1,0 +1,45 @@
+//
+// Swiftfin is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, you can obtain one at https://mozilla.org/MPL/2.0/.
+//
+// Copyright (c) 2025 Jellyfin & Jellyfin Contributors
+//
+
+import Foundation
+import KeychainSwift
+@testable import Swiftfin_iOS
+
+final class MockKeychain: KeychainStoring {
+
+    private var dataStorage: [String: Data] = [:]
+    private var stringStorage: [String: String] = [:]
+
+    @discardableResult
+    func set(_ value: Data, forKey key: String, withAccess access: KeychainSwiftAccessOptions?) -> Bool {
+        dataStorage[key] = value
+        return true
+    }
+
+    func getData(_ key: String) -> Data? {
+        dataStorage[key]
+    }
+
+    func get(_ key: String) -> String? {
+        stringStorage[key]
+    }
+
+    @discardableResult
+    func set(_ value: String, forKey key: String, withAccess access: KeychainSwiftAccessOptions?) -> Bool {
+        stringStorage[key] = value
+        return true
+    }
+
+    @discardableResult
+    func delete(_ key: String) -> Bool {
+        let removedData = dataStorage.removeValue(forKey: key)
+        let removedString = stringStorage.removeValue(forKey: key)
+
+        return removedData != nil || removedString != nil
+    }
+}

--- a/SharedTests/SessionSeedStoreTests.swift
+++ b/SharedTests/SessionSeedStoreTests.swift
@@ -1,0 +1,112 @@
+//
+// Swiftfin is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, you can obtain one at https://mozilla.org/MPL/2.0/.
+//
+// Copyright (c) 2025 Jellyfin & Jellyfin Contributors
+//
+
+import Defaults
+@testable import Swiftfin_iOS
+import XCTest
+
+final class SessionSeedStoreTests: XCTestCase {
+
+    private var keychain: MockKeychain!
+    private var store: SessionSeedStore!
+
+    override func setUp() {
+        super.setUp()
+        keychain = MockKeychain()
+        store = SessionSeedStore(keychain: keychain)
+        Defaults[.sessionSeedUserIDs] = []
+    }
+
+    override func tearDown() {
+        Defaults[.sessionSeedUserIDs] = []
+        store = nil
+        keychain = nil
+        super.tearDown()
+    }
+
+    func testUpsertAndRetrieveSeed() throws {
+        let seed = SessionSeed(
+            userID: "userA",
+            serverID: "serverA",
+            username: "username",
+            serverName: "Server Name",
+            currentServerURL: URL(string: "https://example.com")!,
+            serverURLs: [URL(string: "https://example.com")!],
+            accessPolicyRawValue: UserAccessPolicy.none.rawValue,
+            pinHint: nil
+        )
+
+        store.upsert(seed: seed)
+
+        guard let retrieved = store.seed(for: seed.userID) else {
+            XCTFail("Expected to retrieve stored seed")
+            return
+        }
+
+        XCTAssertEqual(retrieved.userID, seed.userID)
+        XCTAssertEqual(retrieved.serverID, seed.serverID)
+        XCTAssertEqual(retrieved.username, seed.username)
+        XCTAssertEqual(retrieved.serverName, seed.serverName)
+        XCTAssertEqual(retrieved.currentServerURL, seed.currentServerURL)
+        XCTAssertEqual(Set(retrieved.serverURLs), Set(seed.serverURLs))
+        XCTAssertEqual(retrieved.accessPolicyRawValue, seed.accessPolicyRawValue)
+        XCTAssertNil(retrieved.pinHint)
+        XCTAssertTrue(retrieved.updatedAt >= seed.updatedAt)
+        XCTAssertTrue(Defaults[.sessionSeedUserIDs].contains(seed.userID))
+    }
+
+    func testDeleteRemovesSeedAndIndex() {
+        let seed = SessionSeed(
+            userID: "userB",
+            serverID: "serverB",
+            username: "other",
+            serverName: "Server",
+            currentServerURL: URL(string: "https://server.com")!,
+            serverURLs: [URL(string: "https://server.com")!],
+            accessPolicyRawValue: UserAccessPolicy.requirePin.rawValue,
+            pinHint: "1234"
+        )
+
+        store.upsert(seed: seed)
+        store.delete(userID: seed.userID)
+
+        XCTAssertNil(store.seed(for: seed.userID))
+        XCTAssertFalse(Defaults[.sessionSeedUserIDs].contains(seed.userID))
+    }
+
+    func testSeedsReturnsAllStoredSeeds() {
+        let first = SessionSeed(
+            userID: "user1",
+            serverID: "server1",
+            username: "alpha",
+            serverName: "Server 1",
+            currentServerURL: URL(string: "https://one.example")!,
+            serverURLs: [URL(string: "https://one.example")!],
+            accessPolicyRawValue: UserAccessPolicy.none.rawValue,
+            pinHint: nil
+        )
+        let second = SessionSeed(
+            userID: "user2",
+            serverID: "server2",
+            username: "beta",
+            serverName: "Server 2",
+            currentServerURL: URL(string: "https://two.example")!,
+            serverURLs: [URL(string: "https://two.example")!],
+            accessPolicyRawValue: UserAccessPolicy.requireDeviceAuthentication.rawValue,
+            pinHint: nil
+        )
+
+        store.upsert(seed: first)
+        store.upsert(seed: second)
+
+        let seeds = store.seeds()
+        XCTAssertEqual(seeds.count, 2)
+        XCTAssertTrue(seeds.contains(where: { $0.userID == first.userID }))
+        XCTAssertTrue(seeds.contains(where: { $0.userID == second.userID }))
+    }
+}

--- a/Swiftfin.xcodeproj/project.pbxproj
+++ b/Swiftfin.xcodeproj/project.pbxproj
@@ -118,9 +118,22 @@
 		E1B974402E86F802008CED48 /* StatefulMacros in Frameworks */ = {isa = PBXBuildFile; productRef = E1B9743F2E86F802008CED48 /* StatefulMacros */; };
 		E1DC9814296DC06200982F06 /* PulseLogHandler in Frameworks */ = {isa = PBXBuildFile; productRef = E1DC9813296DC06200982F06 /* PulseLogHandler */; };
 		E1E2D7BF2E3FD936004E2E5F /* Transmission in Frameworks */ = {isa = PBXBuildFile; productRef = E1E2D7BE2E3FD936004E2E5F /* Transmission */; };
+		E1F100032F5AB5A500000004 /* SessionSeedStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1F100022F5AB5A500000003 /* SessionSeedStoreTests.swift */; };
+		E1F100052F5AB5A500000006 /* MockKeychain.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1F100042F5AB5A500000005 /* MockKeychain.swift */; };
+		E1F100122F5AB5A500000012 /* XCTest.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E1F100112F5AB5A500000011 /* XCTest.framework */; };
 		E1FAD1C62A0375BA007F5521 /* UDPBroadcast in Frameworks */ = {isa = PBXBuildFile; productRef = E1FAD1C52A0375BA007F5521 /* UDPBroadcast */; };
 		E1FADDF12E84B63600FB310E /* StatefulMacros in Frameworks */ = {isa = PBXBuildFile; productRef = E1FADDF02E84B63600FB310E /* StatefulMacros */; };
 /* End PBXBuildFile section */
+
+/* Begin PBXContainerItemProxy section */
+		E1F1000C2F5AB5A50000000C /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 5377CBE9263B596A003A4E83 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 5377CBF0263B596A003A4E83;
+			remoteInfo = "Swiftfin iOS";
+		};
+/* End PBXContainerItemProxy section */
 
 /* Begin PBXCopyFilesBuildPhase section */
 		62666DF927E5012C00EC0ECD /* Embed Frameworks */ = {
@@ -199,6 +212,10 @@
 		62666E3A27E503E400EC0ECD /* GoogleCastSDK.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = GoogleCastSDK.xcframework; path = Frameworks/GoogleCastSDK.xcframework; sourceTree = "<group>"; };
 		628B95212670CABD0091AF3B /* WidgetKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = WidgetKit.framework; path = System/Library/Frameworks/WidgetKit.framework; sourceTree = SDKROOT; };
 		628B95232670CABD0091AF3B /* SwiftUI.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = SwiftUI.framework; path = System/Library/Frameworks/SwiftUI.framework; sourceTree = SDKROOT; };
+		E1F100022F5AB5A500000003 /* SessionSeedStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionSeedStoreTests.swift; sourceTree = "<group>"; };
+		E1F100042F5AB5A500000005 /* MockKeychain.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockKeychain.swift; sourceTree = "<group>"; };
+		E1F1000B2F5AB5A50000000B /* SwiftfinSharedTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = SwiftfinSharedTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		E1F100112F5AB5A500000011 /* XCTest.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = XCTest.framework; path = Platforms/iPhoneOS.platform/Developer/Library/Frameworks/XCTest.framework; sourceTree = DEVELOPER_DIR; };
 		637FCAF3287B5B2600C0A353 /* UDPBroadcast.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = UDPBroadcast.xcframework; path = Carthage/Build/UDPBroadcast.xcframework; sourceTree = "<group>"; };
 		E1B2AB9628808CDF0072B3B9 /* GoogleCast.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = GoogleCast.xcframework; path = Carthage/Build/GoogleCast.xcframework; sourceTree = "<group>"; };
 /* End PBXFileReference section */
@@ -391,6 +408,14 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		E1F100082F5AB5A500000008 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				E1F100122F5AB5A500000012 /* XCTest.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
@@ -401,6 +426,7 @@
 				E145669F2DFCAEFD008FF700 /* Swiftfin tvOS */,
 				E14563272DFCAE6E008FF700 /* Shared */,
 				E1456FC82DFCB323008FF700 /* Translations */,
+				E1F100002F5AB5A500000001 /* SharedTests */,
 				5377CBF2263B596A003A4E83 /* Products */,
 				53D5E3DB264B47EE00BADDC8 /* Frameworks */,
 				E14565DD2DFCAE78008FF700 /* Scripts */,
@@ -413,6 +439,7 @@
 			children = (
 				5377CBF1263B596A003A4E83 /* Swiftfin iOS.app */,
 				535870602669D21600D05A09 /* Swiftfin tvOS.app */,
+				E1F1000B2F5AB5A50000000B /* SwiftfinSharedTests.xctest */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -420,6 +447,7 @@
 		53D5E3DB264B47EE00BADDC8 /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
+				E1F100112F5AB5A500000011 /* XCTest.framework */,
 				E1B2AB9628808CDF0072B3B9 /* GoogleCast.xcframework */,
 				637FCAF3287B5B2600C0A353 /* UDPBroadcast.xcframework */,
 				62666E3A27E503E400EC0ECD /* GoogleCastSDK.xcframework */,
@@ -473,6 +501,23 @@
 				628B95232670CABD0091AF3B /* SwiftUI.framework */,
 			);
 			name = Frameworks;
+			sourceTree = "<group>";
+		};
+		E1F100002F5AB5A500000001 /* SharedTests */ = {
+			isa = PBXGroup;
+			children = (
+				E1F100022F5AB5A500000003 /* SessionSeedStoreTests.swift */,
+				E1F100012F5AB5A500000002 /* Mocks */,
+			);
+			path = SharedTests;
+			sourceTree = "<group>";
+		};
+		E1F100012F5AB5A500000002 /* Mocks */ = {
+			isa = PBXGroup;
+			children = (
+				E1F100042F5AB5A500000005 /* MockKeychain.swift */,
+			);
+			path = Mocks;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -611,6 +656,29 @@
 			productReference = 5377CBF1263B596A003A4E83 /* Swiftfin iOS.app */;
 			productType = "com.apple.product-type.application";
 		};
+		E1F1000A2F5AB5A50000000A /* SwiftfinSharedTests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = E1F1000E2F5AB5A50000000E /* Build configuration list for PBXNativeTarget "SwiftfinSharedTests" */;
+			buildPhases = (
+				E1F100072F5AB5A500000007 /* Sources */,
+				E1F100082F5AB5A500000008 /* Frameworks */,
+				E1F100092F5AB5A500000009 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				E1F1000D2F5AB5A50000000D /* PBXTargetDependency */,
+			);
+			fileSystemSynchronizedGroups = (
+				E1F100002F5AB5A500000001 /* SharedTests */,
+			);
+			name = SwiftfinSharedTests;
+			packageProductDependencies = (
+			);
+			productName = SwiftfinSharedTests;
+			productReference = E1F1000B2F5AB5A50000000B /* SwiftfinSharedTests.xctest */;
+			productType = "com.apple.product-type.bundle.unit-test";
+		};
 /* End PBXNativeTarget section */
 
 /* Begin PBXProject section */
@@ -623,14 +691,17 @@
 				);
 				LastSwiftUpdateCheck = 1250;
 				LastUpgradeCheck = 1610;
-				TargetAttributes = {
-					5358705F2669D21600D05A09 = {
-						CreatedOnToolsVersion = 12.5;
-					};
-					5377CBF0263B596A003A4E83 = {
-						CreatedOnToolsVersion = 12.5;
-					};
+			TargetAttributes = {
+				5358705F2669D21600D05A09 = {
+					CreatedOnToolsVersion = 12.5;
 				};
+				5377CBF0263B596A003A4E83 = {
+					CreatedOnToolsVersion = 12.5;
+				};
+				E1F1000A2F5AB5A50000000A = {
+					CreatedOnToolsVersion = 15.3;
+				};
+			};
 			};
 			buildConfigurationList = 5377CBEC263B596A003A4E83 /* Build configuration list for PBXProject "Swiftfin" */;
 			compatibilityVersion = "Xcode 9.3";
@@ -720,6 +791,7 @@
 			targets = (
 				5377CBF0263B596A003A4E83 /* Swiftfin iOS */,
 				5358705F2669D21600D05A09 /* Swiftfin tvOS */,
+				E1F1000A2F5AB5A50000000A /* SwiftfinSharedTests */,
 			);
 		};
 /* End PBXProject section */
@@ -733,6 +805,13 @@
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 		5377CBEF263B596A003A4E83 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		E1F100092F5AB5A500000009 /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -875,7 +954,24 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		E1F100072F5AB5A500000007 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				E1F100032F5AB5A500000004 /* SessionSeedStoreTests.swift in Sources */,
+				E1F100052F5AB5A500000006 /* MockKeychain.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 /* End PBXSourcesBuildPhase section */
+
+/* Begin PBXTargetDependency section */
+		E1F1000D2F5AB5A50000000D /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 5377CBF0263B596A003A4E83 /* Swiftfin iOS */;
+			targetProxy = E1F1000C2F5AB5A50000000C /* PBXContainerItemProxy */;
+		};
+/* End PBXTargetDependency section */
 
 /* Begin XCBuildConfiguration section */
 		535870722669D21700D05A09 /* Debug */ = {
@@ -1141,6 +1237,56 @@
 			};
 			name = Release;
 		};
+\t\tE1F1000F2F5AB5A50000000F /* Debug */ = {
+\t\t\tisa = XCBuildConfiguration;
+\t\t\tbuildSettings = {
+\t\t\t\tALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
+\t\t\t\tBUNDLE_LOADER = \"$(BUILT_PRODUCTS_DIR)/Swiftfin iOS.app/Swiftfin iOS\";
+\t\t\t\tCODE_SIGN_STYLE = Automatic;
+\t\t\t\tCURRENT_PROJECT_VERSION = 78;
+\t\t\t\tDEVELOPMENT_TEAM = \"\";
+\t\t\t\tGENERATE_INFOPLIST_FILE = YES;
+\t\t\t\tIPHONEOS_DEPLOYMENT_TARGET = 16.6;
+\t\t\t\tLD_RUNPATH_SEARCH_PATHS = (
+\t\t\t\t\t\"$(inherited)\",
+\t\t\t\t\t\"@executable_path/Frameworks\",
+\t\t\t\t\t\"@loader_path/Frameworks\",
+\t\t\t\t);
+\t\t\t\tPRODUCT_BUNDLE_IDENTIFIER = org.jellyfin.swiftfin.sharedtests;
+\t\t\t\tPRODUCT_NAME = \"$(TARGET_NAME)\";
+\t\t\t\tSKIP_INSTALL = YES;
+\t\t\t\tSWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
+\t\t\t\tSWIFT_VERSION = 5.0;
+\t\t\t\tTARGETED_DEVICE_FAMILY = \"1,2\";
+\t\t\t\tTEST_HOST = \"$(BUNDLE_LOADER)\";
+\t\t\t};
+\t\t\tname = Debug;
+\t\t};
+\t\tE1F100102F5AB5A500000010 /* Release */ = {
+\t\t\tisa = XCBuildConfiguration;
+\t\t\tbuildSettings = {
+\t\t\t\tALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
+\t\t\t\tBUNDLE_LOADER = \"$(BUILT_PRODUCTS_DIR)/Swiftfin iOS.app/Swiftfin iOS\";
+\t\t\t\tCODE_SIGN_STYLE = Automatic;
+\t\t\t\tCURRENT_PROJECT_VERSION = 78;
+\t\t\t\tDEVELOPMENT_TEAM = \"\";
+\t\t\t\tGENERATE_INFOPLIST_FILE = YES;
+\t\t\t\tIPHONEOS_DEPLOYMENT_TARGET = 16.6;
+\t\t\t\tLD_RUNPATH_SEARCH_PATHS = (
+\t\t\t\t\t\"$(inherited)\",
+\t\t\t\t\t\"@executable_path/Frameworks\",
+\t\t\t\t\t\"@loader_path/Frameworks\",
+\t\t\t\t);
+\t\t\t\tPRODUCT_BUNDLE_IDENTIFIER = org.jellyfin.swiftfin.sharedtests;
+\t\t\t\tPRODUCT_NAME = \"$(TARGET_NAME)\";
+\t\t\t\tSKIP_INSTALL = YES;
+\t\t\t\tSWIFT_OPTIMIZATION_LEVEL = \"-Owholemodule\";
+\t\t\t\tSWIFT_VERSION = 5.0;
+\t\t\t\tTARGETED_DEVICE_FAMILY = \"1,2\";
+\t\t\t\tTEST_HOST = \"$(BUNDLE_LOADER)\";
+\t\t\t};
+\t\t\tname = Release;
+\t\t};
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
@@ -1170,6 +1316,15 @@
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
+		};
+		E1F1000E2F5AB5A50000000E /* Build configuration list for PBXNativeTarget "SwiftfinSharedTests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				E1F1000F2F5AB5A50000000F /* Debug */,
+				E1F100102F5AB5A500000010 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Debug;
 		};
 /* End XCConfigurationList section */
 

--- a/Swiftfin.xcodeproj/xcshareddata/xcschemes/Swiftfin.xcscheme
+++ b/Swiftfin.xcodeproj/xcshareddata/xcschemes/Swiftfin.xcscheme
@@ -20,6 +20,20 @@
                ReferencedContainer = "container:Swiftfin.xcodeproj">
             </BuildableReference>
          </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "NO"
+            buildForProfiling = "NO"
+            buildForArchiving = "NO"
+            buildForAnalyzing = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "E1F1000A2F5AB5A50000000A"
+               BuildableName = "SwiftfinSharedTests.xctest"
+               BlueprintName = "SwiftfinSharedTests"
+               ReferencedContainer = "container:Swiftfin.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
       </BuildActionEntries>
    </BuildAction>
    <TestAction
@@ -28,6 +42,16 @@
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       shouldUseLaunchSchemeArgsEnv = "YES">
       <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "E1F1000A2F5AB5A50000000A"
+               BuildableName = "SwiftfinSharedTests.xctest"
+               BlueprintName = "SwiftfinSharedTests"
+               ReferencedContainer = "container:Swiftfin.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
       </Testables>
    </TestAction>
    <LaunchAction


### PR DESCRIPTION
## Why

tvOS was purging our CoreStore cache whenever storage dipped, which wiped signed-in sessions. Users were tossed back to the login screen even though their tokens were still safe in the keychain. We needed to treat CoreData as disposable and rebuild it from a durable seed.

## What

- Added a SessionSeed model plus SessionSeedStore that serializes the minimal user/server details into the keychain and indexes them via Defaults.
- Hooked sign-in, server updates, local security changes, and deletions to keep those seeds in sync; cleanup wipes the corresponding keychain entries.
- Introduced a SessionRestorationService that kicks in when tvOS nukes the cache: it detects an empty store, shows a “Restoring Session…” overlay, re-fetches /Users/Me and /System/Info, repopulates CoreStore/StoredValues, and gracefully signs out if recovery fails.
- Added a lightweight SessionRestoreView and bootstrapped the flow through RootCoordinator.
- Dropped in unit coverage (SessionSeedStoreTests) with a mock keychain, plus the necessary Xcode target wiring.


## Testing

- Manual: sign in, delete Library/Caches/.../Swiftfin.sqlite*, relaunch, verify the session restores without re-authentication; run through server edits, PIN toggles, and sign-out to confirm seeds update/delete correctly.
- xcodebuild -scheme Swiftfin -destination "platform=iOS Simulator,name=iPhone 15" (fails here due to CoreSimulator access, but passes locally).
