### PR TITLE
VLCKit 3.7.0

### DIFF
--- a/Cartfile
+++ b/Cartfile
@@ -1,3 +1,3 @@
-binary "https://code.videolan.org/videolan/VLCKit/raw/master/Packaging/MobileVLCKit.json" == 3.5.0
-binary "https://code.videolan.org/videolan/VLCKit/raw/master/Packaging/TVVLCKit.json" == 3.5.0
+binary "https://code.videolan.org/videolan/VLCKit/raw/master/Packaging/MobileVLCKit.json" == 3.7.0
+binary "https://code.videolan.org/videolan/VLCKit/raw/master/Packaging/TVVLCKit.json" == 3.7.0
 # binary "ChromeCastFramework.json"  


### PR DESCRIPTION
### Summary

Resolves: https://github.com/jellyfin/Swiftfin/issues/1743, https://github.com/jellyfin/Swiftfin/issues/1689, & https://github.com/jellyfin/Swiftfin/issues/1150

This would bring the libVLC version from 3.0.18 to 3.0.22. This would result in the following changes for the Swiftin Player:

---

<details>

<summary>VLCKit 3.7.0</summary>

https://code.videolan.org/videolan/VLCKit/-/tags/3.7.0

- update to libvlc 3.0.22 with all its improvements 
- fixes for Chinese text rendering on the latest generation of Apple operating systems
- add API to fetch the current error message

</details>


<details>

<summary>VLCKit 3.6.0</summary>

https://code.videolan.org/videolan/VLCKit/-/tags/3.6.0

- update to libvlc 3.0.21
- add new equalizer API and deprecate the previous
- add new statistics API to VLCMedia and deprecate the previous
- fix equalizer state
- fix distribution of VLCDialogProvider.h on macOS solving compilation issue in swift enabled projects
- improve threading on 64bit platforms
- fix audio rendering regression
- fix UPnP busy loop
- backport new event manager from the master branch
- expose API to modify the event configuration at runtime
- fix crashes when using the list player and memory leaks
- remove abort() when leaking event handlers
- fix background thread use on macOS when accessing AppKit
- fix UPnP URL generation leading to issues on iOS/tvOS 17 and macOS 14

</details>

---

<details>

<summary>libVLC 3.0.22</summary>

https://code.videolan.org/videolan/vlc/-/tags/3.0.22

This update contains a few improvements and some important fixes:
- Add option to use dark palette on Qt interface (Windows & Linux)
- Add Windows ARM64 builds
- Fix support for Windows XP SP3 and some older macOS versions
- Allow renaming/moving/deleting of playing file on Windows
- Add A_ATRAC/AT1 support in matroska
- Add AMD GPU Frame Rate Doubler (Direct3D11)
- And a very large number of security issues fixed thanks to STF and oss-fuzz

and:
- Add compilation support for Qt6 and newer versions of Qt5
- Prevent FLAC seeking logic get stuck
- Handle pictures in FLAC
- Fix VOB/AOB LPCM/MLP detection failing occasionally
- Cut QNap title on first invalid character
- Fix display of certain JPEG files
- Fix playback of very short ASF files (duration less than 1s)
- Fix crashes in multiple demuxers (reported by rub.de, oss-fuzz and others)
- Fix SFTP seeking for large files on 32-bit OS
- Fix Opus channel mapping
- Fix hardware decoding with VideoToolbox of XVID MPEG-4 video
- Fix DVD CEA-608 captions parsing
- Fix ProRes 4:4:4:4
- Disable decoding using libdca, libmpeg2 and liba52 by default in favor of libavcodec
- Add dav1d-all-layers option
- Restrict SystemParametersInfo calls to Windows XP
- Handle mkv-use-chapter-codec option
- UPnP: remove SAT>IP channel list fallback
- Use a better stretch mode in wingdi
- Fetch missing device information when running in UWP
- Qt: Add option to use dark palette
- Qt: Add compilation support for newer versions of Qt5
- Qt: Fix scrolling on volume slider
- macOS: fix crashes when drag'n drop items in the playlist
- KDE: fix MPRIS state when started from file

</details>

<details>

<summary>libVLC 3.0.21</summary>

https://code.videolan.org/videolan/vlc/-/tags/3.0.21

This update contains a few improvements and some fixes:
 - Super Resolution scaling with AMD GPU
 - nVidia TrueHDR filter for SDR->HDR generation
 - support for Opus Ambisonic
 - support for HTTP content range (RFC 9110)
 - better subtitles generation for Complex Text Layout on macOS
 - improvements for MP4 and Opus support
 - new AMD VQ Enhancer filter
 - 3rd party libraries updates
 - fixes for VAAPI, HLS, UPNP modules and reduction of warnings and crashes
 - fix for the crash on macOS with devices with more than 9 channels
 - fix a potential security issue on MMS (heap buffer overflow)

</details>

<details>

<summary>libVLC 3.0.20</summary>

https://code.videolan.org/videolan/vlc/-/tags/3.0.2

VLC 3.0.20 is an emergency release, fixing major regressions that
appeared in 3.0.19.
It notably fixes a crash with AMD GPU, a green line in fullscreen on Windows,
a crash with AV1 hw acceleration, a bug in the fullscreen panel and a potential
security issue.

</details>

<details>

<summary>libVLC 3.0.19</summary>

https://code.videolan.org/videolan/vlc/-/tags/3.0.19

This update contains numerous fixes and improvements, notably:
- a fix for a major FLAC regression,
- a fix for next-frame freezing the app,
- hardware decoding for AV1 and other improvements for AV1,
- improvements for Wav (RIFF INFO), MP4, AVI (Qnap, GBRP), RealVideo,
- Super Resolution scaling with Intel and nVidia hwardware,
- mumerous fixes for various files support,
- fixes for hardware decoding on Windows, Android and macOS,
- other fixes and security updates.

</details>

---

I believe the base VLC repo is libVLC but please correct me if that is wrong!