### PR TITLE
tvOS: Major UX improvements and tvOS 18 compatibility fixes

### DIFF
--- a/Shared/Coordinators/Navigation/NavigationCoordinator.swift
+++ b/Shared/Coordinators/Navigation/NavigationCoordinator.swift
@@ -26,7 +26,10 @@ final class NavigationCoordinator: ObservableObject {
 
         #if os(tvOS)
         switch style {
-        case .push, .sheet:
+        case .push:
+            // Use fullscreen for push navigation on tvOS
+            presentedFullScreen = route
+        case .sheet:
             presentedSheet = route
         case .fullscreen:
             presentedFullScreen = route

--- a/Shared/Extensions/ViewExtensions/Backport/Backport.swift
+++ b/Shared/Extensions/ViewExtensions/Backport/Backport.swift
@@ -80,6 +80,39 @@ extension Backport where Content: View {
             content
         }
     }
+
+    // MARK: - tvOS Focus Animations
+
+    /// Applies a scale effect based on focus state with platform-appropriate animation.
+    /// On tvOS 18+, uses enhanced spring animation. On older versions, uses simpler easing.
+    @ViewBuilder
+    func focusedScaleEffect(focused: Bool) -> some View {
+        #if os(tvOS)
+        if #available(tvOS 18.0, *) {
+            content
+                .scaleEffect(focused ? 1.08 : 1.0)
+                .animation(.spring(response: 0.25, dampingFraction: 0.8), value: focused)
+        } else {
+            content
+                .scaleEffect(focused ? 1.05 : 1.0)
+                .animation(.easeInOut(duration: 0.2), value: focused)
+        }
+        #else
+        content
+        #endif
+    }
+
+    /// Applies a shadow effect based on focus state for depth perception on tvOS.
+    @ViewBuilder
+    func focusedShadow(focused: Bool) -> some View {
+        content
+            .shadow(
+                color: .black.opacity(focused ? 0.3 : 0.1),
+                radius: focused ? 20 : 5,
+                y: focused ? 10 : 2
+            )
+            .animation(.easeInOut(duration: 0.2), value: focused)
+    }
 }
 
 // MARK: ButtonBorderShape

--- a/Shared/Extensions/ViewExtensions/Backport/TextFieldBackport.swift
+++ b/Shared/Extensions/ViewExtensions/Backport/TextFieldBackport.swift
@@ -1,0 +1,45 @@
+//
+// Swiftfin is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, you can obtain one at https://mozilla.org/MPL/2.0/.
+//
+// Copyright (c) 2025 Jellyfin & Jellyfin Contributors
+//
+
+import SwiftUI
+
+// MARK: - TextField/SecureField Backports for tvOS
+
+// Workaround for tvOS TextField/SecureField label issue
+// https://forums.developer.apple.com/forums/thread/739545
+// On tvOS < 18, using TextField/SecureField with labels in alerts would crash or misbehave.
+// This provides a version-aware wrapper that restores proper labels on tvOS 18+.
+
+extension Backport where Content == Never {
+
+    @ViewBuilder
+    static func textField(_ title: String, text: Binding<String>) -> some View {
+        #if os(tvOS)
+        if #available(tvOS 18.0, *) {
+            TextField(title, text: text)
+        } else {
+            TextField(text: text) {}
+        }
+        #else
+        TextField(title, text: text)
+        #endif
+    }
+
+    @ViewBuilder
+    static func secureField(_ title: String, text: Binding<String>) -> some View {
+        #if os(tvOS)
+        if #available(tvOS 18.0, *) {
+            SecureField(title, text: text)
+        } else {
+            SecureField(text: text) {}
+        }
+        #else
+        SecureField(title, text: text)
+        #endif
+    }
+}

