### PR TITLE
Fix rotation on app foreground

### DIFF
--- a/Shared/Coordinators/Navigation/Router.swift
+++ b/Shared/Coordinators/Navigation/Router.swift
@@ -77,6 +77,12 @@ struct Router: DynamicProperty {
                 in: namespace
             )
         }
+
+        func root(
+            _ root: RootItem
+        ) {
+            router.root(root)
+        }
     }
 
     // `.dismiss` causes changes on disappear

--- a/Shared/Coordinators/Root/RootItem.swift
+++ b/Shared/Coordinators/Root/RootItem.swift
@@ -11,7 +11,7 @@ import SwiftUI
 @MainActor
 struct RootItem: Identifiable {
 
-    var id: String
+    let id: String
     let content: AnyView
 
     init(

--- a/Swiftfin/App/AppDelegate.swift
+++ b/Swiftfin/App/AppDelegate.swift
@@ -19,14 +19,17 @@ class AppDelegate: NSObject, UIApplicationDelegate {
     }
 
     func application(_ application: UIApplication, supportedInterfaceOrientationsFor window: UIWindow?) -> UIInterfaceOrientationMask {
-        if let scene = UIApplication.shared.connectedScenes.first(where: { $0.activationState == .foregroundActive }) as? UIWindowScene,
-           let topViewController = scene.keyWindow?.rootViewController,
-           let presentedViewController = topViewController.presentedViewController,
+
+        guard UIDevice.isPhone else {
+            return .allButUpsideDown
+        }
+
+        if let presentedViewController = window?.rootViewController?.presentedViewController,
            let preferencesHostingController = presentedViewController as? UIPreferencesHostingController
         {
             return preferencesHostingController.supportedInterfaceOrientations
         }
 
-        return UIDevice.isPad ? .allButUpsideDown : .portrait
+        return .portrait
     }
 }

--- a/Swiftfin/App/SwiftfinApp.swift
+++ b/Swiftfin/App/SwiftfinApp.swift
@@ -81,7 +81,7 @@ struct SwiftfinApp: App {
             OverlayToastView {
                 PreferencesView {
                     RootView()
-                        .supportedOrientations(UIDevice.isPad ? .allButUpsideDown : .portrait)
+                        .supportedOrientations(.portrait)
                 }
             }
             .ignoresSafeArea()

--- a/Swiftfin/Views/ServerCheckView.swift
+++ b/Swiftfin/Views/ServerCheckView.swift
@@ -10,9 +10,6 @@ import SwiftUI
 
 struct ServerCheckView: View {
 
-    @EnvironmentObject
-    private var rootCoordinator: RootCoordinator
-
     @Router
     private var router
 
@@ -44,7 +41,7 @@ struct ServerCheckView: View {
         .onReceive(viewModel.events) { event in
             switch event {
             case .connected:
-                rootCoordinator.root(.mainTab)
+                router.root(.mainTab)
             }
         }
         .topBarTrailing {


### PR DESCRIPTION
When determining the rotation when the app was foregrounded, the scene would be `foregroundInactive`. Instead, just get the relevant view controllers from the window itself.

Closes #1898