### PR TITLE
Contributing Guide Cleanup

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,11 +24,7 @@ jobs:
     runs-on: macos-15
 
     env:
-      XCODE_VERSION: "26.2"
-      IOS_VERSION: "18"
-      TVOS_VERSION: "18"
-      TVOS_SIMULATOR: "Apple TV 4K"
-      IPHONE_SIMULATOR: "iPhone 16 Pro"
+      XCODE_VERSION: "26.3"
 
     steps:    
       - name: Checkout

--- a/.github/workflows/testflight.yml
+++ b/.github/workflows/testflight.yml
@@ -12,6 +12,10 @@ jobs:
   build:
     name: "TestFlight ✈️"
     runs-on: macos-15
+    env:
+      XCODE_VERSION: "26.3"
+      DEFAULT_IOS_SCHEME: "Swiftfin"
+      DEFAULT_TVOS_SCHEME: "Swiftfin tvOS"
 
     steps:
     - name: Checkout
@@ -106,25 +110,36 @@ jobs:
         PAYLOAD_VERSION: ${{ github.event.client_payload.version }}
         AUTO_CHANGELOG: ${{ steps.changelog.outputs.changelog }}
       run: |
-        ARGS="keyID:$FL_KEY_ID issuerID:$FL_ISSUER_ID keyContents:$FL_KEY_CONTENTS"
-        ARGS="$ARGS codeSign64:$FL_CODE_SIGN_64 profileName64:$FL_PROFILE_NAME_64"
+        RESOLVED_XCODE_VERSION="${PAYLOAD_XCODE_VERSION:-$XCODE_VERSION}"
+        CHANGELOG_FILE=$(mktemp)
 
-        ARGS="$ARGS scheme:${PAYLOAD_SCHEME:-Swiftfin iOS}"
+        echo "$AUTO_CHANGELOG" > "$CHANGELOG_FILE"
+
+        COMMON_ARGS=(
+          "keyID:$FL_KEY_ID"
+          "issuerID:$FL_ISSUER_ID"
+          "keyContents:$FL_KEY_CONTENTS"
+          "codeSign64:$FL_CODE_SIGN_64"
+          "profileName64:$FL_PROFILE_NAME_64"
+          "xcodeVersion:$RESOLVED_XCODE_VERSION"
+          "changelogFile:$CHANGELOG_FILE"
+        )
 
         if [ -n "$PAYLOAD_BUILD" ]; then
-          ARGS="$ARGS build:$PAYLOAD_BUILD"
+          COMMON_ARGS+=("build:$PAYLOAD_BUILD")
         fi
 
         if [ -n "$PAYLOAD_VERSION" ]; then
-          ARGS="$ARGS version:$PAYLOAD_VERSION"
+          COMMON_ARGS+=("version:$PAYLOAD_VERSION")
         fi
 
-        if [ -n "$PAYLOAD_XCODE_VERSION" ]; then
-          ARGS="$ARGS xcodeVersion:$PAYLOAD_XCODE_VERSION"
+        if [ -n "$PAYLOAD_SCHEME" ]; then
+          SCHEMES=("$PAYLOAD_SCHEME")
+        else
+          SCHEMES=("$DEFAULT_IOS_SCHEME" "$DEFAULT_TVOS_SCHEME")
         fi
 
-        CHANGELOG_FILE=$(mktemp)
-        echo "$AUTO_CHANGELOG" > "$CHANGELOG_FILE"
-        ARGS="$ARGS changelogFile:$CHANGELOG_FILE"
-
-        sudo fastlane testFlightLane $ARGS
+        for scheme in "${SCHEMES[@]}"; do
+          echo "Building and uploading scheme: $scheme"
+          sudo fastlane testFlightLane "${COMMON_ARGS[@]}" "scheme:$scheme"
+        done