--- a/Swiftfin tvOS/Views/ItemView/Components/ActionButtonHStack/ActionButtonHStack.swift
+++ b/Swiftfin tvOS/Views/ItemView/Components/ActionButtonHStack/ActionButtonHStack.swift
@@ -89,7 +89,7 @@ extension ItemView {
         // MARK: - Body
 
         var body: some View {
-            HStack(alignment: .center, spacing: 30) {
+            HStack(alignment: .center, spacing: 20) {
 
                 // MARK: Toggle Played
 
@@ -101,7 +101,7 @@ extension ItemView {
                     }
                     .buttonStyle(.tintedMaterial(tint: Color.jellyfinPurple, foregroundColor: .primary))
                     .isSelected(isCheckmarkSelected)
-                    .frame(minWidth: 100, maxWidth: .infinity)
+                    .frame(minWidth: 90, maxWidth: .infinity)
                 }
 
                 // MARK: Toggle Favorite
@@ -113,7 +113,7 @@ extension ItemView {
                 }
                 .buttonStyle(.tintedMaterial(tint: .pink, foregroundColor: .primary))
                 .isSelected(isHeartSelected)
-                .frame(minWidth: 100, maxWidth: .infinity)
+                .frame(minWidth: 90, maxWidth: .infinity)
 
                 // MARK: Watch a Trailer
 
@@ -123,7 +123,7 @@ extension ItemView {
                         externalTrailers: viewModel.item.remoteTrailers ?? []
                     )
                     .buttonStyle(.tintedMaterial(tint: .pink, foregroundColor: .primary))
-                    .frame(minWidth: 100, maxWidth: .infinity)
+                    .frame(minWidth: 90, maxWidth: .infinity)
                 }
 
                 // MARK: Advanced Options

--- a/Swiftfin tvOS/Views/ItemView/Components/PlayButton/PlayButton.swift
+++ b/Swiftfin tvOS/Views/ItemView/Components/PlayButton/PlayButton.swift
@@ -91,11 +91,13 @@ extension ItemView {
             Button {
                 play()
             } label: {
-                HStack(spacing: 15) {
+                HStack(spacing: 20) {
                     Image(systemName: "play.fill")
+                        .font(.title2)
 
-                    VStack {
+                    VStack(alignment: .leading, spacing: 4) {
                         Text(title)
+                            .font(.headline)
 
                         if let source {
                             Marquee(source, animateWhenFocused: true)
@@ -104,7 +106,8 @@ extension ItemView {
                         }
                     }
                 }
-                .padding(.horizontal, 20)
+                .padding(.horizontal, 30)
+                .padding(.vertical, 10)
             }
             .buttonStyle(
                 .tintedMaterial(

--- a/Swiftfin tvOS/Views/ItemView/ScrollViews/CinematicScrollView.swift
+++ b/Swiftfin tvOS/Views/ItemView/ScrollViews/CinematicScrollView.swift
@@ -133,83 +133,83 @@ extension ItemView {
                     .focusable()
                     .focused($focusedLayer, equals: .top)
 
-                HStack(alignment: .bottom) {
+                VStack(alignment: .leading, spacing: 30) {
+                    // Logo or title at top
+                    ImageView(viewModel.item.imageSource(
+                        .logo,
+                        maxHeight: 200
+                    ))
+                    .placeholder { _ in
+                        EmptyView()
+                    }
+                    .failure {
+                        Marquee(viewModel.item.displayTitle)
+                            .font(.largeTitle)
+                            .fontWeight(.semibold)
+                            .lineLimit(1)
+                            .foregroundStyle(.white)
+                    }
+                    .aspectRatio(contentMode: .fit)
+                    .frame(maxHeight: 150)
 
-                    VStack(alignment: .leading, spacing: 20) {
-
-                        ImageView(viewModel.item.imageSource(
-                            .logo,
-                            maxHeight: 250
-                        ))
-                        .placeholder { _ in
-                            EmptyView()
-                        }
-                        .failure {
-                            Marquee(viewModel.item.displayTitle)
-                                .font(.largeTitle)
-                                .fontWeight(.semibold)
-                                .lineLimit(1)
-                                .foregroundStyle(.white)
-                        }
-                        .aspectRatio(contentMode: .fit)
-                        .padding(.bottom)
-
-                        OverviewView(item: viewModel.item)
-                            .taglineLineLimit(1)
-                            .overviewLineLimit(3)
-
-                        if viewModel.item.type != .person {
-                            HStack {
-
-                                DotHStack {
-                                    if let firstGenre = viewModel.item.genres?.first {
-                                        Text(firstGenre)
-                                    }
-
-                                    if let premiereYear = viewModel.item.premiereDateYear {
-                                        Text(premiereYear)
-                                    }
-
-                                    if let playButtonitem = viewModel.playButtonItem, let runtime = playButtonitem.runTimeLabel {
-                                        Text(runtime)
-                                    }
+                    // Metadata row
+                    if viewModel.item.type != .person {
+                        HStack(spacing: 20) {
+                            DotHStack {
+                                if let firstGenre = viewModel.item.genres?.first {
+                                    Text(firstGenre)
                                 }
-                                .font(.caption)
-                                .foregroundColor(Color(UIColor.lightGray))
 
-                                ItemView.AttributesHStack(
-                                    attributes: attributes,
-                                    viewModel: viewModel
-                                )
+                                if let premiereYear = viewModel.item.premiereDateYear {
+                                    Text(premiereYear)
+                                }
+
+                                if let playButtonitem = viewModel.playButtonItem, let runtime = playButtonitem.runTimeLabel {
+                                    Text(runtime)
+                                }
                             }
+                            .font(.title3)
+                            .foregroundColor(Color(UIColor.lightGray))
+
+                            ItemView.AttributesHStack(
+                                attributes: attributes,
+                                viewModel: viewModel
+                            )
                         }
                     }
 
-                    Spacer()
+                    // Overview - spans full width
+                    OverviewView(item: viewModel.item)
+                        .taglineLineLimit(1)
+                        .overviewLineLimit(4)
 
-                    VStack(spacing: 30) {
+                    // Buttons row - spans full width
+                    HStack(spacing: 30) {
                         if viewModel.item.type == .person || viewModel.item.type == .musicArtist {
-                            ImageView(viewModel.item.imageSource(.primary, maxWidth: 450))
+                            ImageView(viewModel.item.imageSource(.primary, maxWidth: 300))
                                 .failure {
                                     SystemImageContentView(systemName: viewModel.item.systemImage)
                                 }
                                 .posterStyle(.portrait, contentMode: .fill)
                                 .cornerRadius(10)
+                                .frame(height: 200)
                                 .accessibilityIgnoresInvertColors()
                         } else if viewModel.item.presentPlayButton {
                             ItemView.PlayButton(viewModel: viewModel)
                                 .focused($focusedLayer, equals: .playButton)
                                 .frame(height: 100)
                         }
+
                         ItemView.ActionButtonHStack(viewModel: viewModel)
                             .focused($focusedLayer, equals: .actionButtons)
                             .frame(height: 100)
+
+                        Spacer()
                     }
-                    .frame(width: 450)
-                    .padding(.leading, 150)
                 }
+                .frame(maxWidth: .infinity, alignment: .leading)
             }
-            .padding(.horizontal, 50)
+            .padding(.horizontal, 80)
             .onChange(of: focusedLayer) { _, layer in
                 if layer == .top {
                     if viewModel.item.presentPlayButton {

--- a/Swiftfin tvOS/Views/SelectUserView/SelectUserView.swift
+++ b/Swiftfin tvOS/Views/SelectUserView/SelectUserView.swift
@@ -351,10 +351,7 @@ struct SelectUserView: View {
         }
         .alert(L10n.signIn, isPresented: $isPresentingLocalPin) {
 
-            // TODO: Verify on tvOS 18
-            // https://forums.developer.apple.com/forums/thread/739545
-            // TextField(L10n.pin, text: $pin)
-            TextField(text: $pin) {}
+            Backport.textField(L10n.pin, text: $pin)
                 .keyboardType(.numberPad)
 
             Button(L10n.signIn) {

--- a/Swiftfin tvOS/Views/SettingsView/UserProfileSettingsView/UserLocalSecurityView.swift
+++ b/Swiftfin tvOS/Views/SettingsView/UserProfileSettingsView/UserLocalSecurityView.swift
@@ -150,10 +150,7 @@ struct UserLocalSecurityView: View {
                             subtitle: pinHint,
                             description: L10n.setPinHintDescription
                         ) {
-                            // TODO: Verify on tvOS 18
-                            // https://forums.developer.apple.com/forums/thread/739545
-                            // TextField(L10n.hint, text: $pinHint)
-                            TextField(text: $pinHint) {}
+                            Backport.textField(L10n.hint, text: $pinHint)
                         }
                     } header: {
                         Text(L10n.hint)
@@ -199,10 +196,7 @@ struct UserLocalSecurityView: View {
                 presenting: onPinCompletion
             ) { completion in
 
-                // TODO: Verify on tvOS 18
-                // https://forums.developer.apple.com/forums/thread/739545
-                // SecureField(L10n.pin, text: $pin)
-                SecureField(text: $pin) {}
+                Backport.secureField(L10n.pin, text: $pin)
                     .keyboardType(.numberPad)
 
                 Button(L10n.continue) {
@@ -219,10 +213,7 @@ struct UserLocalSecurityView: View {
                 presenting: onPinCompletion
             ) { completion in
 
-                // TODO: Verify on tvOS 18
-                // https://forums.developer.apple.com/forums/thread/739545
-                // SecureField(L10n.pin, text: $pin)
-                SecureField(text: $pin) {}
+                Backport.secureField(L10n.pin, text: $pin)
                     .keyboardType(.numberPad)
 
                 Button(L10n.set) {

--- a/Swiftfin tvOS/Views/VideoPlayerContainerState/PlaybackControls/Components/NavigationBar.swift
+++ b/Swiftfin tvOS/Views/VideoPlayerContainerState/PlaybackControls/Components/NavigationBar.swift
@@ -23,14 +23,10 @@ extension VideoPlayer.PlaybackControls {
                         .foregroundStyle(.white)
                 }
 
-                HStack {
-                    Text(manager.item.displayTitle)
-                        .font(.largeTitle)
-                        .fontWeight(.bold)
-                        .frame(maxWidth: .infinity, alignment: .leading)
-
-                    ActionButtons()
-                }
+                Text(manager.item.displayTitle)
+                    .font(.largeTitle)
+                    .fontWeight(.bold)
+                    .frame(maxWidth: .infinity, alignment: .leading)
             }
         }
     }

--- a/Swiftfin tvOS/Views/VideoPlayerContainerState/PlaybackControls/Components/SplitTimestamp.swift
+++ b/Swiftfin tvOS/Views/VideoPlayerContainerState/PlaybackControls/Components/SplitTimestamp.swift
@@ -50,7 +50,6 @@ extension VideoPlayer.PlaybackControls {
             }
             .trackingSize($trailingTimestampSize)
             .frame(maxWidth: .infinity, alignment: .trailing)
-            .debugBackground()
             .overlay(alignment: .leading) {
                 Text(scrubbedSeconds, format: .runtime)
                     .trackingSize($leadingTimestampSize)

--- a/Swiftfin tvOS/Views/VideoPlayerContainerState/PlaybackControls/SupplementContainerView.swift
+++ b/Swiftfin tvOS/Views/VideoPlayerContainerState/PlaybackControls/SupplementContainerView.swift
@@ -69,7 +69,6 @@ struct SupplementContainerView: View {
         }
         .isVisible(containerState.isPresentingOverlay)
         .animation(.linear(duration: 0.2), value: containerState.isPresentingOverlay)
-        .background(Color.blue.opacity(0.2))
         .focusSection()
         .focused($isFocused)
         .onReceive(manager.$supplements) { newValue in


### PR DESCRIPTION
## Summary
These fixes focus on getting the UI working, not reinventing it or rebooting it.. just fixing some issues that make it unusable at this point.
- Fixed item detail view to display full-screen instead of small card on tvOS
- Repositioned playback controls to bottom 15% of screen with proper menu button handling
- Added tvOS 18.1+ sheet presentation compatibility fix
- Removed debug backgrounds and fixed progress bar color bleed
- Added TextField/SecureField backport for tvOS 18+ label support
- Improved button focus states with custom scale animations

## Changes

### Navigation & Presentation
- Changed push navigation to use `fullScreenCover` on tvOS for proper full-screen item views
- Added `TVSheetPresentationModifier` for version-aware sheet presentation (tvOS 18.1+ fix)
- Fixed item detail view displaying as small card instead of full-screen

### Video Playback Controls
- Repositioned playback controls to bottom 15% of screen
- Removed action buttons (aspect ratio, menu) from playback navigation bar
- Fixed menu button logic to properly exit playback when overlay is hidden
- Replaced `maskLinearGradient` with cleaner `LinearGradient` for bottom overlay
- Removed debug backgrounds (red from SplitTimestamp, blue from SupplementContainerView)

### Progress Bar
- Changed background from `ultraThinMaterial` to solid color to prevent color bleed
- Fixed progress bar styling to avoid picking up colors from video content

### Item Detail View (CinematicHeaderView)
- Restructured layout from horizontal to vertical stacking
- Made content span full width with proper alignment
- Adjusted button sizing and spacing for better tvOS presentation

### TextField/SecureField Compatibility
- Added `TextFieldBackport.swift` for tvOS 18+ label support
- Updated `UserLocalSecurityView` and `SelectUserView` to use backport helpers

### Button Focus States
- Converted `TintedMaterialButtonStyle` to `PrimitiveButtonStyle` for `@FocusState` support
- Added `focusEffectDisabled()` with custom scale animation on tvOS
- Added focus animation helpers to `Backport.swift`