### PR TITLE
Fix episode selector showing blank when no season is selected

### DIFF
--- a/Swiftfin tvOS/Views/ItemView/Components/EpisodeSelector/EpisodeSelector.swift
+++ b/Swiftfin tvOS/Views/ItemView/Components/EpisodeSelector/EpisodeSelector.swift
@@ -63,5 +63,10 @@ struct SeriesEpisodeSelector: View {
                 selectionViewModel.send(.refresh)
             }
         }
+        .onAppear {
+            if selection == nil, let firstSeason = viewModel.seasons.first {
+                selection = firstSeason.id
+            }
+        }
     }
 }

--- a/Swiftfin/Views/ItemView/Components/EpisodeSelector/EpisodeSelector.swift
+++ b/Swiftfin/Views/ItemView/Components/EpisodeSelector/EpisodeSelector.swift
@@ -80,6 +80,11 @@ struct SeriesEpisodeSelector: View {
                 selection = viewModel.seasons.first?.id
             }
         }
+        .onAppear {
+            if selection == nil, let firstSeason = viewModel.seasons.first {
+                selection = firstSeason.id
+            }
+        }
         .onChange(of: selection) { _ in
             guard let selectionViewModel else { return }
 


### PR DESCRIPTION
when opening a series with no season pre-selected, the episode selector showed nothing. Added an onAppear block that automatically selects the first season if the selection is nil, so the episode list always has something to display on load. This is a fix by Claude Code
