### PR TITLE
[tvOS] Fix native player not stopping on dismissal

### DIFF
--- a/Shared/Components/NativeVideoPlayer.swift
+++ b/Shared/Components/NativeVideoPlayer.swift
@@ -28,6 +28,9 @@ struct NativeVideoPlayer: View {
     @Router
     private var router
 
+    @State
+    private var isBeingDismissedByTransition = false
+
     init() {
         self._proxy = .init(wrappedValue: AVMediaPlayerProxy())
     }
@@ -51,9 +54,14 @@ struct NativeVideoPlayer: View {
         .preference(key: IsStatusBarHiddenKey.self, value: true)
         .backport
         .onChange(of: presentationCoordinator.isPresented) { _, isPresented in
-            Container.shared.mediaPlayerManager.reset()
             guard !isPresented else { return }
+            isBeingDismissedByTransition = true
             manager.stop()
+        }
+        .onReceive(manager.$state) { newState in
+            if newState == .stopped, !isBeingDismissedByTransition {
+                router.dismiss()
+            }
         }
         .alert(
             L10n.error,
@@ -102,6 +110,12 @@ extension NativeVideoPlayer {
             #if !os(tvOS)
             updatesNowPlayingInfoCenter = false
             #endif
+        }
+
+        override func viewDidDisappear(_ animated: Bool) {
+            super.viewDidDisappear(animated)
+            player?.pause()
+            player?.replaceCurrentItem(with: nil)
         }
 
         @available(*, unavailable)


### PR DESCRIPTION
## Summary

- Fixes native player (AVPlayerViewController) not stopping playback when backing out on tvOS
- On tvOS, AVPlayerViewController handles the back button internally, bypassing Transmission's `presentationCoordinator` — so `manager.stop()` was never called and the AVPlayer kept playing in the background
- Playing another item after backing out caused two audio streams to overlap

## Changes

- Add `viewDidDisappear` override to `UINativeVideoPlayerViewController` to pause the AVPlayer and clear its item when the VC disappears
- Remove unconditional `Container.shared.mediaPlayerManager.reset()` from the `onChange` handler (the `_stop()` method already calls this internally)
- Add `isBeingDismissedByTransition` state and `onReceive(manager.$state)` handler to match `VideoPlayer`'s dismissal pattern

## Test plan

- [ ] Open native player on tvOS → press back → verify audio stops
- [ ] Open native player on tvOS → press back → play another video → verify only one audio stream plays
- [ ] Let a video end naturally → verify player dismisses correctly
- [ ] Verify iOS native player still works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)