### PR TITLE
Fix `MediaView` Random Images

### DIFF
--- a/Shared/ViewModels/MediaViewModel/MediaViewModel.swift
+++ b/Shared/ViewModels/MediaViewModel/MediaViewModel.swift
@@ -112,7 +112,7 @@ final class MediaViewModel: ViewModel {
         parameters.limit = 3
         parameters.isRecursive = true
         parameters.parentID = parentID
-        parameters.includeItemTypes = [.movie, .series, .boxSet]
+        parameters.includeItemTypes = BaseItemKind.supportedCases
         parameters.filters = filters
         parameters.sortBy = [ItemSortBy.random.rawValue]
 
@@ -120,6 +120,6 @@ final class MediaViewModel: ViewModel {
         let response = try await userSession.client.send(request)
 
         return (response.value.items ?? [])
-            .map { $0.imageSource(.backdrop, maxWidth: 200) }
+            .flatMap { $0.landscapeImageSources(maxWidth: 200) }
     }
 }


### PR DESCRIPTION
### Summary

Resolves: https://github.com/jellyfin/Swiftfin/issues/1879

### Issue

The `MediaViewModel` random images was only pulling Series, Movies, & Collections. So there were no items pulled for Music Videos & Videos to get a random image from. Once enabled, these landscape images are their `.primary` images so they need to be updated with additional logic to get landscape images from `.primary` for impacted types.

### Resolution

1. Use `.landscapeImageSources` so we are still getting images when the landscape is the primary image
2. Use `BaseItemKind.supportedCases` so for ease of maintenance and so we can pull images for Music Videos / Videos