### PR TITLE
Add video player router functionality to EpisodeCard for tvOS

### DIFF
--- a/Swiftfin tvOS/Views/ItemView/Components/EpisodeSelector/Components/EpisodeCard.swift
+++ b/Swiftfin tvOS/Views/ItemView/Components/EpisodeSelector/Components/EpisodeCard.swift
@@ -62,8 +62,12 @@ extension SeriesEpisodeSelector {
         var body: some View {
             VStack(alignment: .leading) {
                 Button {
-                    guard let mediaSource = episode.mediaSources?.first else { return }
-//                    router.route(to: .videoPlayer(manager: OnlineVideoPlayerManager(item: episode, mediaSource: mediaSource)))
+                    router.route(
+                        to: .videoPlayer(
+                            item: episode,
+                            queue: EpisodeMediaPlayerQueue(episode: episode)
+                        )
+                    )
                 } label: {
                     ZStack {
                         Color.clear


### PR DESCRIPTION
I noticed that the `EpisodeCard` for tvOS didn't properly route to the `VideoPlayer`, so I implemented the router in the same way as in mobile version. It seems to be working correctly. 