### PR TITLE
Bump Transmission to 2.8.3

### DIFF
--- a/Shared/Coordinators/Navigation/NavigationInjectionView.swift
+++ b/Shared/Coordinators/Navigation/NavigationInjectionView.swift
@@ -69,6 +69,7 @@ struct NavigationInjectionView: View {
                 NavigationInjectionView(coordinator: newCoordinator) {
                     route.destination
                 }
+                .environmentObject(rootCoordinator)
                 .background(.regularMaterial)
             }
         #else // <- Start: Use this for both OS when fixed
@@ -82,6 +83,7 @@ struct NavigationInjectionView: View {
                 NavigationInjectionView(coordinator: newCoordinator) {
                     route.destination
                 }
+                .environmentObject(rootCoordinator)
             }
         #endif // <- End
         #if os(tvOS)
@@ -93,6 +95,7 @@ struct NavigationInjectionView: View {
             NavigationInjectionView(coordinator: newCoordinator) {
                 route.destination
             }
+            .environmentObject(rootCoordinator)
         }
         #else
         .presentation(
@@ -112,6 +115,7 @@ struct NavigationInjectionView: View {
                         routeBinding.wrappedValue.destination
                             .environment(\.presentationControllerShouldDismiss, $isPresentationInteractive)
                     }
+                    .environmentObject(rootCoordinator)
                 }
 
                 // TODO: presentation options for customizing background color, dimming effect, etc.

--- a/Swiftfin.xcodeproj/project.pbxproj
+++ b/Swiftfin.xcodeproj/project.pbxproj
@@ -1296,7 +1296,7 @@
 			repositoryURL = "https://github.com/nathantannar4/Transmission";
 			requirement = {
 				kind = exactVersion;
-				version = 2.4.5;
+				version = 2.8.3;
 			};
 		};
 		E176EBDC2D050067009F4CF1 /* XCRemoteSwiftPackageReference "swift-identified-collections" */ = {

--- a/Swiftfin.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Swiftfin.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "38a493503cb22432e1bf1b0b812569bb2bdd51f821207a74b6b78ff16a049011",
+  "originHash" : "4117aea6c512a3e43a7bb340fecc0d1cd1f5561733cee28088160bdbb312f092",
   "pins" : [
     {
       "identity" : "blurhashkit",
@@ -69,8 +69,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/nathantannar4/Engine",
       "state" : {
-        "revision" : "8062b68c43373af4abf1695bb8aba86cc013ec9d",
-        "version" : "2.3.2"
+        "revision" : "34664a7b8131caf91f1de0a407dfc6a590a4c52e",
+        "version" : "2.6.5"
       }
     },
     {
@@ -285,8 +285,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/nathantannar4/Transmission",
       "state" : {
-        "revision" : "2da5049d33111238ad4cb979ebce783af9586cef",
-        "version" : "2.4.5"
+        "revision" : "6776b6b6dd2de5bb47253445ab698b700bd38175",
+        "version" : "2.8.3"
       }
     },
     {


### PR DESCRIPTION
### Summary

Fixes/Closes: https://github.com/jellyfin/Swiftfin/issues/1709

Now that the rotation issue is cleared up this the package, bumping this version to take advantage of the ~50 other releases between our pinned version and 2.8.3. Tested on iOS for various transitions and I see no issues on this version. Rotating the player works as expected as well without tearing. VLC still has the weird issue where rotating it loses the height for a second while turning but that exists on 2.4.X as well and appears to be related to VLC as I am not seeing it when testing on AVPlayer on a branch I am looking at using the [AVPlayerProxy](https://github.com/JPKribs/Swiftfin/tree/avplayer). This is not like a final or official branch I am working from but more just a way for me to test some track issues from another PR and also test rotation changes here.

Anecdotally, this feels a lot snappier as well and I can no longer create some weird interactions I can on Main where trying to press buttons mid-transitions causes weird animations/goes to an unexpected location. Very anecdotally seems like an overall improvement!

tvOS builds without issue now per the other change in 2.8.3!