### PR TITLE
Fix access token not updating when signing in to existing account

### DIFF
--- a/Shared/ViewModels/UserSignInViewModel.swift
+++ b/Shared/ViewModels/UserSignInViewModel.swift
@@ -15,12 +15,8 @@ import KeychainSwift
 import OrderedCollections
 import SwiftUI
 
-// TODO: instead of just signing in duplicate user, send event for alert
-//       to override existing user access token?
-//       - won't require deleting and re-signing in user for password changes
-//       - account for local device auth required
 // TODO: ignore NSURLErrorDomain Code=-999 cancelled error on sign in
-//       - need to make NSError wrappres anyways
+//       - need to make NSError wrappers anyways
 
 // Note: UserDto in StoredValues so that it doesn't need to be passed
 //       around along with the user UserState. Was just easy

--- a/Shared/Views/UserSignInView.swift
+++ b/Shared/Views/UserSignInView.swift
@@ -327,7 +327,7 @@ struct UserSignInView: View {
                 Button(L10n.signIn) {
                     viewModel.saveExisting(
                         user: existingUser,
-                        replaceForAccessToken: false,
+                        replaceForAccessToken: true,
                         authenticationAction: (
                             authenticationAction!,
                             existingUserAccessPolicy,


### PR DESCRIPTION
access token never updated because replaceForAcessToken was hardcoded to false. This meant password changes would leave the app stuck with the old token. Changed it to true so the token gets replaced on sign-in. This is a fix by Claude Code
