### PR TITLE
Close Player at Queue End

### DIFF
--- a/Shared/Objects/MediaPlayerManager/MediaPlayerManager.swift
+++ b/Shared/Objects/MediaPlayerManager/MediaPlayerManager.swift
@@ -242,6 +242,8 @@ final class MediaPlayerManager: ViewModel {
 
         if let nextItem = queue?.nextItem, Defaults[.VideoPlayer.autoPlayEnabled] {
             await self.playNewItem(provider: nextItem)
+        } else {
+            await self.stop()
         }
     }
 


### PR DESCRIPTION
### Summary

Right now, at the end of a movie or at the end the queued episodes, the player stays open. This change just closes if the queue is empty or autoplay is off.

### Before

https://github.com/user-attachments/assets/f9ebe734-2aed-4040-8138-7616e8840c5e

### After

https://github.com/user-attachments/assets/a73b162f-0b72-4d81-a48e-161dd4a4bcea