### PR TITLE
[WIP] tvOS: YouTube Support (TubeArchivist)

### DIFF
--- a/Shared/Coordinators/Navigation/NavigationRoute/NavigationRoute+Media.swift
+++ b/Shared/Coordinators/Navigation/NavigationRoute/NavigationRoute+Media.swift
@@ -21,6 +21,15 @@ extension NavigationRoute {
         ChannelLibraryView()
     }
 
+    static func youtubeLibrary(viewModel: YouTubeLibraryViewModel) -> NavigationRoute {
+        NavigationRoute(
+            id: "youtube-library-(\(viewModel.parent?.id ?? "Unparented"))",
+            withNamespace: { .push(.zoom(sourceID: "item", namespace: $0)) }
+        ) {
+            YouTubeLibraryView(viewModel: viewModel)
+        }
+    }
+
     static let liveTV = NavigationRoute(
         id: "liveTV"
     ) {

--- a/Shared/Coordinators/Navigation/NavigationRoute/NavigationRoute+Settings.swift
+++ b/Shared/Coordinators/Navigation/NavigationRoute/NavigationRoute+Settings.swift
@@ -54,6 +54,12 @@ extension NavigationRoute {
         CustomizeViewsSettings()
     }
 
+    static let youtubeLibrariesSettings = NavigationRoute(
+        id: "youtubeLibrariesSettings"
+    ) {
+        YouTubeLibrariesSettingsView()
+    }
+
     #if DEBUG && !os(tvOS)
     static let debugSettings = NavigationRoute(
         id: "debugSettings"

--- a/Shared/Extensions/JellyfinAPI/BaseItemDto/BaseItemDto+Poster.swift
+++ b/Shared/Extensions/JellyfinAPI/BaseItemDto/BaseItemDto+Poster.swift
@@ -89,19 +89,33 @@ extension BaseItemDto: Poster {
     func landscapeImageSources(maxWidth: CGFloat? = nil, quality: Int? = nil) -> [ImageSource] {
         switch type {
         case .episode:
+            var sources: [ImageSource] = [
+                // TubeArchivist episodes carry the YouTube thumbnail in the thumb slot.
+                imageSource(.thumb, maxWidth: maxWidth, quality: quality),
+                imageSource(.primary, maxWidth: maxWidth, quality: quality),
+            ]
+
             if Defaults[.Customization.Episodes.useSeriesLandscapeBackdrop] {
-                [
+                sources.append(contentsOf: [
                     seriesImageSource(.thumb, maxWidth: maxWidth, quality: quality),
                     seriesImageSource(.backdrop, maxWidth: maxWidth, quality: quality),
-                    imageSource(.primary, maxWidth: maxWidth, quality: quality),
-                ]
-            } else {
-                [imageSource(.primary, maxWidth: maxWidth, quality: quality)]
+                ])
             }
+
+            // If episode images are missing, fall back to channel art/backdrop so cards are never blank.
+            sources.append(contentsOf: [
+                seriesImageSource(.primary, maxWidth: maxWidth, quality: quality),
+                seriesImageSource(.backdrop, maxWidth: maxWidth, quality: quality),
+            ])
+
+            return sources
         case .folder, .program, .musicVideo, .video:
-            [imageSource(.primary, maxWidth: maxWidth, quality: quality)]
+            return [
+                imageSource(.thumb, maxWidth: maxWidth, quality: quality),
+                imageSource(.primary, maxWidth: maxWidth, quality: quality),
+            ]
         default:
-            [
+            return [
                 imageSource(.thumb, maxWidth: maxWidth, quality: quality),
                 imageSource(.backdrop, maxWidth: maxWidth, quality: quality),
             ]

--- a/Shared/Services/SwiftfinDefaults.swift
+++ b/Shared/Services/SwiftfinDefaults.swift
@@ -158,6 +158,7 @@ extension Defaults.Keys {
 
             static let rememberLayout: Key<Bool> = UserKey("libraryRememberLayout", default: false)
             static let rememberSort: Key<Bool> = UserKey("libraryRememberSort", default: false)
+            static let youtubeLibraryIDs: Key<Set<String>> = UserKey("youtubeLibraryIDs", default: [])
         }
 
         enum Home {

--- a/Shared/Services/TubeArchivistLibraryDetector.swift
+++ b/Shared/Services/TubeArchivistLibraryDetector.swift
@@ -1,0 +1,102 @@
+//
+// Swiftfin is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, you can obtain one at https://mozilla.org/MPL/2.0/.
+//
+// Copyright (c) 2025 Jellyfin & Jellyfin Contributors
+//
+
+import Foundation
+import Get
+import JellyfinAPI
+
+struct TubeArchivistLibrary: Identifiable, Hashable {
+    let id: String
+    let name: String
+    let collectionType: CollectionType?
+}
+
+enum TubeArchivistLibraryDetector {
+
+    static func fetchLibraries(for userSession: UserSession) async throws -> [TubeArchivistLibrary] {
+        guard let url = userSession.client.fullURL(with: "/Library/VirtualFolders") else {
+            throw DetectorError.invalidURL
+        }
+
+        let request = Request<[VirtualFolder]>(url: url)
+        let response = try await userSession.client.send(request)
+
+        return response.value
+            .filter { isTubeArchivist(folder: $0) }
+            .compactMap { folder in
+                guard let id = folder.itemId else { return nil }
+                return TubeArchivistLibrary(
+                    id: id,
+                    name: folder.name,
+                    collectionType: folder.collectionType
+                )
+            }
+    }
+
+    static func isTubeArchivist(folder: VirtualFolder) -> Bool {
+        guard folder.collectionType == .tvshows else { return false }
+        guard let typeOptions = folder.libraryOptions?.typeOptions else { return false }
+
+        return typeOptions.contains { option in
+            guard option.type.lowercased() == "series" else { return false }
+
+            let fetchers = option.metadataFetchers + option.imageFetchers
+            return fetchers.contains {
+                let value = $0.lowercased()
+                return value.contains("tubearchivist")
+            }
+        }
+    }
+}
+
+// MARK: - Support types
+
+struct VirtualFolder: Decodable {
+    let name: String
+    let collectionType: CollectionType?
+    let libraryOptions: LibraryOptions?
+    let itemId: String?
+
+    enum CodingKeys: String, CodingKey {
+        case name = "Name"
+        case collectionType = "CollectionType"
+        case libraryOptions = "LibraryOptions"
+        case itemId = "ItemId"
+    }
+}
+
+struct LibraryOptions: Decodable {
+    let typeOptions: [TypeOption]?
+
+    enum CodingKeys: String, CodingKey {
+        case typeOptions = "TypeOptions"
+    }
+}
+
+struct TypeOption: Decodable {
+    let type: String
+    let metadataFetchers: [String]
+    let imageFetchers: [String]
+
+    enum CodingKeys: String, CodingKey {
+        case type = "Type"
+        case metadataFetchers = "MetadataFetchers"
+        case imageFetchers = "ImageFetchers"
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        self.type = try container.decodeIfPresent(String.self, forKey: .type) ?? ""
+        self.metadataFetchers = try container.decodeIfPresent([String].self, forKey: .metadataFetchers) ?? []
+        self.imageFetchers = try container.decodeIfPresent([String].self, forKey: .imageFetchers) ?? []
+    }
+}
+
+enum DetectorError: Error {
+    case invalidURL
+}

--- a/Shared/Strings/Strings.swift
+++ b/Shared/Strings/Strings.swift
@@ -92,6 +92,8 @@ internal enum L10n {
   internal static let all = L10n.tr("Localizable", "all", fallback: "All")
   /// All audiences
   internal static let allAudiences = L10n.tr("Localizable", "allAudiences", fallback: "All audiences")
+  /// All Channels
+  internal static let allChannels = L10n.tr("Localizable", "allChannels", fallback: "All Channels")
   /// View all past and present devices that have connected.
   internal static let allDevicesDescription = L10n.tr("Localizable", "allDevicesDescription", fallback: "View all past and present devices that have connected.")
   /// All languages
@@ -986,6 +988,8 @@ internal enum L10n {
   internal static let nextUpRewatch = L10n.tr("Localizable", "nextUpRewatch", fallback: "Rewatching in Next Up")
   /// No
   internal static let no = L10n.tr("Localizable", "no", fallback: "No")
+  /// No channels found
+  internal static let noChannelsFound = L10n.tr("Localizable", "noChannelsFound", fallback: "No channels found")
   /// No profiles defined. Playback issues may occur.
   internal static let noDeviceProfileWarning = L10n.tr("Localizable", "noDeviceProfileWarning", fallback: "No profiles defined. Playback issues may occur.")
   /// No episodes available
@@ -1012,6 +1016,12 @@ internal enum L10n {
   internal static func notImplementedYetWithType(_ p1: Any) -> String {
     return L10n.tr("Localizable", "notImplementedYetWithType", String(describing: p1), fallback: "Type: %@ not implemented yet :(")
   }
+  /// No videos yet
+  internal static let noVideosYet = L10n.tr("Localizable", "noVideosYet", fallback: "No videos yet")
+  /// No TubeArchivist libraries detected
+  internal static let noYouTubeLibrariesDetected = L10n.tr("Localizable", "noYouTubeLibrariesDetected", fallback: "No TubeArchivist libraries detected")
+  /// Add the TubeArchivist metadata provider to a TV library, then reload.
+  internal static let noYouTubeLibrariesDetectedDescription = L10n.tr("Localizable", "noYouTubeLibrariesDetectedDescription", fallback: "Add the TubeArchivist metadata provider to a TV library, then reload.")
   /// Official rating
   internal static let officialRating = L10n.tr("Localizable", "officialRating", fallback: "Official rating")
   /// Offset
@@ -1694,6 +1704,14 @@ internal enum L10n {
   internal static let yellow = L10n.tr("Localizable", "yellow", fallback: "Yellow")
   /// Yes
   internal static let yes = L10n.tr("Localizable", "yes", fallback: "Yes")
+  /// YouTube
+  internal static let youtube = L10n.tr("Localizable", "youtube", fallback: "YouTube")
+  /// YouTube Libraries
+  internal static let youtubeLibraries = L10n.tr("Localizable", "youtubeLibraries", fallback: "YouTube Libraries")
+  /// Enabled libraries move their channels to the YouTube tab and hide them from Series.
+  internal static let youtubeLibrariesHelper = L10n.tr("Localizable", "youtubeLibrariesHelper", fallback: "Enabled libraries move their channels to the YouTube tab and hide them from Series.")
+  /// YouTube
+  internal static let youtubeTile = L10n.tr("Localizable", "youtubeTile", fallback: "YouTube")
 }
 // swiftlint:enable explicit_type_interface function_parameter_count identifier_name line_length
 // swiftlint:enable nesting type_body_length type_name vertical_whitespace_opening_braces

--- a/Shared/ViewModels/MediaViewModel/MediaType.swift
+++ b/Shared/ViewModels/MediaViewModel/MediaType.swift
@@ -16,6 +16,7 @@ extension MediaViewModel {
         case collectionFolder(BaseItemDto)
         case downloads
         case favorites
+        case youtube(BaseItemDto)
         case liveTV(BaseItemDto)
 
         var displayTitle: String {
@@ -26,6 +27,8 @@ extension MediaViewModel {
                 return L10n.downloads
             case .favorites:
                 return L10n.favorites
+            case .youtube:
+                return L10n.youtube
             case .liveTV:
                 return L10n.liveTV
             }
@@ -39,6 +42,8 @@ extension MediaViewModel {
                 return "downloads"
             case .favorites:
                 return "favorites"
+            case let .youtube(item):
+                return item.id
             case let .liveTV(item):
                 return item.id
             }

--- a/Shared/ViewModels/Settings/YouTubeLibrariesSettingsViewModel.swift
+++ b/Shared/ViewModels/Settings/YouTubeLibrariesSettingsViewModel.swift
@@ -1,0 +1,37 @@
+//
+// Swiftfin is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, you can obtain one at https://mozilla.org/MPL/2.0/.
+//
+// Copyright (c) 2025 Jellyfin & Jellyfin Contributors
+//
+
+import Foundation
+
+@MainActor
+final class YouTubeLibrariesSettingsViewModel: ViewModel {
+
+    enum State: Hashable {
+        case initial
+        case loading
+        case content
+        case error(ErrorMessage)
+    }
+
+    @Published
+    private(set) var libraries: [TubeArchivistLibrary] = []
+
+    @Published
+    var state: State = .initial
+
+    func load() async {
+        state = .loading
+
+        do {
+            libraries = try await TubeArchivistLibraryDetector.fetchLibraries(for: userSession)
+            state = .content
+        } catch {
+            state = .error(.init(error.localizedDescription))
+        }
+    }
+}

--- a/Shared/ViewModels/YouTube/YouTubeLibraryViewModel.swift
+++ b/Shared/ViewModels/YouTube/YouTubeLibraryViewModel.swift
@@ -1,0 +1,79 @@
+//
+// Swiftfin is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, you can obtain one at https://mozilla.org/MPL/2.0/.
+//
+// Copyright (c) 2025 Jellyfin & Jellyfin Contributors
+//
+
+import Foundation
+import JellyfinAPI
+
+final class YouTubeLibraryViewModel: PagingLibraryViewModel<BaseItemDto> {
+
+    @Published
+    private(set) var channels: [BaseItemDto] = []
+
+    @Published
+    var selectedChannelID: String? {
+        didSet {
+            Task { @MainActor in
+                self.send(.refresh)
+            }
+        }
+    }
+
+    private let library: BaseItemDto
+
+    init(library: BaseItemDto) {
+        self.library = library
+        super.init(parent: library, filters: nil)
+
+        Task { [weak self] in
+            await self?.loadChannels()
+        }
+    }
+
+    override func get(page: Int) async throws -> [BaseItemDto] {
+        var parameters = Paths.GetItemsByUserIDParameters()
+
+        parameters.enableUserData = true
+        parameters.fields = .MinimumFields
+        parameters.includeItemTypes = [.episode, .video]
+        parameters.sortBy = [ItemSortBy.premiereDate.rawValue, ItemSortBy.dateCreated.rawValue]
+        parameters.sortOrder = [.descending]
+        parameters.isRecursive = true
+        parameters.parentID = selectedChannelID ?? library.id
+        parameters.limit = pageSize
+        parameters.startIndex = page * pageSize
+
+        let request = Paths.getItemsByUserID(userID: userSession.user.id, parameters: parameters)
+        let response = try await userSession.client.send(request)
+
+        return response.value.items ?? []
+    }
+
+    @MainActor
+    private func loadChannels() async {
+        do {
+            channels = try await fetchChannels()
+        } catch {
+            logger.error("Failed to load channels: \(error.localizedDescription)")
+        }
+    }
+
+    private func fetchChannels() async throws -> [BaseItemDto] {
+        var parameters = Paths.GetItemsByUserIDParameters()
+        parameters.enableUserData = true
+        parameters.fields = .MinimumFields
+        parameters.includeItemTypes = [.series]
+        parameters.sortBy = [ItemSortBy.sortName.rawValue]
+        parameters.sortOrder = [.ascending]
+        parameters.parentID = library.id
+
+        let request = Paths.getItemsByUserID(userID: userSession.user.id, parameters: parameters)
+        let response = try await userSession.client.send(request)
+
+        return response.value.items ?? []
+    }
+}

--- a/Shared/Views/MediaView/Components/MediaItem.swift
+++ b/Shared/Views/MediaView/Components/MediaItem.swift
@@ -47,9 +47,12 @@ extension MediaView {
         }
 
         private var useTitleLabel: Bool {
-            useRandomImage ||
-                mediaType == .downloads ||
-                mediaType == .favorites
+            switch mediaType {
+            case .downloads, .favorites, .youtube:
+                return true
+            default:
+                return useRandomImage
+            }
         }
 
         private func setImageSources() {
@@ -60,6 +63,8 @@ extension MediaView {
                 }
 
                 if case let MediaViewModel.MediaType.collectionFolder(item) = mediaType {
+                    self.imageSources = [item.imageSource(.primary, maxWidth: 500)]
+                } else if case let MediaViewModel.MediaType.youtube(item) = mediaType {
                     self.imageSources = [item.imageSource(.primary, maxWidth: 500)]
                 } else if case let MediaViewModel.MediaType.liveTV(item) = mediaType {
                     self.imageSources = [item.imageSource(.primary, maxWidth: 500)]

--- a/Shared/Views/MediaView/MediaView.swift
+++ b/Shared/Views/MediaView/MediaView.swift
@@ -54,6 +54,9 @@ struct MediaView: View {
                         filters: .favorites
                     )
                     router.route(to: .library(viewModel: viewModel), in: namespace)
+                case let .youtube(item):
+                    let viewModel = YouTubeLibraryViewModel(library: item)
+                    router.route(to: .youtubeLibrary(viewModel: viewModel), in: namespace)
                 case .liveTV:
                     router.route(to: .liveTV)
                 }

--- a/Shared/Views/Settings/YouTubeLibrariesSettingsView.swift
+++ b/Shared/Views/Settings/YouTubeLibrariesSettingsView.swift
@@ -1,0 +1,81 @@
+//
+// Swiftfin is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, you can obtain one at https://mozilla.org/MPL/2.0/.
+//
+// Copyright (c) 2025 Jellyfin & Jellyfin Contributors
+//
+
+import Defaults
+import SwiftUI
+
+struct YouTubeLibrariesSettingsView: View {
+
+    @Default(.Customization.Library.youtubeLibraryIDs)
+    private var youtubeLibraryIDs
+
+    @StateObject
+    private var viewModel = YouTubeLibrariesSettingsViewModel()
+
+    private func binding(for id: String) -> Binding<Bool> {
+        Binding {
+            youtubeLibraryIDs.contains(id)
+        } set: { isOn in
+            if isOn {
+                youtubeLibraryIDs.insert(id)
+            } else {
+                youtubeLibraryIDs.remove(id)
+            }
+        }
+    }
+
+    private var hasDetectedLibraries: Bool {
+        viewModel.libraries.isNotEmpty
+    }
+
+    var body: some View {
+        List {
+            switch viewModel.state {
+            case .initial, .loading:
+                Section {
+                    ProgressView()
+                }
+            case let .error(error):
+                Section {
+                    VStack(alignment: .leading, spacing: 8) {
+                        Text(error.localizedDescription)
+                        Button(L10n.retry) {
+                            Task { await viewModel.load() }
+                        }
+                    }
+                }
+            case .content:
+                if hasDetectedLibraries {
+                    Section {
+                        ForEach(viewModel.libraries, id: \.id) { library in
+                            Toggle(library.name, isOn: binding(for: library.id))
+                                .disabled(!hasDetectedLibraries)
+                        }
+                    } footer: {
+                        Text(L10n.youtubeLibrariesHelper)
+                    }
+                } else {
+                    Section {
+                        Toggle("YouTube (no libraries detected)", isOn: .constant(false))
+                            .disabled(true)
+                        VStack(alignment: .leading, spacing: 8) {
+                            Text(L10n.noYouTubeLibrariesDetected)
+                                .font(.headline)
+                            Text(L10n.noYouTubeLibrariesDetectedDescription)
+                                .foregroundColor(.secondary)
+                        }
+                    }
+                }
+            }
+        }
+        .navigationTitle(L10n.youtubeLibraries)
+        .task {
+            await viewModel.load()
+        }
+    }
+}

--- a/Shared/Views/YouTube/YouTubeLibraryView.swift
+++ b/Shared/Views/YouTube/YouTubeLibraryView.swift
@@ -1,0 +1,237 @@
+//
+// Swiftfin is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, you can obtain one at https://mozilla.org/MPL/2.0/.
+//
+// Copyright (c) 2025 Jellyfin & Jellyfin Contributors
+//
+
+import JellyfinAPI
+import SwiftUI
+import UIKit
+
+enum YouTubeChannelRailLayout {
+    static let expandedWidth: CGFloat = 325
+    static let collapsedWidth: CGFloat = 105
+    static let horizontalPadding: CGFloat = 12
+    static let verticalPadding: CGFloat = 12
+}
+
+struct YouTubeLibraryView: View {
+
+    @StateObject
+    private var viewModel: YouTubeLibraryViewModel
+
+    @Router
+    private var router
+
+    #if os(tvOS)
+    @FocusState
+    private var focusedChannelID: String?
+    #endif
+
+    @State
+    private var isChannelRailExpanded = false
+
+    init(viewModel: YouTubeLibraryViewModel) {
+        _viewModel = StateObject(wrappedValue: viewModel)
+
+        if let id = viewModel.parent?.id {
+            StoredValues[.User.libraryPosterType(parentID: id)] = .landscape
+            StoredValues[.User.libraryDisplayType(parentID: id)] = .grid
+        }
+    }
+
+    private func avatar(for channel: BaseItemDto) -> some View {
+        let imageSource = channel.imageSource(.primary, maxWidth: 90)
+
+        return Group {
+            if let url = imageSource.url {
+                AsyncImage(url: url) { phase in
+                    switch phase {
+                    case let .success(image):
+                        image
+                            .resizable()
+                            .scaledToFill()
+                    default:
+                        Circle()
+                            .fill(Color.secondarySystemFill)
+                            .overlay {
+                                Text(channel.displayTitle.initials)
+                                    .font(.footnote.bold())
+                            }
+                    }
+                }
+            } else {
+                Circle()
+                    .fill(Color.secondarySystemFill)
+                    .overlay {
+                        Text(channel.displayTitle.initials)
+                            .font(.footnote.bold())
+                    }
+            }
+        }
+        .frame(width: 44, height: 44)
+        .clipShape(Circle())
+    }
+
+    private func play(_ item: BaseItemDto) {
+        let provider = MediaPlayerItemProvider(item: item) { item in
+            try await MediaPlayerItem.build(for: item)
+        }
+
+        router.route(to: .videoPlayer(provider: provider))
+    }
+
+    private func channelRow(title: String, isSelected: Bool, isExpanded: Bool, action: @escaping () -> Void) -> some View {
+        Button(action: action) {
+            HStack {
+                Circle()
+                    .fill(Color.secondarySystemFill)
+                    .overlay {
+                        Text(title.initials)
+                            .font(.footnote.bold())
+                    }
+                    .frame(width: 44, height: 44)
+
+                if isExpanded {
+                    Text(title)
+                        .lineLimit(1)
+
+                    Spacer()
+                }
+            }
+            .frame(maxWidth: .infinity, alignment: isExpanded ? .leading : .center)
+            .padding(.vertical, 6)
+        }
+        .buttonStyle(.plain)
+        .background(
+            RoundedRectangle(cornerRadius: 12)
+                .fill(isSelected ? Color.accentColor.opacity(0.15) : Color.clear)
+        )
+    }
+
+    private func channelRow(channel: BaseItemDto) -> some View {
+        let isSelected = viewModel.selectedChannelID == channel.id
+        let channelFocusID = channel.id ?? channel.displayTitle
+
+        return Button {
+            viewModel.selectedChannelID = channel.id
+        } label: {
+            HStack {
+                avatar(for: channel)
+
+                if isChannelRailExpanded {
+                    Text(channel.displayTitle)
+                        .lineLimit(1)
+                    Spacer()
+                }
+            }
+            .frame(maxWidth: .infinity, alignment: isChannelRailExpanded ? .leading : .center)
+            .padding(.vertical, 6)
+        }
+        .buttonStyle(.plain)
+        .background(
+            RoundedRectangle(cornerRadius: 12)
+                .fill(isSelected ? Color.accentColor.opacity(0.15) : Color.clear)
+        )
+        #if os(tvOS)
+        .focused($focusedChannelID, equals: channelFocusID)
+        #endif
+    }
+
+    private var channelList: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            if isChannelRailExpanded {
+                Text(L10n.channels)
+                    .font(.headline)
+            }
+
+            channelRow(
+                title: L10n.allChannels,
+                isSelected: viewModel.selectedChannelID == nil,
+                isExpanded: isChannelRailExpanded
+            ) {
+                viewModel.selectedChannelID = nil
+            }
+            #if os(tvOS)
+            .focused($focusedChannelID, equals: "all")
+            #endif
+
+            ScrollView {
+                LazyVStack(alignment: .leading, spacing: 8) {
+                    if viewModel.channels.isEmpty {
+                        Text(L10n.noChannelsFound)
+                            .foregroundColor(.secondary)
+                    } else {
+                        ForEach(viewModel.channels, id: \.id) { channel in
+                            channelRow(channel: channel)
+                        }
+                    }
+                }
+            }
+        }
+        .padding(.vertical, YouTubeChannelRailLayout.verticalPadding)
+        .padding(.horizontal, YouTubeChannelRailLayout.horizontalPadding)
+        .frame(width: isChannelRailExpanded ? YouTubeChannelRailLayout.expandedWidth : YouTubeChannelRailLayout.collapsedWidth)
+        .background({
+            #if os(tvOS)
+            Color.secondary.opacity(0.08)
+            #else
+            Color(UIColor.secondarySystemBackground)
+            #endif
+        }())
+        .animation(.easeInOut(duration: 0.2), value: isChannelRailExpanded)
+    }
+
+    var body: some View {
+        HStack(spacing: 0) {
+            channelList
+
+            Divider()
+
+            PagingLibraryView(
+                viewModel: viewModel,
+                onSelect: play,
+                posterTypeOverride: .landscape,
+                displayTypeOverride: .grid
+            )
+            .padding(.leading, 8)
+            .overlay {
+                if viewModel.state == .content, viewModel.elements.isEmpty {
+                    VStack(spacing: 8) {
+                        Text(L10n.noVideosYet)
+                            .font(.headline)
+                        Text(L10n.noYouTubeLibrariesDetectedDescription)
+                            .foregroundColor(.secondary)
+                            .multilineTextAlignment(.center)
+                    }
+                    .padding()
+                }
+            }
+        }
+        .navigationTitle(L10n.youtube)
+        .task {
+            await MainActor.run {
+                viewModel.send(.refresh)
+            }
+        }
+        #if os(tvOS)
+        .onAppear {
+            focusedChannelID = viewModel.selectedChannelID ?? "all"
+            isChannelRailExpanded = focusedChannelID != nil
+        }
+        .onChange(of: viewModel.selectedChannelID) { _, newValue in
+            focusedChannelID = newValue ?? "all"
+            withAnimation(.easeInOut(duration: 0.2)) {
+                isChannelRailExpanded = focusedChannelID != nil
+            }
+        }
+        .onChange(of: focusedChannelID) { _, newValue in
+            withAnimation(.easeInOut(duration: 0.2)) {
+                isChannelRailExpanded = newValue != nil
+            }
+        }
+        #endif
+    }
+}

--- a/Swiftfin tvOS/Views/SettingsView/SettingsView.swift
+++ b/Swiftfin tvOS/Views/SettingsView/SettingsView.swift
@@ -81,6 +81,10 @@ struct SettingsView: View {
                     ChevronButton(L10n.customize) {
                         router.route(to: .customizeViewsSettings)
                     }
+
+                    ChevronButton("YouTube Libraries") {
+                        router.route(to: .youtubeLibrariesSettings)
+                    }
 //
 //                    ChevronButton(L10n.experimental)
 //                        .onSelect {

--- a/Swiftfin/Views/SettingsView/SettingsView/SettingsView.swift
+++ b/Swiftfin/Views/SettingsView/SettingsView/SettingsView.swift
@@ -93,6 +93,10 @@ struct SettingsView: View {
                     router.route(to: .customizeViewsSettings)
                 }
 
+                ChevronButton("YouTube Libraries") {
+                    router.route(to: .youtubeLibrariesSettings)
+                }
+
                 // Note: uncomment if there are current
                 //       experimental settings
 

--- a/SwiftfinTests/TubeArchivistLibraryDetectorTests.swift
+++ b/SwiftfinTests/TubeArchivistLibraryDetectorTests.swift
@@ -1,0 +1,75 @@
+//
+// Swiftfin is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, you can obtain one at https://mozilla.org/MPL/2.0/.
+//
+// Copyright (c) 2025 Jellyfin & Jellyfin Contributors
+//
+
+@testable import Swiftfin
+import XCTest
+
+final class TubeArchivistLibraryDetectorTests: XCTestCase {
+
+    func testIsTubeArchivistPositive() throws {
+        let json = """
+        {
+          "Name": "YouTube",
+          "CollectionType": "tvshows",
+          "ItemId": "123",
+          "LibraryOptions": {
+            "TypeOptions": [
+              { "Type": "Series", "MetadataFetchers": ["TubeArchivist"], "ImageFetchers": [] }
+            ]
+          }
+        }
+        """.data(using: .utf8)!
+
+        let folder = try JSONDecoder().decode(TestVirtualFolder.self, from: json)
+        XCTAssertTrue(TubeArchivistLibraryDetector.isTubeArchivist(folder: folder.virtualFolder))
+    }
+
+    func testIsTubeArchivistNegativeWrongCollection() throws {
+        let json = """
+        {
+          "Name": "Movies",
+          "CollectionType": "movies",
+          "ItemId": "456",
+          "LibraryOptions": {
+            "TypeOptions": [
+              { "Type": "Series", "MetadataFetchers": ["TubeArchivist"], "ImageFetchers": [] }
+            ]
+          }
+        }
+        """.data(using: .utf8)!
+
+        let folder = try JSONDecoder().decode(TestVirtualFolder.self, from: json)
+        XCTAssertFalse(TubeArchivistLibraryDetector.isTubeArchivist(folder: folder.virtualFolder))
+    }
+
+    func testIsTubeArchivistPositiveImageFetcher() throws {
+        let json = """
+        {
+          "Name": "YouTube",
+          "CollectionType": "tvshows",
+          "ItemId": "789",
+          "LibraryOptions": {
+            "TypeOptions": [
+              { "Type": "Series", "MetadataFetchers": [], "ImageFetchers": ["Some", "TubeArchivistMetadata"] }
+            ]
+          }
+        }
+        """.data(using: .utf8)!
+
+        let folder = try JSONDecoder().decode(TestVirtualFolder.self, from: json)
+        XCTAssertTrue(TubeArchivistLibraryDetector.isTubeArchivist(folder: folder.virtualFolder))
+    }
+}
+
+private struct TestVirtualFolder: Decodable {
+    let virtualFolder: VirtualFolder
+
+    enum CodingKeys: String, CodingKey {
+        case virtualFolder = ""
+    }
+}

--- a/SwiftfinTests/YouTubeChannelRailLayoutTests.swift
+++ b/SwiftfinTests/YouTubeChannelRailLayoutTests.swift
@@ -1,0 +1,27 @@
+//
+// Swiftfin is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, you can obtain one at https://mozilla.org/MPL/2.0/.
+//
+// Copyright (c) 2025 Jellyfin & Jellyfin Contributors
+//
+
+@testable import Swiftfin
+import XCTest
+
+final class YouTubeChannelRailLayoutTests: XCTestCase {
+
+    func testCollapsedIsRoughlyHalfExpandedWidth() {
+        XCTAssertLessThanOrEqual(
+            YouTubeChannelRailLayout.collapsedWidth * 2,
+            YouTubeChannelRailLayout.expandedWidth + 1, // small tolerance
+            "Collapsed rail should be about half the expanded width"
+        )
+    }
+
+    func testWidthsArePositiveAndNonZero() {
+        XCTAssertGreaterThan(YouTubeChannelRailLayout.collapsedWidth, 0)
+        XCTAssertGreaterThan(YouTubeChannelRailLayout.expandedWidth, 0)
+        XCTAssertGreaterThan(YouTubeChannelRailLayout.expandedWidth, YouTubeChannelRailLayout.collapsedWidth)
+    }
+}

--- a/SwiftfinTests/YouTubePosterLayoutTests.swift
+++ b/SwiftfinTests/YouTubePosterLayoutTests.swift
@@ -1,0 +1,57 @@
+//
+// Swiftfin is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, you can obtain one at https://mozilla.org/MPL/2.0/.
+//
+// Copyright (c) 2025 Jellyfin & Jellyfin Contributors
+//
+
+@testable import Swiftfin
+import SwiftUI
+import XCTest
+
+final class YouTubePosterLayoutTests: XCTestCase {
+
+    /// Ensures landscape posters used by the YouTube tab render wider than tall (card aspect check).
+    func testLandscapePosterRendersWiderThanTall() {
+        let poster = DummyPoster()
+        let view = PosterImage(item: poster, type: .landscape)
+        let hosting = UIHostingController(rootView: view)
+
+        // Force view loading and layout
+        _ = hosting.view
+        hosting.view.bounds = CGRect(x: 0, y: 0, width: 800, height: 600)
+        hosting.view.setNeedsLayout()
+        hosting.view.layoutIfNeeded()
+
+        let size = hosting.sizeThatFits(in: CGSize(width: 800, height: 600))
+
+        XCTAssertGreaterThan(size.width, size.height, "Landscape poster should be wider than tall")
+        XCTAssertGreaterThan(size.height, 0, "Height should be positive")
+    }
+}
+
+private struct DummyPoster: Poster {
+    let id: String = "dummy"
+    var unwrappedIDHashOrZero: Int { id.hashValue }
+
+    let displayTitle: String = "Dummy"
+    var preferredPosterDisplayType: PosterDisplayType { .landscape }
+    var systemImage: String { "film" }
+
+    func portraitImageSources(maxWidth: CGFloat?, quality: Int?) -> [ImageSource] { [] }
+
+    func landscapeImageSources(maxWidth: CGFloat?, quality: Int?) -> [ImageSource] {
+        // Two sources to mirror the YouTube flow (thumb then primary)
+        [ImageSource(url: nil), ImageSource(url: nil)]
+    }
+
+    func cinematicImageSources(maxWidth: CGFloat?, quality: Int?) -> [ImageSource] { [] }
+
+    func squareImageSources(maxWidth: CGFloat?, quality: Int?) -> [ImageSource] { [] }
+
+    func thumbImageSources() -> [ImageSource] { [] }
+
+    @MainActor
+    func transform(image: Image) -> some View { image }
+}


### PR DESCRIPTION
## Overview

This pull request introduces a dedicated **YouTube** media surface designed specifically for Jellyfin libraries backed by the [TubeArchivist](https://github.com/tubearchivist/tubearchivist) metadata plugin.

Currently, TubeArchivist libraries are identified as standard "TV Shows," forcing YouTube channels to behave like Seasons and Series. This creates a suboptimal playback experience and cluttered "Latest Media" feeds. This PR solves that friction by detecting these libraries and routing them to a specialized view optimized for flat video content, featuring a channel-filtering sidebar and landscape-forced grids .

Additionally, this PR includes specific layout refinements to the tvOS sidebar (channel rail) to improve focus margins and animation smoothness.

## Technical Implementation

### 1\. Library Detection & Persistence

  * **TubeArchivistLibraryDetector:** Implemented a service that inspects the `MetadataFetchers` and `ImageFetchers` of user libraries. If the string "TubeArchivist" is detected in the options, the library is flagged as a candidate .
  * **Settings Persistence:** Added `Defaults.Customization.Library.youtubeLibraryIDs` to store user preferences regarding which detected libraries should be rendered using the new YouTube interface .
  * **Settings UI:** Introduced a "YouTube Libraries" menu in **Settings \> Libraries**. This list populates only when a compatible library is detected on the server, allowing users to toggle the feature on a per-library basis .

### 2\. Navigation & Data Architecture

  * **Surface Routing:**
      * Modified `MediaViewModel` to introduce a `.youtube(BaseItemDto)` media type. Libraries enabled in settings are now routed to `YouTubeLibraryView` instead of the standard Collection/Folder view .
  * **Feed Exclusion:**
      * Updated `HomeViewModel` to filter enabled YouTube library IDs *out* of the standard "Series" and "Latest" tabs to prevent content duplication across the UI .
  * **YouTubeLibraryViewModel:**
      * **Videos:** Fetches items with `includeItemTypes = [.episode]`, essentially flattening the library structure to show all videos sorted by "Newest" .
      * **Channels:** Fetches items with `includeItemTypes = [.series]` to populate the sidebar filter .

### 3\. Interface & Layout Refinements

  * **View Construction:** Created `YouTubeLibraryView`, utilizing a split layout:
      * **Sidebar:** Displays a scrollable list of Channels with circular avatars. Selection filters the main grid.
      * **Grid:** Renders a standard `PagingLibraryView` but forces the display mode to `.grid` and poster aspect ratio to `.landscape` to accommodate YouTube thumbnails .
  * **Channel Rail Layout:**
      * Defined `YouTubeChannelRailLayout` constants to strictly manage sidebar dimensions .
      * **Collapsed State:** Reduced width to **105pt** (previously wider) with centered icons to correct asymmetric margins on tvOS .
      * **Expanded State:** Maintained at **325pt** with leading alignment for text.
  * **Image Fallbacks:** Updated `BaseItemDto+Poster` logic for this view. If a video thumbnail is missing, it now falls back to the Channel/Series primary image or backdrop to ensure the grid is never populated with empty placeholders .

### 4\. Testing

  * **Unit Tests:** Added `TubeArchivistLibraryDetectorTests` to validate JSON parsing and provider string matching against mock data .
  * **Layout Tests:** Added `YouTubeChannelRailLayoutTests` to ensure the collapsed rail width maintains specific ratios relative to the expanded state, preventing regression during future UI tweaks .
  * **Visual Tests:** Added `YouTubePosterLayoutTests` to verify landscape card aspect ratios .

## Screenshot
![TeamViewer_JohoAhxGj1](https://github.com/user-attachments/assets/9e8374d9-138f-4d18-8a59-fb2725669a99)
![TeamViewer_op6jYOJwpK](https://github.com/user-attachments/assets/0ff7c230-747f-4ce4-8481-8f1f000c948b)

## Verification Steps

1.  **Prerequisite:** Ensure access to a Jellyfin server with the TubeArchivist plugin installed and at least one library configured with that metadata provider.
2.  **Configuration:** Navigate to **Settings \> Libraries \> YouTube Libraries**. Ensure the new menu exists and your library is detected.
3.  **Activation:** Toggle the library to **ON**.
4.  **Home Feed:** Return to the Home screen. Verify the library is no longer visible in the "Series" tab.
5.  **Navigation:** Check the top media picker; a new "YouTube" tile should be present.
6.  **UX (tvOS):**
      * Enter the view. Navigate left to the sidebar.
      * Confirm the rail expands smoothly and collapses to a centered icon state.
      * Select specific channels to verify the grid filters content correctly.