### PR TITLE
Fix flickering issue when switching seasons on tvOS

### DIFF
--- a/Swiftfin tvOS/Views/ItemView/Components/EpisodeSelector/Components/HStacks/EpisodeHStack.swift
+++ b/Swiftfin tvOS/Views/ItemView/Components/EpisodeSelector/Components/HStacks/EpisodeHStack.swift
@@ -95,18 +95,22 @@ extension SeriesEpisodeSelector {
 
         var body: some View {
             ZStack {
-                switch viewModel.state {
-                case .content:
-                    if viewModel.elements.isEmpty {
-                        EmptyHStack(focusedEpisodeID: $focusedEpisodeID)
-                    } else {
-                        contentView(viewModel: viewModel)
+                PlaceholderHStack()
+
+                Group {
+                    switch viewModel.state {
+                    case .content:
+                        if viewModel.elements.isEmpty {
+                            EmptyHStack(focusedEpisodeID: $focusedEpisodeID)
+                        } else {
+                            contentView(viewModel: viewModel)
+                        }
+                    case let .error(error):
+                        ErrorHStack(viewModel: viewModel, error: error, focusedEpisodeID: $focusedEpisodeID)
+                    case .initial, .refreshing:
+                        LoadingHStack(focusedEpisodeID: $focusedEpisodeID)
                     }
-                case let .error(error):
-                    ErrorHStack(viewModel: viewModel, error: error, focusedEpisodeID: $focusedEpisodeID)
-                case .initial, .refreshing:
-                    LoadingHStack(focusedEpisodeID: $focusedEpisodeID)
-                }
+                }.transition(.opacity.animation(.linear(duration: 0.1)))
             }
             .padding(.bottom, 45)
             .focusSection()
@@ -199,6 +203,26 @@ extension SeriesEpisodeSelector {
             }
             .insets(horizontal: EdgeInsets.edgePadding)
             .itemSpacing(EdgeInsets.edgePadding / 2)
+            .scrollDisabled(true)
+        }
+    }
+
+    // MARK: - Placeholder HStack
+
+    struct PlaceholderHStack: View {
+
+        var body: some View {
+            CollectionHStack(
+                count: 1,
+                columns: 3.5
+            ) { _ in
+                SeriesEpisodeSelector.EmptyCard()
+                    .padding(.horizontal, 4)
+            }
+            .insets(horizontal: EdgeInsets.edgePadding)
+            .itemSpacing(EdgeInsets.edgePadding / 2)
+            .opacity(0)
+            .allowsHitTesting(false)
             .scrollDisabled(true)
         }
     }


### PR DESCRIPTION
### Summary

Removes flickering issue for season switching in the `SeriesEpisodeSelector` by adding `PlaceholderHStack`, which maintains the height, and adding a transition to smooth over the change in the `EpisodeCard` stack.

### PlaceholderHStack

I added a new HStack in the `SeriesEpsideSelector` which the utilizes the pre-existing `EmptyCard` with the opacity set to zero and the interactions disabled. This ensures that the height of the `SeriesEpisodeSelector` will always remain constant, which removes the flickering. A new element could have created instead of using the `EmptyCard`, but that's just a lot of repeated code for minimal performance gains and it makes future changes in UI/UX harder to implement.

### Transition

Tried it, looked better.