### PR TITLE
Focus `LetterPickerView` on Entry

### DIFF
--- a/Shared/Components/LetterPickerBar/LetterPickerBar.swift
+++ b/Shared/Components/LetterPickerBar/LetterPickerBar.swift
@@ -18,8 +18,6 @@ struct LetterPickerBar: View {
     private var focusedLetter: ItemLetter?
 
     @State
-    private var lastFocusedLetter: ItemLetter?
-    @State
     private var letterSize: CGSize = .zero
 
     // Largest letter +1p on either side
@@ -59,20 +57,13 @@ struct LetterPickerBar: View {
             .fixedSize()
             .trackingSize($letterSize)
         }
-        .backport
-        .onChange(of: focusedLetter) { _, newValue in
-            if let newValue {
-                lastFocusedLetter = newValue
-            }
-        }
         #if os(tvOS)
         .defaultFocus(
             $focusedLetter,
             viewModel.currentFilters.letter.first
-                ?? lastFocusedLetter
                 ?? ItemLetter.allCases.first
                 ?? ItemLetter(stringLiteral: "#"),
-            priority: focusedLetter == nil ? .userInitiated : .automatic // This prevents focus getting stuck for .leading
+            priority: focusedLetter == nil ? .userInitiated : .automatic
         )
         #endif
     }

--- a/Shared/Components/LetterPickerBar/LetterPickerBar.swift
+++ b/Shared/Components/LetterPickerBar/LetterPickerBar.swift
@@ -14,6 +14,11 @@ struct LetterPickerBar: View {
     @ObservedObject
     var viewModel: FilterViewModel
 
+    @FocusState
+    private var focusedLetter: ItemLetter?
+
+    @State
+    private var lastFocusedLetter: ItemLetter?
     @State
     private var letterSize: CGSize = .zero
 
@@ -35,11 +40,13 @@ struct LetterPickerBar: View {
             ForEach(ItemLetter.allCases, id: \.hashValue) { filterLetter in
                 LetterPickerButton(letter: filterLetter, viewModel: viewModel)
                     .frame(width: dimension, height: dimension)
+                    .focused($focusedLetter, equals: filterLetter)
                     .isSelected(viewModel.currentFilters.letter.contains(filterLetter))
             }
         }
         .scrollIfLargerThanContainer()
         .frame(width: dimension)
+        .focusSection()
         .background {
             ZStack {
                 ForEach(ItemLetter.allCases, id: \.hashValue) { letter in
@@ -52,5 +59,21 @@ struct LetterPickerBar: View {
             .fixedSize()
             .trackingSize($letterSize)
         }
+        .backport
+        .onChange(of: focusedLetter) { _, newValue in
+            if let newValue {
+                lastFocusedLetter = newValue
+            }
+        }
+        #if os(tvOS)
+        .defaultFocus(
+            $focusedLetter,
+            viewModel.currentFilters.letter.first
+                ?? lastFocusedLetter
+                ?? ItemLetter.allCases.first
+                ?? ItemLetter(stringLiteral: "#"),
+            priority: focusedLetter == nil ? .userInitiated : .automatic // This prevents focus getting stuck for .leading
+        )
+        #endif
     }
 }


### PR DESCRIPTION
### Summary

I'm working on some focus elements. I've been digging into some of the default focusing tooling and found the [`defaultFocus`](https://developer.apple.com/documentation/swiftui/view/defaultfocus(_:_:priority:)). I took a detour to see if I could get this to work with the `LetterPickerView` to resolve half of [this comment](https://github.com/jellyfin/Swiftfin/pull/1988#pullrequestreview-4186218453).

The way this works, this will default to the first letter at the top of the bar on first focus. On future focuses, this will default to the selected letter. If there is no selected letter, this will return us to the previously focused letter.

```swift
.defaultFocus(
    $focusedLetter,
    viewModel.currentFilters.letter.first
        ?? lastFocusedLetter
        ?? ItemLetter.allCases.first
        ?? ItemLetter(stringLiteral: "#"),
    priority: focusedLetter == nil ? .userInitiated : .automatic // This prevents focus getting stuck for .leading
)
```

### Bug

Normally, `priority: .userInitiated` works. It works without issue on the `.trailing` side but on the `.leading` side you are trapped inside the `LetterPickerView` and cannot get out. I have no idea why this is but switching it from `.userInitiated` to `.automatic` once an item has been focused resolves this as a workaround.

### Video

Video is a sliced down to the relevant portions to get around the 100mb limit.

https://github.com/user-attachments/assets/c065e812-8de1-4f71-8e3c-edaab6549038