### PR TITLE
Fix home view showing spinner instead of content during refresh

### DIFF
--- a/Swiftfin/Views/HomeView/HomeView.swift
+++ b/Swiftfin/Views/HomeView/HomeView.swift
@@ -59,15 +59,15 @@ struct HomeView: View {
     var body: some View {
         ZStack {
             switch viewModel.state {
-            case .content:
+            case .content, .refreshing:
                 contentView
             case let .error(error):
                 ErrorView(error: error)
-            case .initial, .refreshing:
+            case .initial:
                 ProgressView()
             }
         }
-        .animation(.linear(duration: 0.1), value: viewModel.state)
+        .animation(.linear(duration: 0.2), value: viewModel.state)
         .onFirstAppear {
             viewModel.send(.refresh)
         }


### PR DESCRIPTION
when the home view was refreshing, it was showing a loading spinner instead of keeping the existing content visible. Moved the .refreshing state to render the content view instead of a ProgressView, so the screen doesn't flash blank during a refresh. Also bumped the animation duration from 0.1 to 0.2 seconds. This is a fix by Claude Code
