### PR TITLE
Enable additional sort by options for library views

### DIFF
--- a/Shared/Objects/ItemFilter/ItemSortBy.swift
+++ b/Shared/Objects/ItemFilter/ItemSortBy.swift
@@ -77,10 +77,18 @@ extension ItemSortBy: Displayable, SupportedCaseIterable {
 
     static var supportedCases: [ItemSortBy] {
         [
-            .premiereDate,
+            .default,
             .name,
             .sortName,
+            .premiereDate,
+            .dateCreated,
             .dateLastContentAdded,
+            .communityRating,
+            .criticRating,
+            .productionYear,
+            .runtime,
+            .playCount,
+            .datePlayed,
             .random,
         ]
     }


### PR DESCRIPTION
## Summary
- Expands `ItemSortBy.supportedCases` to include commonly useful sort options already supported by the Jellyfin API
- Adds: `.default`, `.dateCreated`, `.communityRating`, `.criticRating`, `.productionYear`, `.runtime`, `.playCount`, `.datePlayed`
- All display titles and localization strings were already defined — only the `supportedCases` array needed updating

Closes #1523

## Changes
| File | Change |
|------|--------|
| `Shared/Objects/ItemFilter/ItemSortBy.swift` | Expanded `supportedCases` from 5 to 13 options |

## Notes
- Intentionally excluded sort options that may cause issues with certain `BaseItemKind` types (e.g., `.similarityScore` which can return 500 errors per issue discussion)
- Kept `.random` at the end as it's a special case
- Added `.default` as the first option per the suggestion in the issue

## Test plan
- [ ] Verify all new sort options appear in the filter drawer
- [ ] Test sorting by each new option on movies, series, and collections
- [ ] Confirm no API errors (500s) with the selected options
- [ ] Verify sort order (ascending/descending) works correctly with each option

🤖 Generated with [Claude Code](https://claude.com/claude-code)