### PR TITLE
Enable `RedundantViewBuilder` & Lint

### DIFF
--- a/.swiftformat
+++ b/.swiftformat
@@ -42,7 +42,6 @@
     redundantFileprivate,   \
     redundantSelf,          \
     redundantType,          \
-    redundantViewBuilder,   \
     strongOutlets,          \
     trailingCommas,         \
     yodaConditions

--- a/Shared/Components/ListRowCheckbox.swift
+++ b/Shared/Components/ListRowCheckbox.swift
@@ -31,7 +31,6 @@ struct ListRowCheckbox: View {
 
     // MARK: - Body
 
-    @ViewBuilder
     var body: some View {
         if isEditing, isSelected {
             Image(systemName: "checkmark.circle.fill")

--- a/Shared/Components/Localization/CountryPicker.swift
+++ b/Shared/Components/Localization/CountryPicker.swift
@@ -27,7 +27,6 @@ struct CountryPicker: View {
         viewModel.value.first(property: \.twoLetterISORegionName, equalTo: selection.wrappedValue)
     }
 
-    @ViewBuilder
     private var picker: some View {
         Picker(
             title,

--- a/Shared/Components/Localization/ParentalRatingPicker.swift
+++ b/Shared/Components/Localization/ParentalRatingPicker.swift
@@ -27,7 +27,6 @@ struct ParentalRatingPicker: View {
         viewModel.value.first(property: \.name, equalTo: selection.wrappedValue)
     }
 
-    @ViewBuilder
     private var picker: some View {
         Picker(
             title,

--- a/Shared/Components/MarkedList.swift
+++ b/Shared/Components/MarkedList.swift
@@ -47,7 +47,6 @@ extension MarkedList {
         let spacing: CGFloat
         let marker: (Int) -> Marker
 
-        @ViewBuilder
         func body(children: _VariadicView.Children) -> some View {
             VStack(alignment: .leading, spacing: spacing) {
                 ForEach(Array(zip(children.indices, children)), id: \.0) { child in

--- a/Shared/Components/PrimaryButtonStyle.swift
+++ b/Shared/Components/PrimaryButtonStyle.swift
@@ -48,7 +48,6 @@ struct PrimaryButtonStyle: PrimitiveButtonStyle {
         }
     }
 
-    @ViewBuilder
     private func contentView(configuration: Configuration) -> some View {
         ZStack {
             RoundedRectangle(cornerRadius: 10)

--- a/Shared/Components/SeparatorHStack.swift
+++ b/Shared/Components/SeparatorHStack.swift
@@ -77,7 +77,6 @@ extension SeparatorHStack {
             }
         }
 
-        @ViewBuilder
         private func localHStack(@ViewBuilder content: @escaping () -> some View) -> some View {
             HStack(spacing: 0) {
                 content()

--- a/Shared/Components/TruncatedText.swift
+++ b/Shared/Components/TruncatedText.swift
@@ -35,7 +35,6 @@ struct TruncatedText: View {
     private var seeMoreType: SeeMoreType
     private let text: String
 
-    @ViewBuilder
     private var textView: some View {
         ZStack(alignment: .bottomTrailing) {
             Text(text)

--- a/Shared/Components/VideoPlayer.swift
+++ b/Shared/Components/VideoPlayer.swift
@@ -44,7 +44,6 @@ struct VideoPlayer: View {
         self._proxy = .init(wrappedValue: VLCMediaPlayerProxy())
     }
 
-    @ViewBuilder
     private var containerView: some View {
         VideoPlayerContainerView(
             containerState: containerState,

--- a/Shared/Coordinators/Tabs/MainTabView.swift
+++ b/Shared/Coordinators/Tabs/MainTabView.swift
@@ -42,7 +42,6 @@ struct MainTabView: View {
     }
     #endif
 
-    @ViewBuilder
     var body: some View {
         TabView(selection: $tabCoordinator.selectedTabID) {
             ForEach(tabCoordinator.tabs, id: \.item.id) { tab in

--- a/Shared/Extensions/Form.swift
+++ b/Shared/Extensions/Form.swift
@@ -86,7 +86,6 @@ private struct PlatformForm<Image: View, Content: View>: PlatformView {
         }
     }
 
-    @ViewBuilder
     private var descriptionView: some View {
         ZStack {
             image
@@ -98,7 +97,6 @@ private struct PlatformForm<Image: View, Content: View>: PlatformView {
         .animation(.linear(duration: 0.2), value: focusedLearnMore == nil)
     }
 
-    @ViewBuilder
     private func learnMoreModal(_ content: AnyView) -> some View {
         VStack(alignment: .leading, spacing: 16) {
             content

--- a/Shared/Extensions/Picker.swift
+++ b/Shared/Extensions/Picker.swift
@@ -8,7 +8,6 @@
 
 import SwiftUI
 
-@ViewBuilder
 func Picker<Element: CaseIterable & Displayable & Hashable>(
     _ title: String,
     selection: Binding<Element?>,
@@ -25,7 +24,6 @@ func Picker<Element: CaseIterable & Displayable & Hashable>(
     }
 }
 
-@ViewBuilder
 func Picker<Element: CaseIterable & Displayable & Hashable>(
     _ title: String,
     selection: Binding<Element>
@@ -55,7 +53,6 @@ func Picker<Element: SupportedCaseIterable & Displayable & Hashable>(
     }
 }
 
-@ViewBuilder
 func Picker<Element: Identifiable & Displayable & Hashable, Data: RandomAccessCollection>(
     _ title: String,
     sources: Data,

--- a/Shared/Extensions/ProgressViewStyle/PlaybackProgressViewStyle.swift
+++ b/Shared/Extensions/ProgressViewStyle/PlaybackProgressViewStyle.swift
@@ -21,7 +21,6 @@ struct PlaybackProgressViewStyle: ProgressViewStyle {
     var secondaryProgress: Double?
     var cornerStyle: CornerStyle
 
-    @ViewBuilder
     private func buildCapsule(for progress: Double) -> some View {
         Rectangle()
             .cornerRadius(

--- a/Shared/Extensions/ViewExtensions/Backport/Backport.swift
+++ b/Shared/Extensions/ViewExtensions/Backport/Backport.swift
@@ -15,7 +15,6 @@ struct Backport<Content> {
 
 extension Backport where Content: View {
 
-    @ViewBuilder
     func buttonBorderShape(_ shape: ButtonBorderShape) -> some View {
         content.buttonBorderShape(shape.swiftUIValue)
     }

--- a/Shared/Extensions/ViewExtensions/ViewExtensions.swift
+++ b/Shared/Extensions/ViewExtensions/ViewExtensions.swift
@@ -243,7 +243,6 @@ extension View {
     }
 
     /// Apply a corner radius as a ratio of a view's side
-    @ViewBuilder
     func cornerRadius(
         ratio: CGFloat,
         of side: KeyPath<CGSize, CGFloat>,

--- a/Shared/Objects/MediaPlayerManager/MediaPlayerProxy/MediaPlayerProxy+VLC.swift
+++ b/Shared/Objects/MediaPlayerManager/MediaPlayerProxy/MediaPlayerProxy+VLC.swift
@@ -93,7 +93,6 @@ class VLCMediaPlayerProxy: VideoMediaPlayerProxy,
         vlcUIProxy.setSubtitleSize(.absolute(fontSize))
     }
 
-    @ViewBuilder
     var videoPlayerBody: some View {
         VLCPlayerView()
             .environmentObject(vlcUIProxy)

--- a/Shared/Objects/MediaPlayerManager/MediaPlayerProxy/MediaPlayerProxy.swift
+++ b/Shared/Objects/MediaPlayerManager/MediaPlayerProxy/MediaPlayerProxy.swift
@@ -42,7 +42,6 @@ protocol VideoMediaPlayerProxy: MediaPlayerProxy {
     func setAudioStream(_ stream: MediaStream)
     func setSubtitleStream(_ stream: MediaStream)
 
-    @ViewBuilder
     @MainActor
     var videoPlayerBody: Self.VideoPlayerBody { get }
 }

--- a/Shared/Objects/MediaPlayerManager/Supplements/MediaChaptersSupplement.swift
+++ b/Shared/Objects/MediaPlayerManager/Supplements/MediaChaptersSupplement.swift
@@ -93,7 +93,6 @@ extension MediaChaptersSupplement {
             }
         }
 
-        @ViewBuilder
         private var iOSCompactView: some View {
             // TODO: scroll to current chapter
             CollectionVGrid(
@@ -113,7 +112,6 @@ extension MediaChaptersSupplement {
             }
         }
 
-        @ViewBuilder
         private var iOSRegularView: some View {
             // TODO: change to continuousLeadingEdge after
             // layout inset fix in CollectionHStack

--- a/Shared/Objects/MediaPlayerManager/Supplements/MediaInfoSupplement.swift
+++ b/Shared/Objects/MediaPlayerManager/Supplements/MediaInfoSupplement.swift
@@ -39,7 +39,6 @@ extension MediaInfoSupplement {
 
         let item: BaseItemDto
 
-        @ViewBuilder
         private var accessoryView: some View {
             DotHStack {
                 if item.type == .episode, let seasonEpisodeLocator = item.seasonEpisodeLabel {
@@ -89,7 +88,6 @@ extension MediaInfoSupplement {
             .edgePadding(.bottom)
         }
 
-        @ViewBuilder
         private var iOSCompactView: some View {
             VStack(alignment: .leading) {
                 Group {
@@ -132,7 +130,6 @@ extension MediaInfoSupplement {
             .frame(maxWidth: .infinity, alignment: .topLeading)
         }
 
-        @ViewBuilder
         private var iOSRegularView: some View {
             HStack(alignment: .bottom, spacing: EdgeInsets.edgePadding) {
                 // TODO: determine what to do with non-portrait (channel, home video) images

--- a/Shared/Objects/MediaPlayerManager/Supplements/MediaPlayerSupplement.swift
+++ b/Shared/Objects/MediaPlayerManager/Supplements/MediaPlayerSupplement.swift
@@ -20,7 +20,6 @@ protocol MediaPlayerSupplement: Displayable, Identifiable {
     var id: String { get }
 
     @MainActor
-    @ViewBuilder
     var videoPlayerBody: Self.VideoPlayerBody { get }
 }
 

--- a/Shared/Objects/MediaPlayerManager/Supplements/PlaybackInformationSupplement.swift
+++ b/Shared/Objects/MediaPlayerManager/Supplements/PlaybackInformationSupplement.swift
@@ -54,7 +54,17 @@ extension PlaybackInformationSupplement {
             }
         }
 
-        var tvOSView: some View {}
+        var tvOSView: some View {
+            VStack {
+                if let session = viewModel.currentSession {
+                    Text(session.userName ?? "Unknown User")
+                        .font(.caption)
+                        .padding(6)
+                        .background(.ultraThinMaterial, in: RoundedRectangle(cornerRadius: 8, style: .continuous))
+                        .padding()
+                }
+            }
+        }
     }
 }
 

--- a/Shared/Objects/MediaPlayerManager/Supplements/PlaybackRateMediaPlayerSupplement.swift
+++ b/Shared/Objects/MediaPlayerManager/Supplements/PlaybackRateMediaPlayerSupplement.swift
@@ -27,7 +27,6 @@ struct PlaybackRateMediaPlayerSupplement: MediaPlayerSupplement {
         @EnvironmentObject
         private var manager: MediaPlayerManager
 
-        @ViewBuilder
         private var compactView: some View {
             VStack {
 
@@ -67,8 +66,10 @@ struct PlaybackRateMediaPlayerSupplement: MediaPlayerSupplement {
             }
         }
 
-        @ViewBuilder
-        private var regularView: some View {}
+        private var regularView: some View {
+            Color.orange
+                .opacity(0.5)
+        }
 
         var iOSView: some View {
             CompactOrRegularView(
@@ -76,11 +77,12 @@ struct PlaybackRateMediaPlayerSupplement: MediaPlayerSupplement {
             ) {
                 compactView
             } regularView: {
-                Color.orange
-                    .opacity(0.5)
+                regularView
             }
         }
 
-        var tvOSView: some View {}
+        var tvOSView: some View {
+            regularView
+        }
     }
 }

--- a/Shared/Objects/PlatformView.swift
+++ b/Shared/Objects/PlatformView.swift
@@ -13,24 +13,20 @@ protocol PlatformView: View {
     associatedtype iOSBody: View
     associatedtype tvOSBody: View
 
-    @ViewBuilder
     @MainActor
     var iOSView: Self.iOSBody { get }
-    @ViewBuilder
     @MainActor
     var tvOSView: Self.tvOSBody { get }
 }
 
 extension PlatformView {
     #if os(iOS)
-    @ViewBuilder
     @MainActor
     var body: some View {
         iOSView
     }
 
     #elseif os(tvOS)
-    @ViewBuilder
     @MainActor
     var body: some View {
         tvOSView

--- a/Shared/Views/ConnecToServerView/ConnectToServerView.swift
+++ b/Shared/Views/ConnecToServerView/ConnectToServerView.swift
@@ -80,7 +80,6 @@ struct ConnectToServerView: View {
 
     // MARK: - Local Servers Section
 
-    @ViewBuilder
     private var localServersSection: some View {
         Section(L10n.localServers) {
             if viewModel.localServers.isEmpty {

--- a/Shared/Views/MediaView/Components/MediaItem.swift
+++ b/Shared/Views/MediaView/Components/MediaItem.swift
@@ -67,7 +67,6 @@ extension MediaView {
             }
         }
 
-        @ViewBuilder
         private var titleLabel: some View {
             Text(mediaType.displayTitle)
                 .font(.title2)

--- a/Shared/Views/MediaView/MediaView.swift
+++ b/Shared/Views/MediaView/MediaView.swift
@@ -30,7 +30,6 @@ struct MediaView: View {
         }
     }
 
-    @ViewBuilder
     private var content: some View {
         CollectionVGrid(
             uniqueElements: viewModel.mediaItems,

--- a/Shared/Views/SettingsView/DeviceProfileSettings/CustomDeviceProfilesView.swift
+++ b/Shared/Views/SettingsView/DeviceProfileSettings/CustomDeviceProfilesView.swift
@@ -27,14 +27,12 @@ struct CustomDeviceProfilesView: View {
         customDeviceProfileAction == .add || customProfiles.isNotEmpty
     }
 
-    @ViewBuilder
     private var addButton: some View {
         Button(L10n.add) {
             router.route(to: .createDeviceProfile)
         }
     }
 
-    @ViewBuilder
     private func deleteButton(profile: CustomDeviceProfile) -> some View {
         Button(L10n.delete, systemImage: "trash", role: .destructive) {
             customProfiles.removeFirst(equalTo: profile)
@@ -58,7 +56,6 @@ struct CustomDeviceProfilesView: View {
         }
     }
 
-    @ViewBuilder
     private var behaviorView: some View {
         Section(L10n.behavior) {
             #if os(iOS)
@@ -84,7 +81,6 @@ struct CustomDeviceProfilesView: View {
         }
     }
 
-    @ViewBuilder
     private var customProfileView: some View {
         Section(customDeviceProfileAction == .add ? L10n.custom : L10n.profiles) {
 
@@ -151,7 +147,6 @@ struct CustomDeviceProfilesView: View {
         }
     }
 
-    @ViewBuilder
     private func profileView(
         useAsTranscodingProfile: Bool,
         audio: [AudioCodec],

--- a/Shared/Views/SettingsView/DeviceProfileSettings/EditDeviceProfileView.swift
+++ b/Shared/Views/SettingsView/DeviceProfileSettings/EditDeviceProfileView.swift
@@ -81,7 +81,6 @@ extension CustomDeviceProfilesView {
             #endif
         }
 
-        @ViewBuilder
         private var contentView: some View {
             Form(systemImage: "doc") {
                 Section(L10n.behavior) {

--- a/Shared/Views/SettingsView/SettingsView.swift
+++ b/Shared/Views/SettingsView/SettingsView.swift
@@ -100,7 +100,6 @@ struct SettingsView: View {
 
     // MARK: - Video Player Section
 
-    @ViewBuilder
     private var videoPlayerSection: some View {
         Section(L10n.videoPlayer) {
             #if os(iOS)
@@ -167,7 +166,6 @@ struct SettingsView: View {
 
     // MARK: - Diagnostics Section
 
-    @ViewBuilder
     private var diagnosticsSection: some View {
         Section {
             ChevronButton(L10n.logs) {

--- a/Shared/Views/UserSignInView/UserSignInView.swift
+++ b/Shared/Views/UserSignInView/UserSignInView.swift
@@ -208,7 +208,6 @@ struct UserSignInView: View {
 
     // MARK: - Public Users Section
 
-    @ViewBuilder
     private var publicUsersSection: some View {
         Section(L10n.publicUsers) {
             if viewModel.publicUsers.isEmpty {

--- a/Swiftfin tvOS/Components/ColorPicker/Components/ColorPicker+Alert.swift
+++ b/Swiftfin tvOS/Components/ColorPicker/Components/ColorPicker+Alert.swift
@@ -20,7 +20,6 @@ extension ColorPicker {
 
         let value: Binding<Color>
 
-        @ViewBuilder
         private func gradientSection(for component: WritableKeyPath<Color.RGBA, CGFloat>, title: String) -> some View {
             Section {
                 ColorGradientSlider(

--- a/Swiftfin tvOS/Components/PosterButton.swift
+++ b/Swiftfin tvOS/Components/PosterButton.swift
@@ -27,7 +27,6 @@ struct PosterButton<Item: Poster>: View {
     private let label: any View
     private let action: () -> Void
 
-    @ViewBuilder
     private func poster(overlay: some View) -> some View {
         PosterImage(item: item, type: type)
             .frame(maxWidth: .infinity, maxHeight: .infinity)

--- a/Swiftfin tvOS/Extensions/View/View-tvOS.swift
+++ b/Swiftfin tvOS/Extensions/View/View-tvOS.swift
@@ -12,7 +12,6 @@ import SwiftUIIntrospect
 
 extension View {
 
-    @ViewBuilder
     func navigationBarBranding(
         isLoading: Bool = false
     ) -> some View {
@@ -24,19 +23,16 @@ extension View {
     }
 
     /// - Important: This does nothing on tvOS.
-    @ViewBuilder
     func navigationBarTitleDisplayMode(_ mode: NavigationBarItem.TitleDisplayMode) -> some View {
         self
     }
 
     /// - Important: This does nothing on tvOS.
-    @ViewBuilder
     func statusBarHidden() -> some View {
         self
     }
 
     /// - Important: This does nothing on tvOS.
-    @ViewBuilder
     func prefersStatusBarHidden(_ hidden: Bool) -> some View {
         self
     }

--- a/Swiftfin tvOS/Views/ChannelLibraryView/ChannelLibraryView.swift
+++ b/Swiftfin tvOS/Views/ChannelLibraryView/ChannelLibraryView.swift
@@ -19,7 +19,6 @@ struct ChannelLibraryView: View {
     @StateObject
     private var viewModel = ChannelLibraryViewModel()
 
-    @ViewBuilder
     private var contentView: some View {
         CollectionVGrid(
             uniqueElements: viewModel.elements,

--- a/Swiftfin tvOS/Views/ChannelLibraryView/Components/WideChannelGridItem.swift
+++ b/Swiftfin tvOS/Views/ChannelLibraryView/Components/WideChannelGridItem.swift
@@ -25,7 +25,6 @@ extension ChannelLibraryView {
         private var onSelect: () -> Void
         private let timer = Timer.publish(every: 5, on: .main, in: .common).autoconnect()
 
-        @ViewBuilder
         private var channelLogo: some View {
             VStack {
                 ZStack {
@@ -51,7 +50,6 @@ extension ChannelLibraryView {
             }
         }
 
-        @ViewBuilder
         private func programLabel(for program: BaseItemDto) -> some View {
             HStack(alignment: .top, spacing: EdgeInsets.edgePadding / 2) {
                 AlternateLayoutView(alignment: .leading) {
@@ -71,7 +69,6 @@ extension ChannelLibraryView {
             .lineLimit(1)
         }
 
-        @ViewBuilder
         private var programListView: some View {
             VStack(alignment: .leading, spacing: 0) {
                 if let currentProgram = channel.currentProgram {

--- a/Swiftfin tvOS/Views/HomeView/HomeView.swift
+++ b/Swiftfin tvOS/Views/HomeView/HomeView.swift
@@ -22,7 +22,6 @@ struct HomeView: View {
     @Default(.Customization.Home.showRecentlyAdded)
     private var showRecentlyAdded
 
-    @ViewBuilder
     private var contentView: some View {
         ScrollView {
             VStack(alignment: .leading, spacing: 0) {

--- a/Swiftfin tvOS/Views/ItemOverviewView.swift
+++ b/Swiftfin tvOS/Views/ItemOverviewView.swift
@@ -13,7 +13,6 @@ struct ItemOverviewView: View {
 
     let item: BaseItemDto
 
-    @ViewBuilder
     private var content: some View {
         GeometryReader { proxy in
             VStack(alignment: .center) {

--- a/Swiftfin tvOS/Views/ItemView/Components/ActionButtonHStack/Components/TrailerMenu.swift
+++ b/Swiftfin tvOS/Views/ItemView/Components/ActionButtonHStack/Components/TrailerMenu.swift
@@ -70,7 +70,6 @@ extension ItemView {
             }
         }
 
-        @ViewBuilder
         private var trailerMenu: some View {
             Menu(L10n.trailers, systemImage: "movieclapper") {
 

--- a/Swiftfin tvOS/Views/ItemView/Components/EpisodeSelector/Components/EpisodeCard.swift
+++ b/Swiftfin tvOS/Views/ItemView/Components/EpisodeSelector/Components/EpisodeCard.swift
@@ -21,7 +21,6 @@ extension SeriesEpisodeSelector {
         @FocusState
         private var isFocused: Bool
 
-        @ViewBuilder
         private var overlayView: some View {
             ZStack {
                 if let progressLabel = episode.progressLabel {

--- a/Swiftfin tvOS/Views/ItemView/Components/EpisodeSelector/Components/EpisodeContent.swift
+++ b/Swiftfin tvOS/Views/ItemView/Components/EpisodeSelector/Components/EpisodeContent.swift
@@ -23,7 +23,6 @@ extension SeriesEpisodeSelector {
         let header: String
         let content: String
 
-        @ViewBuilder
         private var subHeaderView: some View {
             Text(subHeader)
                 .font(.caption)
@@ -31,7 +30,6 @@ extension SeriesEpisodeSelector {
                 .lineLimit(1)
         }
 
-        @ViewBuilder
         private var headerView: some View {
             Text(header)
                 .font(.footnote)
@@ -41,7 +39,6 @@ extension SeriesEpisodeSelector {
                 .padding(.bottom, 1)
         }
 
-        @ViewBuilder
         private var contentView: some View {
             Text(content)
                 .font(.caption.weight(.light))

--- a/Swiftfin tvOS/Views/ItemView/Components/EpisodeSelector/Components/HStacks/SeasonHStack.swift
+++ b/Swiftfin tvOS/Views/ItemView/Components/EpisodeSelector/Components/HStacks/SeasonHStack.swift
@@ -91,7 +91,6 @@ extension SeriesEpisodeSelector {
 
         // MARK: - Season Button
 
-        @ViewBuilder
         private func seasonButton(season: SeasonItemViewModel) -> some View {
             Button {
                 selection = season.id

--- a/Swiftfin tvOS/Views/ItemView/ItemView.swift
+++ b/Swiftfin tvOS/Views/ItemView/ItemView.swift
@@ -70,7 +70,6 @@ struct ItemView: View {
         CinematicScrollView(viewModel: viewModel, content: content)
     }
 
-    @ViewBuilder
     private var innerBody: some View {
         scrollContainerView(viewModel: viewModel) {
             scrollContentView

--- a/Swiftfin tvOS/Views/MediaSourceInfoView.swift
+++ b/Swiftfin tvOS/Views/MediaSourceInfoView.swift
@@ -19,7 +19,6 @@ struct MediaSourceInfoView: View {
 
     let source: MediaSourceInfo
 
-    @ViewBuilder
     private var content: some View {
         GeometryReader { proxy in
             VStack(alignment: .center) {

--- a/Swiftfin tvOS/Views/PagingLibraryView/Components/LibraryRow.swift
+++ b/Swiftfin tvOS/Views/PagingLibraryView/Components/LibraryRow.swift
@@ -42,7 +42,6 @@ extension PagingLibraryView {
             }
         }
 
-        @ViewBuilder
         private func itemAccessoryView(item: BaseItemDto) -> some View {
             DotHStack {
                 if item.type == .episode, let seasonEpisodeLocator = item.seasonEpisodeLabel {
@@ -80,7 +79,6 @@ extension PagingLibraryView {
             }
         }
 
-        @ViewBuilder
         private var rowContent: some View {
             HStack {
                 VStack(alignment: .leading, spacing: 5) {
@@ -99,7 +97,6 @@ extension PagingLibraryView {
             }
         }
 
-        @ViewBuilder
         private var rowLeading: some View {
             ZStack {
                 Color.clear

--- a/Swiftfin tvOS/Views/PagingLibraryView/PagingLibraryView.swift
+++ b/Swiftfin tvOS/Views/PagingLibraryView/PagingLibraryView.swift
@@ -195,7 +195,6 @@ struct PagingLibraryView<Element: Poster & Identifiable>: View {
 
     // MARK: Portrait Grid Item View
 
-    @ViewBuilder
     private func portraitGridItemView(item: Element) -> some View {
         PosterButton(
             item: item,
@@ -216,7 +215,6 @@ struct PagingLibraryView<Element: Poster & Identifiable>: View {
 
     // MARK: List Item View
 
-    @ViewBuilder
     private func listItemView(item: Element, posterType: PosterDisplayType) -> some View {
         LibraryRow(
             item: item,
@@ -228,7 +226,6 @@ struct PagingLibraryView<Element: Poster & Identifiable>: View {
 
     // MARK: Grid View
 
-    @ViewBuilder
     private var gridView: some View {
         CollectionVGrid(
             uniqueElements: viewModel.elements,
@@ -275,7 +272,6 @@ struct PagingLibraryView<Element: Poster & Identifiable>: View {
 
     // MARK: Content View
 
-    @ViewBuilder
     private var contentView: some View {
 
         innerContent

--- a/Swiftfin tvOS/Views/ProgramsView/ProgramsView.swift
+++ b/Swiftfin tvOS/Views/ProgramsView/ProgramsView.swift
@@ -21,7 +21,6 @@ struct ProgramsView: View {
     @StateObject
     private var programsViewModel = ProgramsViewModel()
 
-    @ViewBuilder
     private var contentView: some View {
         ScrollView(showsIndicators: false) {
             VStack(spacing: 20) {
@@ -52,7 +51,6 @@ struct ProgramsView: View {
         }
     }
 
-    @ViewBuilder
     private func programsSection(
         title: String,
         keyPath: KeyPath<ProgramsViewModel, [BaseItemDto]>

--- a/Swiftfin tvOS/Views/SearchView.swift
+++ b/Swiftfin tvOS/Views/SearchView.swift
@@ -24,7 +24,6 @@ struct SearchView: View {
     @StateObject
     private var viewModel = SearchViewModel()
 
-    @ViewBuilder
     private var suggestionsView: some View {
         VStack(spacing: 20) {
             ForEach(viewModel.suggestions) { item in
@@ -37,7 +36,6 @@ struct SearchView: View {
         }
     }
 
-    @ViewBuilder
     private var resultsView: some View {
         ScrollView(showsIndicators: false) {
             VStack(spacing: 20) {
@@ -145,7 +143,6 @@ struct SearchView: View {
         }
     }
 
-    @ViewBuilder
     private func itemsSection(
         title: String,
         type: BaseItemKind,

--- a/Swiftfin tvOS/Views/SelectUserView/Components/AddUserBottomButton.swift
+++ b/Swiftfin tvOS/Views/SelectUserView/Components/AddUserBottomButton.swift
@@ -21,7 +21,6 @@ extension SelectUserView {
 
         // MARK: View Builders
 
-        @ViewBuilder
         private var label: some View {
             Label(L10n.addUser, systemImage: "plus")
                 .foregroundStyle(Color.primary)

--- a/Swiftfin tvOS/Views/SelectUserView/Components/SelectUserBottomBar.swift
+++ b/Swiftfin tvOS/Views/SelectUserView/Components/SelectUserBottomBar.swift
@@ -58,7 +58,6 @@ extension SelectUserView {
 
         // MARK: - Advanced Menu
 
-        @ViewBuilder
         private var advancedMenu: some View {
             Menu {
                 Button(L10n.editUsers, systemImage: "person.crop.circle") {
@@ -96,7 +95,6 @@ extension SelectUserView {
 
         // MARK: - Delete User Button
 
-        @ViewBuilder
         private var deleteUsersButton: some View {
             Button(
                 L10n.delete,
@@ -110,7 +108,6 @@ extension SelectUserView {
 
         // MARK: - Content View
 
-        @ViewBuilder
         private var contentView: some View {
             HStack(alignment: .top, spacing: 20) {
                 if isEditing {

--- a/Swiftfin tvOS/Views/SelectUserView/Components/ServerSelectionMenu.swift
+++ b/Swiftfin tvOS/Views/SelectUserView/Components/ServerSelectionMenu.swift
@@ -38,7 +38,6 @@ extension SelectUserView {
             self.servers = servers
         }
 
-        @ViewBuilder
         private var label: some View {
             HStack(spacing: 16) {
                 if let selectedServer {

--- a/Swiftfin tvOS/Views/SelectUserView/SelectUserView.swift
+++ b/Swiftfin tvOS/Views/SelectUserView/SelectUserView.swift
@@ -130,7 +130,6 @@ struct SelectUserView: View {
 
     // MARK: - Grid Content View
 
-    @ViewBuilder
     private var userGrid: some View {
         CenteredLazyVGrid(
             data: userItems,
@@ -159,7 +158,6 @@ struct SelectUserView: View {
         }
     }
 
-    @ViewBuilder
     private var addUserButtonGrid: some View {
         CenteredLazyVGrid(
             data: [0],
@@ -177,7 +175,6 @@ struct SelectUserView: View {
 
     // MARK: - User View
 
-    @ViewBuilder
     private var contentView: some View {
         VStack {
             ZStack {
@@ -242,7 +239,6 @@ struct SelectUserView: View {
 
     // MARK: - Connect to Server View
 
-    @ViewBuilder
     private var connectToServerView: some View {
         VStack(spacing: 50) {
             Text(L10n.connectToJellyfinServerStart)

--- a/Swiftfin tvOS/Views/VideoPlayerContainerState/PlaybackControls/Components/ActionButtons/ActionButtons.swift
+++ b/Swiftfin tvOS/Views/VideoPlayerContainerState/PlaybackControls/Components/ActionButtons/ActionButtons.swift
@@ -85,7 +85,6 @@ extension VideoPlayer.PlaybackControls.NavigationBar {
             }
         }
 
-        @ViewBuilder
         private var menuButtons: some View {
             Menu(
                 "Menu",

--- a/Swiftfin tvOS/Views/VideoPlayerContainerState/PlaybackControls/Components/ActionButtons/AudioActionButton.swift
+++ b/Swiftfin tvOS/Views/VideoPlayerContainerState/PlaybackControls/Components/ActionButtons/AudioActionButton.swift
@@ -29,7 +29,6 @@ extension VideoPlayer.PlaybackControls.NavigationBar.ActionButtons {
             }
         }
 
-        @ViewBuilder
         private func content(playbackItem: MediaPlayerItem) -> some View {
             ForEach(playbackItem.audioStreams, id: \.index) { stream in
                 Button {

--- a/Swiftfin tvOS/Views/VideoPlayerContainerState/PlaybackControls/Components/ActionButtons/SubtitleActionButton.swift
+++ b/Swiftfin tvOS/Views/VideoPlayerContainerState/PlaybackControls/Components/ActionButtons/SubtitleActionButton.swift
@@ -29,7 +29,6 @@ extension VideoPlayer.PlaybackControls.NavigationBar.ActionButtons {
             }
         }
 
-        @ViewBuilder
         private func content(playbackItem: MediaPlayerItem) -> some View {
             ForEach(playbackItem.subtitleStreams.prepending(.none), id: \.index) { stream in
                 Button {

--- a/Swiftfin tvOS/Views/VideoPlayerContainerState/PlaybackControls/Components/PlaybackProgress.swift
+++ b/Swiftfin tvOS/Views/VideoPlayerContainerState/PlaybackControls/Components/PlaybackProgress.swift
@@ -59,7 +59,6 @@ extension VideoPlayer.PlaybackControls {
             scrubbedSecondsBox.value
         }
 
-        @ViewBuilder
         private var liveIndicator: some View {
             Text("Live")
                 .font(.subheadline)

--- a/Swiftfin tvOS/Views/VideoPlayerContainerState/PlaybackControls/SupplementContainerView.swift
+++ b/Swiftfin tvOS/Views/VideoPlayerContainerState/PlaybackControls/SupplementContainerView.swift
@@ -29,7 +29,6 @@ struct SupplementContainerView: View {
     @State
     private var currentSupplements: IdentifiedArrayOf<AnyMediaPlayerSupplement> = []
 
-    @ViewBuilder
     private func supplementContainer(for supplement: some MediaPlayerSupplement) -> some View {
         AlternateLayoutView(alignment: .topLeading) {
             Color.clear

--- a/Swiftfin/Components/LetterPickerBar/LetterPickerBar.swift
+++ b/Swiftfin/Components/LetterPickerBar/LetterPickerBar.swift
@@ -16,7 +16,6 @@ struct LetterPickerBar: View {
 
     // MARK: - Body
 
-    @ViewBuilder
     var body: some View {
         VStack(spacing: 0) {
             Spacer()

--- a/Swiftfin/Components/ListTitleSection.swift
+++ b/Swiftfin/Components/ListTitleSection.swift
@@ -80,7 +80,6 @@ struct InsetGroupedListHeader<Content: View>: View {
     private let description: Text?
     private let onLearnMore: (() -> Void)?
 
-    @ViewBuilder
     private var header: some View {
         Button {
             onLearnMore?()

--- a/Swiftfin/Components/PosterButton.swift
+++ b/Swiftfin/Components/PosterButton.swift
@@ -28,7 +28,6 @@ struct PosterButton<Item: Poster>: View {
     private let label: any View
     private let action: (Namespace.ID) -> Void
 
-    @ViewBuilder
     private func posterView(overlay: some View = EmptyView()) -> some View {
         VStack(alignment: .leading) {
             PosterImage(item: item, type: type)

--- a/Swiftfin/Components/PosterHStack.swift
+++ b/Swiftfin/Components/PosterHStack.swift
@@ -36,7 +36,6 @@ struct PosterHStack<Element: Poster, Data: Collection>: View where Data.Element 
         }
     }
 
-    @ViewBuilder
     private var stack: some View {
         CollectionHStack(
             uniqueElements: data,

--- a/Swiftfin/Extensions/View/View-iOS.swift
+++ b/Swiftfin/Extensions/View/View-iOS.swift
@@ -48,7 +48,6 @@ extension View {
         }
     }
 
-    @ViewBuilder
     func navigationBarCloseButton(
         disabled: Bool = false,
         _ action: @escaping () -> Void
@@ -61,7 +60,6 @@ extension View {
         )
     }
 
-    @ViewBuilder
     func navigationBarMenuButton(
         isLoading: Bool = false,
         isHidden: Bool = false,
@@ -77,7 +75,6 @@ extension View {
         )
     }
 
-    @ViewBuilder
     func listRowCornerRadius(_ radius: CGFloat) -> some View {
         introspect(.listCell, on: .iOS(.v16), .iOS(.v17), .iOS(.v18)) { cell in
             cell.layer.cornerRadius = radius

--- a/Swiftfin/Views/AdminDashboardView/APIKeyView/Components/APIKeysRow.swift
+++ b/Swiftfin/Views/AdminDashboardView/APIKeyView/Components/APIKeysRow.swift
@@ -24,7 +24,6 @@ extension APIKeysView {
         let deleteAction: () -> Void
         let replaceAction: () -> Void
 
-        @ViewBuilder
         private var rowContent: some View {
             VStack(alignment: .leading, spacing: 4) {
                 Text(apiKey.appName ?? L10n.unknown)

--- a/Swiftfin/Views/AdminDashboardView/ActiveSessions/ActiveSessionDetailView/Components/StreamSection.swift
+++ b/Swiftfin/Views/AdminDashboardView/ActiveSessions/ActiveSessionDetailView/Components/StreamSection.swift
@@ -49,7 +49,6 @@ extension ActiveSessionDetailView {
 
         // MARK: - Transcoding Details
 
-        @ViewBuilder
         private func getMediaComparison(sourceComponent: String, destinationComponent: String) -> some View {
             HStack {
                 Text(sourceComponent)

--- a/Swiftfin/Views/AdminDashboardView/ActiveSessions/ActiveSessionDetailView/ServerSessionDetailView.swift
+++ b/Swiftfin/Views/AdminDashboardView/ActiveSessions/ActiveSessionDetailView/ServerSessionDetailView.swift
@@ -21,7 +21,6 @@ struct ActiveSessionDetailView: View {
 
     // MARK: Create Idle Content View
 
-    @ViewBuilder
     private func idleContent(session: SessionInfoDto) -> some View {
         List {
             if let userID = session.userID {
@@ -45,7 +44,6 @@ struct ActiveSessionDetailView: View {
 
     // MARK: Create Session Content View
 
-    @ViewBuilder
     private func sessionContent(
         session: SessionInfoDto,
         nowPlayingItem: BaseItemDto,

--- a/Swiftfin/Views/AdminDashboardView/ActiveSessions/ActiveSessionsView/ActiveSessionsView.swift
+++ b/Swiftfin/Views/AdminDashboardView/ActiveSessions/ActiveSessionsView/ActiveSessionsView.swift
@@ -55,7 +55,6 @@ struct ActiveSessionsView: View {
 
     // MARK: - Body
 
-    @ViewBuilder
     var body: some View {
         ZStack {
             switch viewModel.state {
@@ -101,7 +100,6 @@ struct ActiveSessionsView: View {
 
     // MARK: - Active Within Filter Button
 
-    @ViewBuilder
     private var activeWithinFilterButton: some View {
         Picker(selection: $viewModel.activeWithinSeconds) {
             Label(
@@ -149,7 +147,6 @@ struct ActiveSessionsView: View {
 
     // MARK: - Show Inactive Sessions Button
 
-    @ViewBuilder
     private var showInactiveSessionsButton: some View {
         Picker(selection: $viewModel.showSessionType) {
             ForEach(ActiveSessionFilter.allCases, id: \.self) { filter in

--- a/Swiftfin/Views/AdminDashboardView/ActiveSessions/ActiveSessionsView/Components/ActiveSessionProgressSection.swift
+++ b/Swiftfin/Views/AdminDashboardView/ActiveSessions/ActiveSessionsView/Components/ActiveSessionProgressSection.swift
@@ -38,7 +38,6 @@ extension ActiveSessionsView {
             self.showTranscodeReason = showTranscodeReason
         }
 
-        @ViewBuilder
         private var playbackInformation: some View {
             HStack(alignment: .top) {
                 FlowLayout(

--- a/Swiftfin/Views/AdminDashboardView/ActiveSessions/ActiveSessionsView/Components/ActiveSessionRow.swift
+++ b/Swiftfin/Views/AdminDashboardView/ActiveSessions/ActiveSessionsView/Components/ActiveSessionRow.swift
@@ -61,7 +61,6 @@ extension ActiveSessionsView {
             }
         }
 
-        @ViewBuilder
         private func activeSessionDetails(_ nowPlayingItem: BaseItemDto, playState: PlayerStateInfo) -> some View {
             VStack(alignment: .leading, spacing: 4) {
                 Text(session.userName ?? L10n.unknown)
@@ -82,7 +81,6 @@ extension ActiveSessionsView {
             .font(.subheadline)
         }
 
-        @ViewBuilder
         private var idleSessionDetails: some View {
             VStack(alignment: .leading, spacing: 4) {
 

--- a/Swiftfin/Views/AdminDashboardView/ServerActivity/ServerActivityView/Components/ServerActivityEntry.swift
+++ b/Swiftfin/Views/AdminDashboardView/ServerActivity/ServerActivityView/Components/ServerActivityEntry.swift
@@ -54,7 +54,6 @@ extension ServerActivityView {
 
         // MARK: - User Image
 
-        @ViewBuilder
         private var rowContent: some View {
             HStack {
                 VStack(alignment: .leading) {

--- a/Swiftfin/Views/AdminDashboardView/ServerActivity/ServerActivityView/ServerActivityView.swift
+++ b/Swiftfin/Views/AdminDashboardView/ServerActivity/ServerActivityView/ServerActivityView.swift
@@ -96,7 +96,6 @@ struct ServerActivityView: View {
 
     // MARK: - User Filter Button
 
-    @ViewBuilder
     private var userFilterButton: some View {
         Picker(selection: $viewModel.hasUserId) {
             Label(
@@ -133,7 +132,6 @@ struct ServerActivityView: View {
 
     // MARK: - Start Date Button
 
-    @ViewBuilder
     private var startDateButton: some View {
         Button {
             router.route(to: .activityFilters(viewModel: viewModel))

--- a/Swiftfin/Views/AdminDashboardView/ServerDevices/DevicesView/Components/DeviceRow.swift
+++ b/Swiftfin/Views/AdminDashboardView/ServerDevices/DevicesView/Components/DeviceRow.swift
@@ -57,7 +57,6 @@ extension DevicesView {
 
         // MARK: - Device Image View
 
-        @ViewBuilder
         private var deviceImage: some View {
             ZStack {
                 device.type.clientColor
@@ -79,7 +78,6 @@ extension DevicesView {
 
         // MARK: - Row Content
 
-        @ViewBuilder
         private var rowContent: some View {
             HStack {
                 VStack(alignment: .leading) {

--- a/Swiftfin/Views/AdminDashboardView/ServerDevices/DevicesView/DevicesView.swift
+++ b/Swiftfin/Views/AdminDashboardView/ServerDevices/DevicesView/DevicesView.swift
@@ -103,7 +103,6 @@ struct DevicesView: View {
 
     // MARK: - Device List View
 
-    @ViewBuilder
     private var contentView: some View {
         List {
             InsetGroupedListHeader(

--- a/Swiftfin/Views/AdminDashboardView/ServerLogsView/ServerLogsView.swift
+++ b/Swiftfin/Views/AdminDashboardView/ServerLogsView/ServerLogsView.swift
@@ -21,7 +21,6 @@ struct ServerLogsView: View {
     @StateObject
     private var viewModel = ServerLogsViewModel()
 
-    @ViewBuilder
     private var contentView: some View {
         List {
             ListTitleSection(

--- a/Swiftfin/Views/AdminDashboardView/ServerTasks/AddTaskTriggerView/AddTaskTriggerView.swift
+++ b/Swiftfin/Views/AdminDashboardView/ServerTasks/AddTaskTriggerView/AddTaskTriggerView.swift
@@ -53,7 +53,6 @@ struct AddTaskTriggerView: View {
 
     // MARK: - View for TaskTriggerInfoType.daily
 
-    @ViewBuilder
     private var dailyView: some View {
         TimeRow(taskTriggerInfo: $taskTriggerInfo)
     }
@@ -76,7 +75,6 @@ struct AddTaskTriggerView: View {
 
     // MARK: - View for TaskTriggerInfoType.interval
 
-    @ViewBuilder
     private var intervalView: some View {
         IntervalRow(taskTriggerInfo: $taskTriggerInfo)
     }

--- a/Swiftfin/Views/AdminDashboardView/ServerTasks/ServerTasksView/Components/ServerTaskRow.swift
+++ b/Swiftfin/Views/AdminDashboardView/ServerTasks/ServerTasksView/Components/ServerTaskRow.swift
@@ -27,7 +27,6 @@ extension ServerTasksView {
 
         // MARK: - Task Details Section
 
-        @ViewBuilder
         private var taskView: some View {
             VStack(alignment: .leading, spacing: 4) {
 
@@ -69,7 +68,6 @@ extension ServerTasksView {
             }
         }
 
-        @ViewBuilder
         var body: some View {
             Button {
                 isPresentingConfirmation = true

--- a/Swiftfin/Views/AdminDashboardView/ServerTasks/ServerTasksView/ServerTasksView.swift
+++ b/Swiftfin/Views/AdminDashboardView/ServerTasks/ServerTasksView/ServerTasksView.swift
@@ -46,7 +46,6 @@ struct ServerTasksView: View {
 
     // MARK: - Body
 
-    @ViewBuilder
     private var contentView: some View {
         List {
 

--- a/Swiftfin/Views/AdminDashboardView/ServerUsers/ServerUserSettings/ServerUserAccessSchedule/EditAccessScheduleView/Components/EditAccessScheduleRow.swift
+++ b/Swiftfin/Views/AdminDashboardView/ServerUsers/ServerUserSettings/ServerUserAccessSchedule/EditAccessScheduleView/Components/EditAccessScheduleRow.swift
@@ -45,7 +45,6 @@ extension EditAccessScheduleView {
 
         // MARK: - Row Content
 
-        @ViewBuilder
         private var rowContent: some View {
             HStack {
                 VStack(alignment: .leading) {

--- a/Swiftfin/Views/AdminDashboardView/ServerUsers/ServerUserSettings/ServerUserAccessSchedule/EditAccessScheduleView/EditAccessScheduleView.swift
+++ b/Swiftfin/Views/AdminDashboardView/ServerUsers/ServerUserSettings/ServerUserAccessSchedule/EditAccessScheduleView/EditAccessScheduleView.swift
@@ -132,7 +132,6 @@ struct EditAccessScheduleView: View {
 
     // MARK: - Content View
 
-    @ViewBuilder
     var contentView: some View {
         List {
             ListTitleSection(

--- a/Swiftfin/Views/AdminDashboardView/ServerUsers/ServerUserSettings/ServerUserAccessTags/EditServerUserAccessTagsView/EditServerUserAccessTagsView.swift
+++ b/Swiftfin/Views/AdminDashboardView/ServerUsers/ServerUserSettings/ServerUserAccessTags/EditServerUserAccessTagsView/EditServerUserAccessTagsView.swift
@@ -141,7 +141,6 @@ struct EditServerUserAccessTagsView: View {
         .errorMessage($error)
     }
 
-    @ViewBuilder
     private func makeRow(tag: TagWithAccess) -> some View {
         EditAccessTagRow(tag: tag.tag) {
             if isEditing {
@@ -157,7 +156,6 @@ struct EditServerUserAccessTagsView: View {
 
     // MARK: - Content View
 
-    @ViewBuilder
     private var contentView: some View {
         List {
             ListTitleSection(

--- a/Swiftfin/Views/AdminDashboardView/ServerUsers/ServerUserSettings/ServerUserAccessView/ServerUserAccessView.swift
+++ b/Swiftfin/Views/AdminDashboardView/ServerUsers/ServerUserSettings/ServerUserAccessView/ServerUserAccessView.swift
@@ -81,7 +81,6 @@ struct ServerUserMediaAccessView: View {
 
     // MARK: - Content View
 
-    @ViewBuilder
     var contentView: some View {
         List {
             accessView

--- a/Swiftfin/Views/AdminDashboardView/ServerUsers/ServerUserSettings/ServerUserDeviceAccessView/ServerUserDeviceAccessView.swift
+++ b/Swiftfin/Views/AdminDashboardView/ServerUsers/ServerUserSettings/ServerUserDeviceAccessView/ServerUserDeviceAccessView.swift
@@ -88,7 +88,6 @@ struct ServerUserDeviceAccessView: View {
 
     // MARK: - Content View
 
-    @ViewBuilder
     var contentView: some View {
         List {
             InsetGroupedListHeader {

--- a/Swiftfin/Views/AdminDashboardView/ServerUsers/ServerUserSettings/ServerUserLiveTVAccessView/ServerUserLiveTVAccessView.swift
+++ b/Swiftfin/Views/AdminDashboardView/ServerUsers/ServerUserSettings/ServerUserLiveTVAccessView/ServerUserLiveTVAccessView.swift
@@ -83,7 +83,6 @@ struct ServerUserLiveTVAccessView: View {
 
     // MARK: - Content View
 
-    @ViewBuilder
     var contentView: some View {
         List {
             Section(L10n.access) {

--- a/Swiftfin/Views/AdminDashboardView/ServerUsers/ServerUserSettings/ServerUserParentalRatingView/ServerUserParentalRatingView.swift
+++ b/Swiftfin/Views/AdminDashboardView/ServerUsers/ServerUserSettings/ServerUserParentalRatingView/ServerUserParentalRatingView.swift
@@ -89,7 +89,6 @@ struct ServerUserParentalRatingView: View {
 
     // MARK: - Maximum Parental Ratings View
 
-    @ViewBuilder
     private var maxParentalRatingsView: some View {
         Section {
             Picker(L10n.parentalRating, selection: $tempPolicy.maxParentalRating) {
@@ -117,7 +116,6 @@ struct ServerUserParentalRatingView: View {
 
     // MARK: - Block Unrated Items View
 
-    @ViewBuilder
     private var blockUnratedItemsView: some View {
         Section {
             ForEach(UnratedItem.allCases.sorted(using: \.displayTitle), id: \.self) { item in

--- a/Swiftfin/Views/AdminDashboardView/ServerUsers/ServerUserSettings/ServerUserPermissionsView/Components/Sections/SessionsSection.swift
+++ b/Swiftfin/Views/AdminDashboardView/ServerUsers/ServerUserSettings/ServerUserPermissionsView/Components/Sections/SessionsSection.swift
@@ -25,7 +25,6 @@ extension ServerUserPermissionsView {
 
         // MARK: - Failed Login Selection View
 
-        @ViewBuilder
         private var FailedLoginsView: some View {
             Section {
                 Picker(
@@ -72,7 +71,6 @@ extension ServerUserPermissionsView {
 
         // MARK: - Failed Login Selection Button
 
-        @ViewBuilder
         private func MaxFailedLoginsButton() -> some View {
             ChevronButton(
                 L10n.customFailedLogins,
@@ -92,7 +90,6 @@ extension ServerUserPermissionsView {
 
         // MARK: - Failed Login Validation
 
-        @ViewBuilder
         private var MaxSessionsView: some View {
             Section {
                 Picker(
@@ -125,7 +122,6 @@ extension ServerUserPermissionsView {
             }
         }
 
-        @ViewBuilder
         private func MaxSessionsButton() -> some View {
             ChevronButton(
                 L10n.customSessions,

--- a/Swiftfin/Views/AdminDashboardView/ServerUsers/ServerUserSettings/ServerUserPermissionsView/ServerUserPermissionsView.swift
+++ b/Swiftfin/Views/AdminDashboardView/ServerUsers/ServerUserSettings/ServerUserPermissionsView/ServerUserPermissionsView.swift
@@ -93,7 +93,6 @@ struct ServerUserPermissionsView: View {
 
     // MARK: - Permissions List View
 
-    @ViewBuilder
     var permissionsListView: some View {
         List {
             StatusSection(policy: $tempPolicy)

--- a/Swiftfin/Views/AdminDashboardView/ServerUsers/ServerUsersView/Components/ServerUsersRow.swift
+++ b/Swiftfin/Views/AdminDashboardView/ServerUsers/ServerUsersView/Components/ServerUsersRow.swift
@@ -72,7 +72,6 @@ extension ServerUsersView {
 
         // MARK: - User Image View
 
-        @ViewBuilder
         private var userImage: some View {
             ZStack {
                 UserProfileImage(
@@ -91,7 +90,6 @@ extension ServerUsersView {
 
         // MARK: - Row Content
 
-        @ViewBuilder
         private var rowContent: some View {
             HStack {
                 VStack(alignment: .leading) {

--- a/Swiftfin/Views/AdminDashboardView/ServerUsers/ServerUsersView/ServerUsersView.swift
+++ b/Swiftfin/Views/AdminDashboardView/ServerUsers/ServerUsersView/ServerUsersView.swift
@@ -158,7 +158,6 @@ struct ServerUsersView: View {
 
     // MARK: - User List View
 
-    @ViewBuilder
     private var userListView: some View {
         List {
             InsetGroupedListHeader(

--- a/Swiftfin/Views/ChannelLibraryView/ChannelLibraryView.swift
+++ b/Swiftfin/Views/ChannelLibraryView/ChannelLibraryView.swift
@@ -99,7 +99,6 @@ struct ChannelLibraryView: View {
         }
     }
 
-    @ViewBuilder
     private var contentView: some View {
         CollectionVGrid(
             uniqueElements: viewModel.elements,

--- a/Swiftfin/Views/ChannelLibraryView/Components/DetailedChannelView.swift
+++ b/Swiftfin/Views/ChannelLibraryView/Components/DetailedChannelView.swift
@@ -29,7 +29,6 @@ extension ChannelLibraryView {
 
         private let timer = Timer.publish(every: 5, on: .main, in: .common).autoconnect()
 
-        @ViewBuilder
         private var channelLogo: some View {
             VStack {
                 PosterImage(
@@ -44,7 +43,6 @@ extension ChannelLibraryView {
             }
         }
 
-        @ViewBuilder
         private func programLabel(for program: BaseItemDto) -> some View {
             HStack(alignment: .top) {
                 AlternateLayoutView(alignment: .leading) {
@@ -64,7 +62,6 @@ extension ChannelLibraryView {
             .lineLimit(1)
         }
 
-        @ViewBuilder
         private var programListView: some View {
             VStack(alignment: .leading, spacing: 0) {
                 if let currentProgram = channel.currentProgram {

--- a/Swiftfin/Views/HomeView/HomeView.swift
+++ b/Swiftfin/Views/HomeView/HomeView.swift
@@ -29,7 +29,6 @@ struct HomeView: View {
     @StateObject
     private var viewModel = HomeViewModel()
 
-    @ViewBuilder
     private var contentView: some View {
         ScrollView {
             VStack(alignment: .leading, spacing: 10) {

--- a/Swiftfin/Views/ItemEditorView/IdentifyItemView/Components/RemoteSearchResultView.swift
+++ b/Swiftfin/Views/ItemEditorView/IdentifyItemView/Components/RemoteSearchResultView.swift
@@ -32,7 +32,6 @@ extension IdentifyItemView {
 
         // MARK: - Body
 
-        @ViewBuilder
         private var header: some View {
             Section {
                 HStack(alignment: .bottom, spacing: 12) {

--- a/Swiftfin/Views/ItemEditorView/IdentifyItemView/IdentifyItemView.swift
+++ b/Swiftfin/Views/ItemEditorView/IdentifyItemView/IdentifyItemView.swift
@@ -87,7 +87,6 @@ struct IdentifyItemView: View {
 
     // MARK: - Content View
 
-    @ViewBuilder
     private var contentView: some View {
         Form {
             ListTitleSection(
@@ -172,7 +171,6 @@ struct IdentifyItemView: View {
 
     // MARK: - Result Image
 
-    @ViewBuilder
     static func resultImage(_ url: URL?) -> some View {
         ZStack {
             Color.clear

--- a/Swiftfin/Views/ItemEditorView/ItemEditorView.swift
+++ b/Swiftfin/Views/ItemEditorView/ItemEditorView.swift
@@ -97,7 +97,6 @@ struct ItemEditorView: View {
 
     // MARK: - Refresh Button
 
-    @ViewBuilder
     private var refreshButtonView: some View {
         Section {
             Button {
@@ -163,7 +162,6 @@ struct ItemEditorView: View {
 
     // MARK: - Editable Metadata Components Routing Buttons
 
-    @ViewBuilder
     private var editComponentsView: some View {
         Section {
             ChevronButton(L10n.genres) {

--- a/Swiftfin/Views/ItemEditorView/ItemImages/AddItemImageView.swift
+++ b/Swiftfin/Views/ItemEditorView/ItemImages/AddItemImageView.swift
@@ -147,7 +147,6 @@ struct AddItemImageView: View {
 
     // MARK: - Poster Image Button
 
-    @ViewBuilder
     private func imageButton(_ image: RemoteImageInfo) -> some View {
         Button {
             router.route(
@@ -166,7 +165,6 @@ struct AddItemImageView: View {
 
     // MARK: - Poster Image
 
-    @ViewBuilder
     private func posterImage(
         _ posterImageInfo: RemoteImageInfo?,
         posterStyle: PosterDisplayType

--- a/Swiftfin/Views/ItemEditorView/ItemImages/ItemImageDetailsView/ItemImageDetailsView.swift
+++ b/Swiftfin/Views/ItemEditorView/ItemImages/ItemImageDetailsView/ItemImageDetailsView.swift
@@ -84,7 +84,6 @@ struct ItemImageDetailsView: View {
 
     // MARK: - Content View
 
-    @ViewBuilder
     private var contentView: some View {
         List {
             HeaderSection(

--- a/Swiftfin/Views/ItemEditorView/ItemImages/ItemImagesView.swift
+++ b/Swiftfin/Views/ItemEditorView/ItemImages/ItemImagesView.swift
@@ -89,7 +89,6 @@ struct ItemImagesView: View {
 
     // MARK: - Image View
 
-    @ViewBuilder
     private var imageView: some View {
         ScrollView {
             ForEach(ImageType.allCases.sorted(using: \.rawValue), id: \.self) { imageType in
@@ -132,7 +131,6 @@ struct ItemImagesView: View {
 
     // MARK: - Section Header
 
-    @ViewBuilder
     private func sectionHeader(for imageType: ImageType) -> some View {
         HStack {
             Text(imageType.displayTitle)
@@ -168,7 +166,6 @@ struct ItemImagesView: View {
 
     // TODO: instead of using `posterStyle`, should be sized based on
     //       the image type and just ignore and poster styling
-    @ViewBuilder
     private func imageButton(
         imageInfo: ImageInfo,
         onSelect: @escaping () -> Void

--- a/Swiftfin/Views/ItemEditorView/ItemMetadata/EditItemElementView/Components/EditItemElementRow.swift
+++ b/Swiftfin/Views/ItemEditorView/ItemMetadata/EditItemElementView/Components/EditItemElementRow.swift
@@ -51,7 +51,6 @@ extension EditItemElementView {
 
         // MARK: - Row Content
 
-        @ViewBuilder
         private var rowContent: some View {
             HStack {
                 VStack(alignment: .leading) {

--- a/Swiftfin/Views/ItemEditorView/ItemMetadata/EditMetadataView/Components/Sections/SeriesSection.swift
+++ b/Swiftfin/Views/ItemEditorView/ItemMetadata/EditMetadataView/Components/Sections/SeriesSection.swift
@@ -48,7 +48,6 @@ extension EditMetadataView {
 
         // MARK: - Series Status View
 
-        @ViewBuilder
         private var seriesStatusView: some View {
             Picker(
                 L10n.status,
@@ -67,7 +66,6 @@ extension EditMetadataView {
 
         // MARK: - Air Time View
 
-        @ViewBuilder
         private var airTimeView: some View {
             DatePicker(
                 L10n.airTime,
@@ -83,7 +81,6 @@ extension EditMetadataView {
 
         // MARK: - Air Days View
 
-        @ViewBuilder
         private var airDaysView: some View {
             ForEach(DayOfWeek.allCases, id: \.self) { field in
                 Toggle(
@@ -97,7 +94,6 @@ extension EditMetadataView {
 
         // MARK: - Run Time View
 
-        @ViewBuilder
         private var runTimeView: some View {
             ChevronButton(
                 L10n.runtime,

--- a/Swiftfin/Views/ItemEditorView/ItemMetadata/EditMetadataView/EditMetadataView.swift
+++ b/Swiftfin/Views/ItemEditorView/ItemMetadata/EditMetadataView/EditMetadataView.swift
@@ -46,7 +46,6 @@ struct EditMetadataView: View {
 
     // MARK: - Body
 
-    @ViewBuilder
     var body: some View {
         ZStack {
             switch viewModel.state {
@@ -86,7 +85,6 @@ struct EditMetadataView: View {
 
     // MARK: - Content View
 
-    @ViewBuilder
     private var contentView: some View {
         Form {
             TitleSection(item: $tempItem)

--- a/Swiftfin/Views/ItemEditorView/ItemSubtitles/Components/ItemSubtitleButton.swift
+++ b/Swiftfin/Views/ItemEditorView/ItemSubtitles/Components/ItemSubtitleButton.swift
@@ -52,7 +52,6 @@ extension ItemSubtitlesView {
 
         // MARK: - Row Content
 
-        @ViewBuilder
         private var rowContent: some View {
             HStack {
                 Text(subtitle.displayTitle ?? L10n.unknown)

--- a/Swiftfin/Views/ItemEditorView/ItemSubtitles/ItemSubtitleSearchView/ItemSubtitleSearchView.swift
+++ b/Swiftfin/Views/ItemEditorView/ItemSubtitles/ItemSubtitleSearchView/ItemSubtitleSearchView.swift
@@ -102,7 +102,6 @@ struct ItemSubtitleSearchView: View {
 
     // MARK: - Content View
 
-    @ViewBuilder
     private var contentView: some View {
         Form {
             searchSection
@@ -112,7 +111,6 @@ struct ItemSubtitleSearchView: View {
 
     // MARK: - Search Section
 
-    @ViewBuilder
     private var searchSection: some View {
         Section(L10n.options) {
             CulturePicker(L10n.language, threeLetterISOLanguageName: $language)
@@ -133,7 +131,6 @@ struct ItemSubtitleSearchView: View {
 
     // MARK: - Results Section
 
-    @ViewBuilder
     private var resultsSection: some View {
         Section(L10n.search) {
             if viewModel.searchResults.isEmpty {

--- a/Swiftfin/Views/ItemEditorView/ItemSubtitles/ItemSubtitleUploadView/ItemSubtitleUploadView.swift
+++ b/Swiftfin/Views/ItemEditorView/ItemSubtitles/ItemSubtitleUploadView/ItemSubtitleUploadView.swift
@@ -110,7 +110,6 @@ struct ItemSubtitleUploadView: View {
 
     // MARK: - Content View
 
-    @ViewBuilder
     private var contentView: some View {
         Form {
             Section(L10n.options) {

--- a/Swiftfin/Views/ItemEditorView/ItemSubtitles/ItemSubtitlesView.swift
+++ b/Swiftfin/Views/ItemEditorView/ItemSubtitles/ItemSubtitlesView.swift
@@ -160,7 +160,6 @@ struct ItemSubtitlesView: View {
 
     // MARK: - Content Views
 
-    @ViewBuilder
     private var contentView: some View {
         List {
             ListTitleSection(

--- a/Swiftfin/Views/ItemView/Components/ActionButtonHStack/Components/TrailerMenu.swift
+++ b/Swiftfin/Views/ItemView/Components/ActionButtonHStack/Components/TrailerMenu.swift
@@ -58,7 +58,6 @@ extension ItemView {
 
         // MARK: - Single Trailer Button
 
-        @ViewBuilder
         private var trailerButton: some View {
             Button(
                 L10n.trailers,
@@ -76,7 +75,6 @@ extension ItemView {
 
         // MARK: - Multiple Trailers Menu Button
 
-        @ViewBuilder
         private var trailerMenu: some View {
             Menu(L10n.trailers, systemImage: "movieclapper") {
 

--- a/Swiftfin/Views/ItemView/Components/EpisodeSelector/Components/EpisodeContent.swift
+++ b/Swiftfin/Views/ItemView/Components/EpisodeSelector/Components/EpisodeContent.swift
@@ -21,7 +21,6 @@ extension SeriesEpisodeSelector {
         let content: String
         let action: () -> Void
 
-        @ViewBuilder
         private var subHeaderView: some View {
             Text(subHeader)
                 .font(.footnote)
@@ -29,7 +28,6 @@ extension SeriesEpisodeSelector {
                 .lineLimit(1)
         }
 
-        @ViewBuilder
         private var headerView: some View {
             Text(header)
                 .font(.body)
@@ -39,7 +37,6 @@ extension SeriesEpisodeSelector {
                 .padding(.bottom, 1)
         }
 
-        @ViewBuilder
         private var contentView: some View {
             Text(content)
                 .font(.caption)

--- a/Swiftfin/Views/ItemView/ItemView.swift
+++ b/Swiftfin/Views/ItemView/ItemView.swift
@@ -125,7 +125,6 @@ struct ItemView: View {
         }
     }
 
-    @ViewBuilder
     private var innerBody: some View {
         scrollContainerView(viewModel: viewModel) {
             scrollContentView

--- a/Swiftfin/Views/ItemView/ScrollViews/CompactPortraitScrollView.swift
+++ b/Swiftfin/Views/ItemView/ScrollViews/CompactPortraitScrollView.swift
@@ -51,7 +51,6 @@ extension ItemView {
                 .animation(.linear(duration: 0.1), value: imageSource.url?.hashValue)
         }
 
-        @ViewBuilder
         private var headerView: some View {
             GeometryReader { proxy in
                 withHeaderImageItem { imageSource, bottomColor in
@@ -114,7 +113,6 @@ extension ItemView.CompactPosterScrollView {
         @ObservedObject
         var viewModel: ItemViewModel
 
-        @ViewBuilder
         private var rightShelfView: some View {
             VStack(alignment: .leading) {
 

--- a/Swiftfin/Views/ItemView/ScrollViews/SimpleScrollView.swift
+++ b/Swiftfin/Views/ItemView/ScrollViews/SimpleScrollView.swift
@@ -33,7 +33,6 @@ extension ItemView {
             self.viewModel = viewModel
         }
 
-        @ViewBuilder
         private var shelfView: some View {
             VStack(alignment: .center, spacing: 10) {
                 if let parentTitle = viewModel.item.parentTitle {
@@ -100,7 +99,6 @@ extension ItemView {
             }
         }
 
-        @ViewBuilder
         private var header: some View {
             VStack(alignment: .center) {
                 ZStack {

--- a/Swiftfin/Views/ItemView/ScrollViews/iPadOSCinematicScrollView.swift
+++ b/Swiftfin/Views/ItemView/ScrollViews/iPadOSCinematicScrollView.swift
@@ -59,7 +59,6 @@ extension ItemView {
                 .animation(.linear(duration: 0.1), value: imageSource.url?.hashValue)
         }
 
-        @ViewBuilder
         private var headerView: some View {
             withHeaderImageItem { imageSource, bottomColor in
                 ImageView(imageSource)

--- a/Swiftfin/Views/PagingLibraryView/Components/LibraryRow.swift
+++ b/Swiftfin/Views/PagingLibraryView/Components/LibraryRow.swift
@@ -33,7 +33,6 @@ extension PagingLibraryView {
             self.posterType = posterType
         }
 
-        @ViewBuilder
         private func itemAccessoryView(item: BaseItemDto) -> some View {
             DotHStack {
                 if item.type == .episode, let seasonEpisodeLocator = item.seasonEpisodeLabel {
@@ -71,7 +70,6 @@ extension PagingLibraryView {
             }
         }
 
-        @ViewBuilder
         private var rowContent: some View {
             HStack {
                 VStack(alignment: .leading, spacing: 5) {
@@ -91,7 +89,6 @@ extension PagingLibraryView {
             }
         }
 
-        @ViewBuilder
         private var rowLeading: some View {
             PosterImage(
                 item: item,

--- a/Swiftfin/Views/PagingLibraryView/PagingLibraryView.swift
+++ b/Swiftfin/Views/PagingLibraryView/PagingLibraryView.swift
@@ -180,7 +180,6 @@ struct PagingLibraryView<Element: Poster>: View {
     // Note: if parent is a folders then other items will have labels,
     //       so an empty content view is necessary
 
-    @ViewBuilder
     private func gridItemView(item: Element, posterType: PosterDisplayType) -> some View {
         PosterButton(
             item: item,
@@ -199,7 +198,6 @@ struct PagingLibraryView<Element: Poster>: View {
         }
     }
 
-    @ViewBuilder
     private func listItemView(item: Element, posterType: PosterDisplayType) -> some View {
         LibraryRow(
             item: item,
@@ -209,7 +207,6 @@ struct PagingLibraryView<Element: Poster>: View {
         }
     }
 
-    @ViewBuilder
     private var elementsView: some View {
         CollectionVGrid(
             uniqueElements: viewModel.elements,

--- a/Swiftfin/Views/ProgramsView/ProgramsView.swift
+++ b/Swiftfin/Views/ProgramsView/ProgramsView.swift
@@ -22,7 +22,6 @@ struct ProgramsView: View {
     @StateObject
     private var programsViewModel = ProgramsViewModel()
 
-    @ViewBuilder
     private var liveTVSectionScrollView: some View {
         ScrollView(.horizontal, showsIndicators: false) {
             HStack {
@@ -39,7 +38,6 @@ struct ProgramsView: View {
 
     // TODO: probably make own pill view
     //       - see if could merge with item view pills
-    @ViewBuilder
     private func liveTVSectionPill(title: String, systemImage: String, onSelect: @escaping () -> Void) -> some View {
         Button {
             onSelect()
@@ -55,7 +53,6 @@ struct ProgramsView: View {
         }
     }
 
-    @ViewBuilder
     private var contentView: some View {
         ScrollView(showsIndicators: false) {
             VStack(spacing: 20) {
@@ -94,7 +91,6 @@ struct ProgramsView: View {
         }
     }
 
-    @ViewBuilder
     private func programsSection(
         title: String,
         keyPath: KeyPath<ProgramsViewModel, [BaseItemDto]>

--- a/Swiftfin/Views/SearchView.swift
+++ b/Swiftfin/Views/SearchView.swift
@@ -37,7 +37,6 @@ struct SearchView: View {
     @StateObject
     private var viewModel = SearchViewModel()
 
-    @ViewBuilder
     private var suggestionsView: some View {
         VStack(spacing: 20) {
             ForEach(viewModel.suggestions) { item in
@@ -48,7 +47,6 @@ struct SearchView: View {
         }
     }
 
-    @ViewBuilder
     private var resultsView: some View {
         ScrollView(showsIndicators: false) {
             VStack(spacing: 20) {
@@ -156,7 +154,6 @@ struct SearchView: View {
         }
     }
 
-    @ViewBuilder
     private func itemsSection(
         title: String,
         type: BaseItemKind,

--- a/Swiftfin/Views/SelectUserView/Components/AddUserGridButton.swift
+++ b/Swiftfin/Views/SelectUserView/Components/AddUserGridButton.swift
@@ -22,7 +22,6 @@ extension SelectUserView {
         let servers: OrderedSet<ServerState>
         let action: (ServerState) -> Void
 
-        @ViewBuilder
         private var label: some View {
             VStack(alignment: .center) {
                 ZStack {

--- a/Swiftfin/Views/SelectUserView/Components/AddUserListRow.swift
+++ b/Swiftfin/Views/SelectUserView/Components/AddUserListRow.swift
@@ -22,7 +22,6 @@ extension SelectUserView {
         let servers: OrderedSet<ServerState>
         let action: (ServerState) -> Void
 
-        @ViewBuilder
         private var rowContent: some View {
             Text(L10n.addUser)
                 .font(.title3)
@@ -33,7 +32,6 @@ extension SelectUserView {
                 .frame(maxWidth: .infinity, alignment: .leading)
         }
 
-        @ViewBuilder
         private var rowLeading: some View {
             ZStack {
                 Group {
@@ -54,7 +52,6 @@ extension SelectUserView {
             .padding(.vertical, 8)
         }
 
-        @ViewBuilder
         private var label: some View {
             ListRow(insets: .init(horizontal: EdgeInsets.edgePadding)) {
                 rowLeading

--- a/Swiftfin/Views/SelectUserView/Components/UserListRow.swift
+++ b/Swiftfin/Views/SelectUserView/Components/UserListRow.swift
@@ -50,7 +50,6 @@ extension SelectUserView {
             return isSelected ? .primary : .secondary
         }
 
-        @ViewBuilder
         private var personView: some View {
             ZStack {
                 Group {
@@ -69,7 +68,6 @@ extension SelectUserView {
             .aspectRatio(1, contentMode: .fill)
         }
 
-        @ViewBuilder
         private var rowContent: some View {
             HStack {
 

--- a/Swiftfin/Views/SelectUserView/SelectUserView.swift
+++ b/Swiftfin/Views/SelectUserView/SelectUserView.swift
@@ -166,7 +166,6 @@ struct SelectUserView: View {
 
     // MARK: - Advanced Menu
 
-    @ViewBuilder
     private var advancedMenu: some View {
         Menu(L10n.advanced, systemImage: "gearshape.fill") {
 
@@ -223,7 +222,6 @@ struct SelectUserView: View {
         }
     }
 
-    @ViewBuilder
     private var addUserGridButtonView: some View {
         AddUserGridButton(
             selectedServer: selectedServer,
@@ -305,7 +303,6 @@ struct SelectUserView: View {
 
     // MARK: - List Content View
 
-    @ViewBuilder
     private var listContentView: some View {
         List {
             let userItems = self.userItems
@@ -360,7 +357,6 @@ struct SelectUserView: View {
 
     // MARK: - User View
 
-    @ViewBuilder
     private var contentView: some View {
         VStack(spacing: 0) {
             ZStack {
@@ -428,7 +424,6 @@ struct SelectUserView: View {
 
     // MARK: - Connect to Server View
 
-    @ViewBuilder
     private var connectToServerView: some View {
         VStack(spacing: 10) {
             Text(L10n.connectToJellyfinServerStart)

--- a/Swiftfin/Views/SettingsView/UserProfileSettingsView/QuickConnectAuthorizeView.swift
+++ b/Swiftfin/Views/SettingsView/UserProfileSettingsView/QuickConnectAuthorizeView.swift
@@ -49,7 +49,6 @@ struct QuickConnectAuthorizeView: View {
 
     // MARK: Display the User Being Authenticated
 
-    @ViewBuilder
     private var loginUserRow: some View {
         HStack {
             UserProfileImage(

--- a/Swiftfin/Views/VideoPlayerContainerView/PlaybackControls/Components/NavigationBar/ActionButtons/ActionButtons.swift
+++ b/Swiftfin/Views/VideoPlayerContainerView/PlaybackControls/Components/NavigationBar/ActionButtons/ActionButtons.swift
@@ -85,7 +85,6 @@ extension VideoPlayer.PlaybackControls.NavigationBar {
             }
         }
 
-        @ViewBuilder
         private var compactView: some View {
             Menu(
                 L10n.menu,
@@ -107,7 +106,6 @@ extension VideoPlayer.PlaybackControls.NavigationBar {
             }
         }
 
-        @ViewBuilder
         private var regularView: some View {
             HStack(spacing: 0) {
                 ForEach(

--- a/Swiftfin/Views/VideoPlayerContainerView/PlaybackControls/Components/NavigationBar/ActionButtons/AudioActionButton.swift
+++ b/Swiftfin/Views/VideoPlayerContainerView/PlaybackControls/Components/NavigationBar/ActionButtons/AudioActionButton.swift
@@ -29,7 +29,6 @@ extension VideoPlayer.PlaybackControls.NavigationBar.ActionButtons {
             }
         }
 
-        @ViewBuilder
         private func content(playbackItem: MediaPlayerItem) -> some View {
             Picker(L10n.audio, selection: $selectedAudioStreamIndex) {
                 ForEach(playbackItem.audioStreams, id: \.index) { stream in

--- a/Swiftfin/Views/VideoPlayerContainerView/PlaybackControls/Components/NavigationBar/ActionButtons/PlaybackQualityActionButton.swift
+++ b/Swiftfin/Views/VideoPlayerContainerView/PlaybackControls/Components/NavigationBar/ActionButtons/PlaybackQualityActionButton.swift
@@ -47,7 +47,6 @@ extension VideoPlayer.PlaybackControls.NavigationBar.ActionButtons {
 
         // TODO: transition to Picker
         //       - need local State value
-        @ViewBuilder
         private func content(playbackItem: MediaPlayerItem) -> some View {
             ForEach(PlaybackBitrate.allCases, id: \.rawValue) { bitrate in
                 Button {

--- a/Swiftfin/Views/VideoPlayerContainerView/PlaybackControls/Components/NavigationBar/ActionButtons/SubtitleActionButton.swift
+++ b/Swiftfin/Views/VideoPlayerContainerView/PlaybackControls/Components/NavigationBar/ActionButtons/SubtitleActionButton.swift
@@ -29,7 +29,6 @@ extension VideoPlayer.PlaybackControls.NavigationBar.ActionButtons {
             }
         }
 
-        @ViewBuilder
         private func content(playbackItem: MediaPlayerItem) -> some View {
             Picker(L10n.subtitles, selection: $selectedSubtitleStreamIndex) {
                 ForEach(playbackItem.subtitleStreams.prepending(.none), id: \.index) { stream in

--- a/Swiftfin/Views/VideoPlayerContainerView/PlaybackControls/Components/NavigationBar/NavigationBar.swift
+++ b/Swiftfin/Views/VideoPlayerContainerView/PlaybackControls/Components/NavigationBar/NavigationBar.swift
@@ -85,7 +85,6 @@ extension VideoPlayer.PlaybackControls.NavigationBar {
             return (title: item.displayTitle, subtitle: nil)
         }
 
-        @ViewBuilder
         private func _subtitle(_ subtitle: String) -> some View {
             Text(subtitle)
                 .font(.subheadline)

--- a/Swiftfin/Views/VideoPlayerContainerView/PlaybackControls/Components/PlaybackButtons.swift
+++ b/Swiftfin/Views/VideoPlayerContainerView/PlaybackControls/Components/PlaybackButtons.swift
@@ -38,7 +38,6 @@ extension VideoPlayer.PlaybackControls {
             !manager.item.isLiveStream
         }
 
-        @ViewBuilder
         private var playButton: some View {
             Button {
                 switch manager.playbackRequestStatus {
@@ -64,7 +63,6 @@ extension VideoPlayer.PlaybackControls {
             }
         }
 
-        @ViewBuilder
         private var jumpForwardButton: some View {
             Button {
                 manager.proxy?.jumpForward(jumpForwardInterval.rawValue)
@@ -80,7 +78,6 @@ extension VideoPlayer.PlaybackControls {
             .foregroundStyle(.primary)
         }
 
-        @ViewBuilder
         private var jumpBackwardButton: some View {
             Button {
                 manager.proxy?.jumpBackward(jumpBackwardInterval.rawValue)

--- a/Swiftfin/Views/VideoPlayerContainerView/PlaybackControls/Components/PlaybackProgress/PlaybackProgress.swift
+++ b/Swiftfin/Views/VideoPlayerContainerView/PlaybackControls/Components/PlaybackProgress/PlaybackProgress.swift
@@ -77,7 +77,6 @@ extension VideoPlayer.PlaybackControls {
             return clamp(videoPlayerProxy.videoSize.value.aspectRatio, min: 0.25, max: 4)
         }
 
-        @ViewBuilder
         private var liveIndicator: some View {
             Text("Live")
                 .font(.subheadline)
@@ -91,7 +90,6 @@ extension VideoPlayer.PlaybackControls {
                 }
         }
 
-        @ViewBuilder
         private var slowScrubbingIndicator: some View {
             HStack {
                 Image(systemName: "backward.fill")
@@ -101,7 +99,6 @@ extension VideoPlayer.PlaybackControls {
             .font(.caption)
         }
 
-        @ViewBuilder
         private var capsuleSlider: some View {
             AlternateLayoutView {
                 EmptyHitTestView()

--- a/Swiftfin/Views/VideoPlayerContainerView/PlaybackControls/Components/PlaybackProgress/SplitTimestamp.swift
+++ b/Swiftfin/Views/VideoPlayerContainerView/PlaybackControls/Components/PlaybackProgress/SplitTimestamp.swift
@@ -34,7 +34,6 @@ extension VideoPlayer.PlaybackControls {
             scrubbedSecondsBox.value
         }
 
-        @ViewBuilder
         private var leadingTimestamp: some View {
             HStack(spacing: 2) {
 
@@ -50,7 +49,6 @@ extension VideoPlayer.PlaybackControls {
             }
         }
 
-        @ViewBuilder
         private var trailingTimestamp: some View {
             HStack(spacing: 2) {
                 Group {

--- a/Swiftfin/Views/VideoPlayerContainerView/SupplementContainerView/SupplementContainerView.swift
+++ b/Swiftfin/Views/VideoPlayerContainerView/SupplementContainerView/SupplementContainerView.swift
@@ -37,7 +37,6 @@ extension VideoPlayer.UIVideoPlayerContainerViewController {
             containerState.isScrubbing
         }
 
-        @ViewBuilder
         private func supplementContainer(for supplement: some MediaPlayerSupplement) -> some View {
             AlternateLayoutView(alignment: .topLeading) {
                 Color.clear


### PR DESCRIPTION
### Summary

Enables `redundantViewBuilder` in `.swiftformat` to remove where these are not needed. Then, lint the project to clean these up. Some of this I was doing [here](https://github.com/jellyfin/Swiftfin/pull/1902) but this separates this into its own PR.

**Let me know if this flag is intentionally disabled and I can close this branch out without merge!**

### Special Considerations

There are only 2 files where removing this caused issues. Neither of them are currently in use and are overridden by any [tvOS Player implementation](https://github.com/jellyfin/Swiftfin/pull/1902) we land on. 

1. `Shared/Objects/MediaPlayerManager/Supplements/PlaybackInformationSupplement.swift`
2. `Shared/Objects/MediaPlayerManager/Supplements/PlaybackRateMediaPlayerSupplement.swift`

For these, just replace Empty `{}` with what iOS is using for this to be overridden when https://github.com/jellyfin/Swiftfin/issues/818 is resolved or when we implement the `PlaybackRateMediaPlayerSupplement` which is WIP for iOS as well.