--- a/Documentation/contributing.md
+++ b/Documentation/contributing.md
@@ -43,6 +43,14 @@ You can change the `PRODUCT_BUNDLE_IDENTIFIER` value to have multiple builds of 
 
 Swiftfin releases are built using [Xcode 26.2](https://github.com/jellyfin/Swiftfin/blob/main/.github/workflows/ci.yml#L27). Any changes you create should be built and tested on that version to ensure compatibility with the project. For that reason, this version of Xcode is the recommended version for development.
 
+### Testing
+
+Swiftfin can be tested using Xcode's built-in Simulator or on real hardware. See Apple's guide on [Running your app in Simulator or on a device](https://developer.apple.com/documentation/xcode/running-your-app-in-simulator-or-on-a-device/) for instructions on both approaches.
+
+> **Note:** Some functionality behaves differently between the Simulator and real devices, including picture-in-picture, device storage, and background playback. In these scenarios, it is recommended to test code changes on real hardware to ensure correct behavior.
+>
+> To run Swiftfin on real hardware, you will need to self-sign the app using your own development team. This is handled through the `XcodeConfig/DevelopmentTeam.xcconfig` file described in the [Xcode Config](#xcode-config) section above. Do not include self-signing changes in your Pull Requests.
+
 ## Git Flow
 
 Swiftfin follows the same Pull Request Guidelines as outlined in the [Jellyfin Pull Request Guidelines](https://jellyfin.org/docs/general/contributing/development.html#pull-request-guidelines).
@@ -59,14 +67,6 @@ The following must pass in order for a PR to be merged:
 - label(s) are attached, if applicable
 
 Labeling PRs with `enhancement`, `bug`, or `crash` will allow the PR to be tracked in GitHub's [automatically generated release notes](https://docs.github.com/en/repositories/releasing-projects-on-github/automatically-generated-release-notes). Small fixes (like minor UI adjustments) or non-user facing issues (like developer project clean up) can also have the `ignore-for-release` label because they may not be important to include in the release notes.
-
-## Testing
-
-Swiftfin can be tested using Xcode's built-in Simulator or on real hardware. See Apple's guide on [Running your app in Simulator or on a device](https://developer.apple.com/documentation/xcode/running-your-app-in-simulator-or-on-a-device/) for instructions on both approaches.
-
-> **Note:** Some functionality behaves differently between the Simulator and real devices, including picture-in-picture, device storage, and background playback. In these scenarios, it is recommended to test code changes on real hardware to ensure correct behavior.
->
-> To run Swiftfin on real hardware, you will need to self-sign the app using your own development team. This is handled through the `XcodeConfig/DevelopmentTeam.xcconfig` file described in the [Xcode Config](#xcode-config) section above. Do not include self-signing changes in your Pull Requests.
 
 ### Documentation
 Documentation for advanced or complex features and other implementation reasoning is encouraged so that future developers may have insights and a better understand of the application. `// MARK:` comments are encouraged for organization, maintainability, and ease of navigation in Xcode's Minimap.

--- a/Documentation/contributing.md
+++ b/Documentation/contributing.md
@@ -68,7 +68,7 @@ The following must pass in order for a PR to be merged:
 
 Labeling PRs with `enhancement`, `bug`, or `crash` will allow the PR to be tracked in GitHub's [automatically generated release notes](https://docs.github.com/en/repositories/releasing-projects-on-github/automatically-generated-release-notes). Small fixes (like minor UI adjustments) or non-user facing issues (like developer project clean up) can also have the `ignore-for-release` label because they may not be important to include in the release notes.
 
-### Documentation
+## Documentation
 Documentation for advanced or complex features and other implementation reasoning is encouraged so that future developers may have insights and a better understand of the application. `// MARK:` comments are encouraged for organization, maintainability, and ease of navigation in Xcode's Minimap.
 
 ## Architecture

--- a/Documentation/contributing.md
+++ b/Documentation/contributing.md
@@ -8,7 +8,7 @@
 
 ## Setup
 
-Fork the Swiftfin repo and install the necessary dependencies with Xcode 15:
+Fork the Swiftfin repo and install the necessary dependencies with Xcode 15 or higher:
 
 ```bash
 # install Carthage, SwiftFormat, and SwiftGen with homebrew
@@ -39,6 +39,10 @@ You can change the `PRODUCT_BUNDLE_IDENTIFIER` value to have multiple builds of 
 
 `DevelopmentTeam.xcconfig` is already added to the `.gitignore`.
 
+### Xcode Version
+
+Swiftfin releases are built using [Xcode 26.2](https://github.com/jellyfin/Swiftfin/blob/main/.github/workflows/ci.yml#L27). Any changes you create should be built and tested on that version to ensure compatibility with the project. For that reason, this version of Xcode is the recommended version for development.
+
 ## Git Flow
 
 Swiftfin follows the same Pull Request Guidelines as outlined in the [Jellyfin Pull Request Guidelines](https://jellyfin.org/docs/general/contributing/development.html#pull-request-guidelines).
@@ -55,6 +59,14 @@ The following must pass in order for a PR to be merged:
 - label(s) are attached, if applicable
 
 Labeling PRs with `enhancement`, `bug`, or `crash` will allow the PR to be tracked in GitHub's [automatically generated release notes](https://docs.github.com/en/repositories/releasing-projects-on-github/automatically-generated-release-notes). Small fixes (like minor UI adjustments) or non-user facing issues (like developer project clean up) can also have the `ignore-for-release` label because they may not be important to include in the release notes.
+
+## Testing
+
+Swiftfin can be tested using Xcode's built-in Simulator or on real hardware. See Apple's guide on [Running your app in Simulator or on a device](https://developer.apple.com/documentation/xcode/running-your-app-in-simulator-or-on-a-device/) for instructions on both approaches.
+
+> **Note:** Some functionality behaves differently between the Simulator and real devices, including picture-in-picture, device storage, and background playback. In these scenarios, it is recommended to test code changes on real hardware to ensure correct behavior.
+>
+> To run Swiftfin on real hardware, you will need to self-sign the app using your own development team. This is handled through the `XcodeConfig/DevelopmentTeam.xcconfig` file described in the [Xcode Config](#xcode-config) section above. Do not include self-signing changes in your Pull Requests.
 
 ### Documentation
 Documentation for advanced or complex features and other implementation reasoning is encouraged so that future developers may have insights and a better understand of the application. `// MARK:` comments are encouraged for organization, maintainability, and ease of navigation in Xcode's Minimap.

--- a/Documentation/contributing.md
+++ b/Documentation/contributing.md
@@ -47,9 +47,7 @@ Swiftfin releases are built using the Xcode version pinned in our [CI workflow](
 
 Swiftfin can be tested using Xcode's built-in Simulator or on real hardware. See Apple's guide on [Running your app in Simulator or on a device](https://developer.apple.com/documentation/xcode/running-your-app-in-simulator-or-on-a-device/) for instructions on both approaches.
 
-> **Note:** Some functionality behaves differently between the Simulator and real devices, including picture-in-picture, device storage, and background playback. In these scenarios, it is recommended to test code changes on real hardware to ensure correct behavior.
->
-> To run Swiftfin on real hardware, you will need to self-sign the app using your own development team. This is handled through the `XcodeConfig/DevelopmentTeam.xcconfig` file described in the [Xcode Config](#xcode-config) section above. Do not include self-signing changes in your Pull Requests.
+> **Note:** Some functionality behaves differently between the Simulator and real devices, including picture-in-picture, device storage, and local network access. In these scenarios, it is recommended to test code changes on real hardware to ensure correct behavior.
 
 ## Git Flow
 

--- a/Documentation/contributing.md
+++ b/Documentation/contributing.md
@@ -41,7 +41,7 @@ You can change the `PRODUCT_BUNDLE_IDENTIFIER` value to have multiple builds of 
 
 ### Xcode Version
 
-Swiftfin releases are built using [Xcode 26.2](https://github.com/jellyfin/Swiftfin/blob/main/.github/workflows/ci.yml#L27). Any changes you create should be built and tested on that version to ensure compatibility with the project. For that reason, this version of Xcode is the recommended version for development.
+Swiftfin releases are built using the Xcode version pinned in our [CI workflow](https://github.com/jellyfin/Swiftfin/blob/main/.github/workflows/ci.yml#L27). Any changes you create should be built and tested on that version to ensure compatibility with the project. For that reason, that version of Xcode is the recommended version for development.
 
 ### Testing
 

--- a/Documentation/contributing.md
+++ b/Documentation/contributing.md
@@ -8,7 +8,7 @@
 
 ## Setup
 
-Fork the Swiftfin repo and install the necessary dependencies with Xcode 15 or higher:
+Fork the Swiftfin repo and install the necessary dependencies:
 
 ```bash
 # install Carthage, SwiftFormat, and SwiftGen with homebrew
@@ -41,7 +41,7 @@ You can change the `PRODUCT_BUNDLE_IDENTIFIER` value to have multiple builds of 
 
 ### Xcode Version
 
-Swiftfin releases are built using the Xcode version pinned in our [CI workflow](https://github.com/jellyfin/Swiftfin/blob/main/.github/workflows/ci.yml#L27). Any changes you create should be built and tested on that version to ensure compatibility with the project. For that reason, that version of Xcode is the recommended version for development.
+Swiftfin is built using the Xcode version pinned in our [CI workflow](https://github.com/jellyfin/Swiftfin/blob/main/.github/workflows/ci.yml#L27). This is the recommended version of Xcode for development.
 
 ### Testing
 


### PR DESCRIPTION
### Summary

Updates the Contributing guide to update some [dated elements.](https://github.com/jellyfin/Swiftfin/issues/1928#issuecomment-4292608263) Primarily, Xcode 15 where it should be 15+ now.

Adds an Xcode version section. This is because I've been getting some questions about this lately so I think this would be best to document. Instead of hard coding this where we have to update this late, I instead just reference our CI workflow's Xcode version. The idea being, what we release on is our recommended version. This link also should reduce the need to manually updating this document every time that version updates.

Adds a section for testing. This is another question I've been seeing lately about how to run on real hardware for testing. This primarily just links https://developer.apple.com/documentation/xcode/running-your-app-in-simulator-or-on-a-device/ but I thought this would be good to add to our documentation to help provide some clarity for elements that should be tested on real hardware.

Also, Documentation was ### nested under Git Flow which didn't make sense so I just changes it to the same level at ##.