### PR TITLE
feat: enable more library sort-by options

### DIFF
--- a/Shared/Objects/ItemFilter/ItemSortBy.swift
+++ b/Shared/Objects/ItemFilter/ItemSortBy.swift
@@ -80,7 +80,15 @@ extension ItemSortBy: Displayable, SupportedCaseIterable {
             .premiereDate,
             .name,
             .sortName,
+            .communityRating,
+            .criticRating,
+            .dateCreated,
             .dateLastContentAdded,
+            .datePlayed,
+            .officialRating,
+            .playCount,
+            .productionYear,
+            .runtime,
             .random,
         ]
     }


### PR DESCRIPTION
## Summary

Adds 8 additional sort-by options to `ItemSortBy.supportedCases`, increasing the available library sort options from 5 to 13:

| New Option | Description |
|------------|-------------|
| `communityRating` | Sort by user community ratings |
| `criticRating` | Sort by critic ratings |
| `dateCreated` | Sort by date added to server |
| `datePlayed` | Sort by last played date |
| `officialRating` | Sort by content rating (PG, R, etc.) |
| `playCount` | Sort by number of plays |
| `productionYear` | Sort by release year |
| `runtime` | Sort by duration |

### Excluded options

The following were intentionally excluded as they are content-type-specific or cause errors:
- `similarityScore` — causes 500 errors (noted in #1523)
- `searchScore` — only meaningful for search results
- `airedEpisodeOrder`, `seriesSortName`, `seriesDatePlayed`, `parentIndexNumber`, `indexNumber` — episode/series-specific
- `album`, `albumArtist`, `artist` — music-specific
- `isFolder`, `videoBitRate`, `airTime`, `startDate` — not useful for general library browsing

All newly added options already have `displayTitle` mappings and L10n strings.

Closes #1523

## Test plan

- [ ] Verify sort options appear in library filter UI on iOS
- [ ] Verify sort options appear in library filter UI on tvOS
- [ ] Test each new sort option produces correct ordering
- [ ] Confirm no 500 errors from any new option
- [ ] @0xLeif review

🤖 Generated with [Claude Code](https://claude.com/claude-code)