### PR TITLE
Link: LLM/"AI" Development Policy into Contributor Documentation

### DIFF
--- a/Documentation/contributing.md
+++ b/Documentation/contributing.md
@@ -4,6 +4,8 @@
 
 > Even if you can't contribute code, you can still help Jellyfin (Swiftfin)! The two main things you can help with are testing and creating issues. Contributing to code, documentation, ..., and other non-code components are all outlined in the sections below.
 
+> Please note [Jellyfin's LLM/AI Development Policy](https://jellyfin.org/docs/general/contributing/llm-policies/) applies to all Swiftfin contributions.
+
 ## Setup
 
 Fork the Swiftfin repo and install the necessary dependencies with Xcode 15:


### PR DESCRIPTION
### Summary

Adds a link to https://jellyfin.org/docs/general/contributing/llm-policies/ for our contributor documentation.