### PR TITLE
Add SwiftfinTests / SwiftfinTVOSTests targets and seed shared-logic unit tests

### DIFF
--- a/Scripts/add_test_target.rb
+++ b/Scripts/add_test_target.rb
@@ -1,0 +1,154 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+#
+# Adds the SwiftfinTests (iOS) and SwiftfinTVOSTests (tvOS) unit-test
+# bundles to Swiftfin.xcodeproj and wires them into the matching shared
+# schemes. Idempotent: safe to re-run on an already-scaffolded project.
+# Run from the repo root: `ruby Scripts/add_test_target.rb`.
+
+require "xcodeproj"
+
+PROJECT_PATH = "Swiftfin.xcodeproj"
+
+TARGETS = [
+  {
+    name: "SwiftfinTests",
+    host: "Swiftfin iOS",
+    sdk_root: :ios,
+    sources_dir: "Tests/SwiftfinTests",
+    bundle_id: "org.jellyfin.swiftfin.tests",
+    scheme_name: "Swiftfin",
+    deployment_setting: "IPHONEOS_DEPLOYMENT_TARGET",
+    default_deployment: "16.6",
+    targeted_device_family: "1,2",
+    test_host_app: "Swiftfin iOS",
+  },
+  {
+    name: "SwiftfinTVOSTests",
+    host: "Swiftfin tvOS",
+    sdk_root: :tvos,
+    sources_dir: "Tests/SwiftfinTVOSTests",
+    bundle_id: "org.jellyfin.swiftfin.tvos.tests",
+    scheme_name: "Swiftfin tvOS",
+    deployment_setting: "TVOS_DEPLOYMENT_TARGET",
+    default_deployment: "16.6",
+    targeted_device_family: "3",
+    test_host_app: "Swiftfin tvOS",
+  },
+].freeze
+
+project = Xcodeproj::Project.open(PROJECT_PATH)
+
+def find_swift_files(dir)
+  return [] unless Dir.exist?(dir)
+  Dir.glob(File.join(dir, "**", "*.swift")).sort
+end
+
+def ensure_group(project, path_components)
+  parent = project.main_group
+  path_components.each do |component|
+    sub = parent.children.find { |c| c.respond_to?(:path) && c.path == component }
+    if sub.nil?
+      sub = parent.new_group(component, component)
+      sub.set_source_tree("<group>")
+    end
+    parent = sub
+  end
+  parent
+end
+
+TARGETS.each do |spec|
+  if project.targets.any? { |t| t.name == spec[:name] }
+    puts "[add_test_target] '#{spec[:name]}' already exists — skipping."
+    next
+  end
+
+  host_target = project.targets.find { |t| t.name == spec[:host] }
+  abort "Host target '#{spec[:host]}' not found" unless host_target
+
+  host_debug = host_target.build_configurations.find { |c| c.name == "Debug" }
+  deployment_target = host_debug.build_settings[spec[:deployment_setting]] || spec[:default_deployment]
+  swift_version     = host_debug.build_settings["SWIFT_VERSION"] || "5.0"
+
+  test_target = project.new_target(
+    :unit_test_bundle,
+    spec[:name],
+    spec[:sdk_root],
+    deployment_target,
+    project.products_group,
+    :swift,
+  )
+
+  test_host = "$(BUILT_PRODUCTS_DIR)/#{spec[:test_host_app]}.app/#{spec[:test_host_app]}"
+  test_target.build_configurations.each do |cfg|
+    s = cfg.build_settings
+    s["PRODUCT_NAME"]                = "$(TARGET_NAME)"
+    s[spec[:deployment_setting]]     = deployment_target
+    s["SWIFT_VERSION"]               = swift_version
+    s["PRODUCT_BUNDLE_IDENTIFIER"]   = spec[:bundle_id]
+    s["GENERATE_INFOPLIST_FILE"]     = "YES"
+    s["TEST_HOST"]                   = test_host
+    s["BUNDLE_LOADER"]               = "$(TEST_HOST)"
+    s["CODE_SIGN_STYLE"]             = "Automatic"
+    s["TARGETED_DEVICE_FAMILY"]      = spec[:targeted_device_family]
+    s["LD_RUNPATH_SEARCH_PATHS"]     = [
+      "$(inherited)",
+      "@executable_path/Frameworks",
+      "@loader_path/Frameworks",
+    ]
+  end
+
+  group_components = spec[:sources_dir].split(File::SEPARATOR)
+  group = ensure_group(project, group_components)
+
+  swift_files = find_swift_files(spec[:sources_dir])
+  swift_files.each do |path|
+    rel = File.basename(path)
+    file_ref = group.files.find { |f| f.path == rel } || group.new_reference(rel)
+    test_target.source_build_phase.add_file_reference(file_ref, true)
+  end
+
+  test_target.add_dependency(host_target)
+
+  puts "[add_test_target] Added '#{spec[:name]}' (host: #{spec[:host]}, deployment: #{deployment_target}, swift: #{swift_version}, sources: #{swift_files.size})."
+end
+
+project.save
+
+# Wire each test target into its host scheme.
+TARGETS.each do |spec|
+  test_target = project.targets.find { |t| t.name == spec[:name] }
+  next unless test_target
+
+  scheme_path = File.join(PROJECT_PATH, "xcshareddata/xcschemes/#{spec[:scheme_name]}.xcscheme")
+  unless File.exist?(scheme_path)
+    warn "[add_test_target] Scheme not found, skipping wire-up: #{scheme_path}"
+    next
+  end
+
+  scheme = Xcodeproj::XCScheme.new(scheme_path)
+
+  already_in_build = scheme.build_action.entries.any? { |e|
+    e.buildable_references.any? { |r| r.target_name == spec[:name] }
+  }
+  unless already_in_build
+    build_entry = Xcodeproj::XCScheme::BuildAction::Entry.new(test_target)
+    build_entry.build_for_testing   = true
+    build_entry.build_for_running   = false
+    build_entry.build_for_profiling = false
+    build_entry.build_for_archiving = false
+    build_entry.build_for_analyzing = false
+    scheme.build_action.add_entry(build_entry)
+  end
+
+  already_testable = scheme.test_action.testables.any? { |t|
+    t.buildable_references.any? { |r| r.target_name == spec[:name] }
+  }
+  unless already_testable
+    testable = Xcodeproj::XCScheme::TestAction::TestableReference.new(test_target)
+    scheme.test_action.add_testable(testable)
+  end
+
+  scheme.save!
+  puts "[add_test_target] Wired '#{spec[:name]}' into scheme: #{scheme_path}"
+end

--- a/Swiftfin.xcodeproj/project.pbxproj
+++ b/Swiftfin.xcodeproj/project.pbxproj
@@ -7,6 +7,8 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		2CD797CBC62CA3749A1F93A1 /* IntTimeLabelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 53CC6A670218D75A7669288C /* IntTimeLabelTests.swift */; };
+		3BFD249C0AB954F7674922A5 /* SwiftfinTVOSTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26F25A7A9DFF734F18809F44 /* SwiftfinTVOSTests.swift */; };
 		53ABFDDC267972BF00886593 /* TVServices.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 53ABFDDB267972BF00886593 /* TVServices.framework */; };
 		62666DF727E5012C00EC0ECD /* MobileVLCKit.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 53D5E3DC264B47EE00BADDC8 /* MobileVLCKit.xcframework */; };
 		62666DF827E5012C00EC0ECD /* MobileVLCKit.xcframework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 53D5E3DC264B47EE00BADDC8 /* MobileVLCKit.xcframework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
@@ -42,6 +44,10 @@
 		62666E3227E5021E00EC0ECD /* UIKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 62666E3127E5021E00EC0ECD /* UIKit.framework */; };
 		62666E3E27E503FA00EC0ECD /* MediaAccessibility.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5362E4BE267D40E4000E2F71 /* MediaAccessibility.framework */; };
 		62666E3F27E5040300EC0ECD /* SystemConfiguration.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5362E4C6267D40F4000E2F71 /* SystemConfiguration.framework */; };
+		73BEF088F93EFD2EB520395F /* DurationExtensionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4E52EB1479D7CDA6EC5CCFB0 /* DurationExtensionsTests.swift */; };
+		87B5847E8C6086B256794DCD /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = A3B04562D260715795F3B5C3 /* Foundation.framework */; };
+		8ED581A7DD931BC3D630C6E5 /* StringTrimmingSuffixTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 829F075942590C7C9D09ECDD /* StringTrimmingSuffixTests.swift */; };
+		B8FFFCC76620AA6C780A951F /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 857496230130DDF30211B569 /* Foundation.framework */; };
 		BD88CB422D77E6A0006BB5E3 /* TVOSPicker in Frameworks */ = {isa = PBXBuildFile; productRef = BD88CB412D77E6A0006BB5E3 /* TVOSPicker */; };
 		E1002B682793CFBA00E47059 /* Algorithms in Frameworks */ = {isa = PBXBuildFile; productRef = E1002B672793CFBA00E47059 /* Algorithms */; };
 		E1002B6B2793E36600E47059 /* Algorithms in Frameworks */ = {isa = PBXBuildFile; productRef = E1002B6A2793E36600E47059 /* Algorithms */; };
@@ -118,7 +124,26 @@
 		E1E2D7BF2E3FD936004E2E5F /* Transmission in Frameworks */ = {isa = PBXBuildFile; productRef = E1E2D7BE2E3FD936004E2E5F /* Transmission */; };
 		E1FAD1C62A0375BA007F5521 /* UDPBroadcast in Frameworks */ = {isa = PBXBuildFile; productRef = E1FAD1C52A0375BA007F5521 /* UDPBroadcast */; };
 		E1FADDF12E84B63600FB310E /* StatefulMacros in Frameworks */ = {isa = PBXBuildFile; productRef = E1FADDF02E84B63600FB310E /* StatefulMacros */; };
+		E2125D35D64E88F48D57F520 /* RuntimeFormatStyleTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5CF25EBFBEEA6CC552FAA181 /* RuntimeFormatStyleTests.swift */; };
+		F2F266687AAE277B899ADAEC /* SwiftfinTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9148914C45C39330C25E7B45 /* SwiftfinTests.swift */; };
 /* End PBXBuildFile section */
+
+/* Begin PBXContainerItemProxy section */
+		662A47CE5096160FF6F7189D /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 5377CBE9263B596A003A4E83 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 5377CBF0263B596A003A4E83;
+			remoteInfo = "Swiftfin iOS";
+		};
+		D99A9DE4C230575B41065DE7 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 5377CBE9263B596A003A4E83 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 5358705F2669D21600D05A09;
+			remoteInfo = "Swiftfin tvOS";
+		};
+/* End PBXContainerItemProxy section */
 
 /* Begin PBXCopyFilesBuildPhase section */
 		62666DF927E5012C00EC0ECD /* Embed Frameworks */ = {
@@ -146,6 +171,8 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		26F25A7A9DFF734F18809F44 /* SwiftfinTVOSTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SwiftfinTVOSTests.swift; sourceTree = "<group>"; };
+		4E52EB1479D7CDA6EC5CCFB0 /* DurationExtensionsTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = DurationExtensionsTests.swift; sourceTree = "<group>"; };
 		535870602669D21600D05A09 /* Swiftfin tvOS.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "Swiftfin tvOS.app"; sourceTree = BUILT_PRODUCTS_DIR; };
 		5362E4A7267D4067000E2F71 /* GoogleCast.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = GoogleCast.framework; path = "../../Downloads/GoogleCastSDK-ios-4.6.0_dynamic/GoogleCast.framework"; sourceTree = "<group>"; };
 		5362E4AA267D40AD000E2F71 /* AVFoundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = AVFoundation.framework; path = System/Library/Frameworks/AVFoundation.framework; sourceTree = SDKROOT; };
@@ -166,7 +193,9 @@
 		5362E4C8267D40F7000E2F71 /* UIKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = UIKit.framework; path = System/Library/Frameworks/UIKit.framework; sourceTree = SDKROOT; };
 		5377CBF1263B596A003A4E83 /* Swiftfin iOS.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "Swiftfin iOS.app"; sourceTree = BUILT_PRODUCTS_DIR; };
 		53ABFDDB267972BF00886593 /* TVServices.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = TVServices.framework; path = Platforms/AppleTVOS.platform/Developer/SDKs/AppleTVOS15.0.sdk/System/Library/Frameworks/TVServices.framework; sourceTree = DEVELOPER_DIR; };
+		53CC6A670218D75A7669288C /* IntTimeLabelTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = IntTimeLabelTests.swift; sourceTree = "<group>"; };
 		53D5E3DC264B47EE00BADDC8 /* MobileVLCKit.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = MobileVLCKit.xcframework; path = Carthage/Build/MobileVLCKit.xcframework; sourceTree = "<group>"; };
+		5CF25EBFBEEA6CC552FAA181 /* RuntimeFormatStyleTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = RuntimeFormatStyleTests.swift; sourceTree = "<group>"; };
 		625CB57D2678E81E00530A6E /* TVVLCKit.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = TVVLCKit.xcframework; path = Carthage/Build/TVVLCKit.xcframework; sourceTree = "<group>"; };
 		62666E0027E5016900EC0ECD /* CoreFoundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreFoundation.framework; path = System/Library/Frameworks/CoreFoundation.framework; sourceTree = SDKROOT; };
 		62666E0527E5017A00EC0ECD /* CoreVideo.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreVideo.framework; path = System/Library/Frameworks/CoreVideo.framework; sourceTree = SDKROOT; };
@@ -198,25 +227,31 @@
 		628B95212670CABD0091AF3B /* WidgetKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = WidgetKit.framework; path = System/Library/Frameworks/WidgetKit.framework; sourceTree = SDKROOT; };
 		628B95232670CABD0091AF3B /* SwiftUI.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = SwiftUI.framework; path = System/Library/Frameworks/SwiftUI.framework; sourceTree = SDKROOT; };
 		637FCAF3287B5B2600C0A353 /* UDPBroadcast.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = UDPBroadcast.xcframework; path = Carthage/Build/UDPBroadcast.xcframework; sourceTree = "<group>"; };
+		7385EE5DC7B8AFBFC8FF354B /* SwiftfinTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = SwiftfinTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		829F075942590C7C9D09ECDD /* StringTrimmingSuffixTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = StringTrimmingSuffixTests.swift; sourceTree = "<group>"; };
+		857496230130DDF30211B569 /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS18.0.sdk/System/Library/Frameworks/Foundation.framework; sourceTree = DEVELOPER_DIR; };
+		9148914C45C39330C25E7B45 /* SwiftfinTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SwiftfinTests.swift; sourceTree = "<group>"; };
+		A3B04562D260715795F3B5C3 /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = Platforms/AppleTVOS.platform/Developer/SDKs/AppleTVOS18.0.sdk/System/Library/Frameworks/Foundation.framework; sourceTree = DEVELOPER_DIR; };
+		ADE90C3876CA7E24C4D81AF9 /* SwiftfinTVOSTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = SwiftfinTVOSTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		E1B2AB9628808CDF0072B3B9 /* GoogleCast.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = GoogleCast.xcframework; path = Carthage/Build/GoogleCast.xcframework; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFileSystemSynchronizedBuildFileExceptionSet section */
-		E14561A22DFCAE51008FF700 /* PBXFileSystemSynchronizedBuildFileExceptionSet */ = {
+		E14561A22DFCAE51008FF700 /* Exceptions for "Swiftfin" folder in "Swiftfin iOS" target */ = {
 			isa = PBXFileSystemSynchronizedBuildFileExceptionSet;
 			membershipExceptions = (
 				Resources/Info.plist,
 			);
 			target = 5377CBF0263B596A003A4E83 /* Swiftfin iOS */;
 		};
-		E14561A32DFCAE51008FF700 /* PBXFileSystemSynchronizedBuildFileExceptionSet */ = {
+		E14561A32DFCAE51008FF700 /* Exceptions for "Swiftfin" folder in "Swiftfin tvOS" target */ = {
 			isa = PBXFileSystemSynchronizedBuildFileExceptionSet;
 			membershipExceptions = (
 				Resources/Assets.xcassets,
 			);
 			target = 5358705F2669D21600D05A09 /* Swiftfin tvOS */;
 		};
-		E14565D92DFCAE6E008FF700 /* PBXFileSystemSynchronizedBuildFileExceptionSet */ = {
+		E14565D92DFCAE6E008FF700 /* Exceptions for "Shared" folder in "Swiftfin tvOS" target */ = {
 			isa = PBXFileSystemSynchronizedBuildFileExceptionSet;
 			membershipExceptions = (
 				Extensions/JellyfinAPI/TaskTriggerInfoType.swift,
@@ -245,7 +280,7 @@
 			);
 			target = 5358705F2669D21600D05A09 /* Swiftfin tvOS */;
 		};
-		E14567272DFCAEFD008FF700 /* PBXFileSystemSynchronizedBuildFileExceptionSet */ = {
+		E14567272DFCAEFD008FF700 /* Exceptions for "Swiftfin tvOS" folder in "Swiftfin tvOS" target */ = {
 			isa = PBXFileSystemSynchronizedBuildFileExceptionSet;
 			membershipExceptions = (
 				Resources/Info.plist,
@@ -255,15 +290,87 @@
 /* End PBXFileSystemSynchronizedBuildFileExceptionSet section */
 
 /* Begin PBXFileSystemSynchronizedRootGroup section */
-		E14560852DFCAE51008FF700 /* Swiftfin */ = {isa = PBXFileSystemSynchronizedRootGroup; exceptions = (E14561A22DFCAE51008FF700 /* PBXFileSystemSynchronizedBuildFileExceptionSet */, E14561A32DFCAE51008FF700 /* PBXFileSystemSynchronizedBuildFileExceptionSet */, ); explicitFileTypes = {}; explicitFolders = (); path = Swiftfin; sourceTree = "<group>"; };
-		E14563272DFCAE6E008FF700 /* Shared */ = {isa = PBXFileSystemSynchronizedRootGroup; exceptions = (E14565D92DFCAE6E008FF700 /* PBXFileSystemSynchronizedBuildFileExceptionSet */, ); explicitFileTypes = {}; explicitFolders = (); path = Shared; sourceTree = "<group>"; };
-		E14565DD2DFCAE78008FF700 /* Scripts */ = {isa = PBXFileSystemSynchronizedRootGroup; explicitFileTypes = {}; explicitFolders = (); path = Scripts; sourceTree = "<group>"; };
-		E145669F2DFCAEFD008FF700 /* Swiftfin tvOS */ = {isa = PBXFileSystemSynchronizedRootGroup; exceptions = (E14567272DFCAEFD008FF700 /* PBXFileSystemSynchronizedBuildFileExceptionSet */, ); explicitFileTypes = {}; explicitFolders = (); path = "Swiftfin tvOS"; sourceTree = "<group>"; };
-		E1456FC82DFCB323008FF700 /* Translations */ = {isa = PBXFileSystemSynchronizedRootGroup; explicitFileTypes = {}; explicitFolders = (); path = Translations; sourceTree = "<group>"; };
-		E150B7D12DFF2E7C00DC7CF4 /* XcodeConfig */ = {isa = PBXFileSystemSynchronizedRootGroup; explicitFileTypes = {}; explicitFolders = (); path = XcodeConfig; sourceTree = "<group>"; };
+		E14560852DFCAE51008FF700 /* Swiftfin */ = {
+			isa = PBXFileSystemSynchronizedRootGroup;
+			exceptions = (
+				E14561A22DFCAE51008FF700 /* Exceptions for "Swiftfin" folder in "Swiftfin iOS" target */,
+				E14561A32DFCAE51008FF700 /* Exceptions for "Swiftfin" folder in "Swiftfin tvOS" target */,
+			);
+			explicitFileTypes = {
+			};
+			explicitFolders = (
+			);
+			path = Swiftfin;
+			sourceTree = "<group>";
+		};
+		E14563272DFCAE6E008FF700 /* Shared */ = {
+			isa = PBXFileSystemSynchronizedRootGroup;
+			exceptions = (
+				E14565D92DFCAE6E008FF700 /* Exceptions for "Shared" folder in "Swiftfin tvOS" target */,
+			);
+			explicitFileTypes = {
+			};
+			explicitFolders = (
+			);
+			path = Shared;
+			sourceTree = "<group>";
+		};
+		E14565DD2DFCAE78008FF700 /* Scripts */ = {
+			isa = PBXFileSystemSynchronizedRootGroup;
+			exceptions = (
+			);
+			explicitFileTypes = {
+			};
+			explicitFolders = (
+			);
+			path = Scripts;
+			sourceTree = "<group>";
+		};
+		E145669F2DFCAEFD008FF700 /* Swiftfin tvOS */ = {
+			isa = PBXFileSystemSynchronizedRootGroup;
+			exceptions = (
+				E14567272DFCAEFD008FF700 /* Exceptions for "Swiftfin tvOS" folder in "Swiftfin tvOS" target */,
+			);
+			explicitFileTypes = {
+			};
+			explicitFolders = (
+			);
+			path = "Swiftfin tvOS";
+			sourceTree = "<group>";
+		};
+		E1456FC82DFCB323008FF700 /* Translations */ = {
+			isa = PBXFileSystemSynchronizedRootGroup;
+			exceptions = (
+			);
+			explicitFileTypes = {
+			};
+			explicitFolders = (
+			);
+			path = Translations;
+			sourceTree = "<group>";
+		};
+		E150B7D12DFF2E7C00DC7CF4 /* XcodeConfig */ = {
+			isa = PBXFileSystemSynchronizedRootGroup;
+			exceptions = (
+			);
+			explicitFileTypes = {
+			};
+			explicitFolders = (
+			);
+			path = XcodeConfig;
+			sourceTree = "<group>";
+		};
 /* End PBXFileSystemSynchronizedRootGroup section */
 
 /* Begin PBXFrameworksBuildPhase section */
+		41C6E93FB14D12029593EFD3 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				87B5847E8C6086B256794DCD /* Foundation.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		5358705D2669D21600D05A09 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
@@ -387,9 +494,38 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		580C786C263218A5A4293054 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				B8FFFCC76620AA6C780A951F /* Foundation.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		17E59B3F0B805E06443715D3 /* SwiftfinTests */ = {
+			isa = PBXGroup;
+			children = (
+				4E52EB1479D7CDA6EC5CCFB0 /* DurationExtensionsTests.swift */,
+				53CC6A670218D75A7669288C /* IntTimeLabelTests.swift */,
+				5CF25EBFBEEA6CC552FAA181 /* RuntimeFormatStyleTests.swift */,
+				829F075942590C7C9D09ECDD /* StringTrimmingSuffixTests.swift */,
+				9148914C45C39330C25E7B45 /* SwiftfinTests.swift */,
+			);
+			name = SwiftfinTests;
+			path = SwiftfinTests;
+			sourceTree = "<group>";
+		};
+		3130D26A067A62ECF55A1A82 /* iOS */ = {
+			isa = PBXGroup;
+			children = (
+				857496230130DDF30211B569 /* Foundation.framework */,
+			);
+			name = iOS;
+			sourceTree = "<group>";
+		};
 		5377CBE8263B596A003A4E83 = {
 			isa = PBXGroup;
 			children = (
@@ -401,6 +537,7 @@
 				53D5E3DB264B47EE00BADDC8 /* Frameworks */,
 				E14565DD2DFCAE78008FF700 /* Scripts */,
 				E150B7D12DFF2E7C00DC7CF4 /* XcodeConfig */,
+				90D38740BA6B0E4C84FD88F3 /* Tests */,
 			);
 			sourceTree = "<group>";
 		};
@@ -409,6 +546,8 @@
 			children = (
 				5377CBF1263B596A003A4E83 /* Swiftfin iOS.app */,
 				535870602669D21600D05A09 /* Swiftfin tvOS.app */,
+				7385EE5DC7B8AFBFC8FF354B /* SwiftfinTests.xctest */,
+				ADE90C3876CA7E24C4D81AF9 /* SwiftfinTVOSTests.xctest */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -467,8 +606,37 @@
 				53D5E3DC264B47EE00BADDC8 /* MobileVLCKit.xcframework */,
 				628B95212670CABD0091AF3B /* WidgetKit.framework */,
 				628B95232670CABD0091AF3B /* SwiftUI.framework */,
+				3130D26A067A62ECF55A1A82 /* iOS */,
+				621E855EDB8EF869A82F3D8E /* tvOS */,
 			);
 			name = Frameworks;
+			sourceTree = "<group>";
+		};
+		621E855EDB8EF869A82F3D8E /* tvOS */ = {
+			isa = PBXGroup;
+			children = (
+				A3B04562D260715795F3B5C3 /* Foundation.framework */,
+			);
+			name = tvOS;
+			sourceTree = "<group>";
+		};
+		90D38740BA6B0E4C84FD88F3 /* Tests */ = {
+			isa = PBXGroup;
+			children = (
+				17E59B3F0B805E06443715D3 /* SwiftfinTests */,
+				B8332B932A89BF4A4154EA28 /* SwiftfinTVOSTests */,
+			);
+			name = Tests;
+			path = Tests;
+			sourceTree = "<group>";
+		};
+		B8332B932A89BF4A4154EA28 /* SwiftfinTVOSTests */ = {
+			isa = PBXGroup;
+			children = (
+				26F25A7A9DFF734F18809F44 /* SwiftfinTVOSTests.swift */,
+			);
+			name = SwiftfinTVOSTests;
+			path = SwiftfinTVOSTests;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -607,6 +775,42 @@
 			productReference = 5377CBF1263B596A003A4E83 /* Swiftfin iOS.app */;
 			productType = "com.apple.product-type.application";
 		};
+		7EA200CD46C0F36FA2837BB9 /* SwiftfinTVOSTests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 2AD352743AB1989161D66226 /* Build configuration list for PBXNativeTarget "SwiftfinTVOSTests" */;
+			buildPhases = (
+				356C3B71321204732F4D11CA /* Sources */,
+				41C6E93FB14D12029593EFD3 /* Frameworks */,
+				17EDDB8566308A2EFFB156E8 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				A18011C4692216443F7EA1D0 /* PBXTargetDependency */,
+			);
+			name = SwiftfinTVOSTests;
+			productName = SwiftfinTVOSTests;
+			productReference = ADE90C3876CA7E24C4D81AF9 /* SwiftfinTVOSTests.xctest */;
+			productType = "com.apple.product-type.bundle.unit-test";
+		};
+		94246B288E505F188EDE1B10 /* SwiftfinTests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 51EA295791D6D938FF25F9A6 /* Build configuration list for PBXNativeTarget "SwiftfinTests" */;
+			buildPhases = (
+				0C6478C4E3AECD63795CF058 /* Sources */,
+				580C786C263218A5A4293054 /* Frameworks */,
+				B2A16EC9AE20B6D13FFC3B90 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				CC7F66E1BC0D91C953E166F9 /* PBXTargetDependency */,
+			);
+			name = SwiftfinTests;
+			productName = SwiftfinTests;
+			productReference = 7385EE5DC7B8AFBFC8FF354B /* SwiftfinTests.xctest */;
+			productType = "com.apple.product-type.bundle.unit-test";
+		};
 /* End PBXNativeTarget section */
 
 /* Begin PBXProject section */
@@ -721,11 +925,20 @@
 			targets = (
 				5377CBF0263B596A003A4E83 /* Swiftfin iOS */,
 				5358705F2669D21600D05A09 /* Swiftfin tvOS */,
+				94246B288E505F188EDE1B10 /* SwiftfinTests */,
+				7EA200CD46C0F36FA2837BB9 /* SwiftfinTVOSTests */,
 			);
 		};
 /* End PBXProject section */
 
 /* Begin PBXResourcesBuildPhase section */
+		17EDDB8566308A2EFFB156E8 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		5358705E2669D21600D05A09 /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -734,6 +947,13 @@
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 		5377CBEF263B596A003A4E83 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		B2A16EC9AE20B6D13FFC3B90 /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -900,6 +1120,26 @@
 /* End PBXShellScriptBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
+		0C6478C4E3AECD63795CF058 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				73BEF088F93EFD2EB520395F /* DurationExtensionsTests.swift in Sources */,
+				2CD797CBC62CA3749A1F93A1 /* IntTimeLabelTests.swift in Sources */,
+				E2125D35D64E88F48D57F520 /* RuntimeFormatStyleTests.swift in Sources */,
+				8ED581A7DD931BC3D630C6E5 /* StringTrimmingSuffixTests.swift in Sources */,
+				F2F266687AAE277B899ADAEC /* SwiftfinTests.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		356C3B71321204732F4D11CA /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				3BFD249C0AB954F7674922A5 /* SwiftfinTVOSTests.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		5358705C2669D21600D05A09 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -916,7 +1156,67 @@
 		};
 /* End PBXSourcesBuildPhase section */
 
+/* Begin PBXTargetDependency section */
+		A18011C4692216443F7EA1D0 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = "Swiftfin tvOS";
+			target = 5358705F2669D21600D05A09 /* Swiftfin tvOS */;
+			targetProxy = D99A9DE4C230575B41065DE7 /* PBXContainerItemProxy */;
+		};
+		CC7F66E1BC0D91C953E166F9 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = "Swiftfin iOS";
+			target = 5377CBF0263B596A003A4E83 /* Swiftfin iOS */;
+			targetProxy = 662A47CE5096160FF6F7189D /* PBXContainerItemProxy */;
+		};
+/* End PBXTargetDependency section */
+
 /* Begin XCBuildConfiguration section */
+		2D2D4F3330606789ECCA04A0 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				CLANG_ENABLE_OBJC_WEAK = NO;
+				CODE_SIGN_STYLE = Automatic;
+				GENERATE_INFOPLIST_FILE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 16.6;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = org.jellyfin.swiftfin.tests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = iphoneos;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Swiftfin iOS.app/Swiftfin iOS";
+			};
+			name = Debug;
+		};
+		2E37672E975FD5FD829C130E /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				CLANG_ENABLE_OBJC_WEAK = NO;
+				CODE_SIGN_STYLE = Automatic;
+				GENERATE_INFOPLIST_FILE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 16.6;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = org.jellyfin.swiftfin.tests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = iphoneos;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Swiftfin iOS.app/Swiftfin iOS";
+				VALIDATE_PRODUCT = YES;
+			};
+			name = Release;
+		};
 		535870722669D21700D05A09 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
@@ -1180,9 +1480,70 @@
 			};
 			name = Release;
 		};
+		5EFC163D90E96A7A99830E29 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				CODE_SIGN_STYLE = Automatic;
+				GENERATE_INFOPLIST_FILE = YES;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = org.jellyfin.swiftfin.tvos.tests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = appletvos;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = 3;
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Swiftfin tvOS.app/Swiftfin tvOS";
+				TVOS_DEPLOYMENT_TARGET = 17.0;
+				VALIDATE_PRODUCT = YES;
+			};
+			name = Release;
+		};
+		62DB0226DDC490DB58835A54 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				CODE_SIGN_STYLE = Automatic;
+				GENERATE_INFOPLIST_FILE = YES;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = org.jellyfin.swiftfin.tvos.tests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = appletvos;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = 3;
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Swiftfin tvOS.app/Swiftfin tvOS";
+				TVOS_DEPLOYMENT_TARGET = 17.0;
+			};
+			name = Debug;
+		};
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
+		2AD352743AB1989161D66226 /* Build configuration list for PBXNativeTarget "SwiftfinTVOSTests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				5EFC163D90E96A7A99830E29 /* Release */,
+				62DB0226DDC490DB58835A54 /* Debug */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		51EA295791D6D938FF25F9A6 /* Build configuration list for PBXNativeTarget "SwiftfinTests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				2E37672E975FD5FD829C130E /* Release */,
+				2D2D4F3330606789ECCA04A0 /* Debug */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
 		535870712669D21700D05A09 /* Build configuration list for PBXNativeTarget "Swiftfin tvOS" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (

--- a/Swiftfin.xcodeproj/xcshareddata/xcschemes/Swiftfin tvOS.xcscheme
+++ b/Swiftfin.xcodeproj/xcshareddata/xcschemes/Swiftfin tvOS.xcscheme
@@ -20,6 +20,20 @@
                ReferencedContainer = "container:Swiftfin.xcodeproj">
             </BuildableReference>
          </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "NO"
+            buildForProfiling = "NO"
+            buildForArchiving = "NO"
+            buildForAnalyzing = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "7EA200CD46C0F36FA2837BB9"
+               BuildableName = "SwiftfinTVOSTests.xctest"
+               BlueprintName = "SwiftfinTVOSTests"
+               ReferencedContainer = "container:Swiftfin.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
       </BuildActionEntries>
    </BuildAction>
    <TestAction
@@ -28,6 +42,16 @@
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       shouldUseLaunchSchemeArgsEnv = "YES">
       <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "7EA200CD46C0F36FA2837BB9"
+               BuildableName = "SwiftfinTVOSTests.xctest"
+               BlueprintName = "SwiftfinTVOSTests"
+               ReferencedContainer = "container:Swiftfin.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
       </Testables>
    </TestAction>
    <LaunchAction

--- a/Swiftfin.xcodeproj/xcshareddata/xcschemes/Swiftfin.xcscheme
+++ b/Swiftfin.xcodeproj/xcshareddata/xcschemes/Swiftfin.xcscheme
@@ -20,6 +20,20 @@
                ReferencedContainer = "container:Swiftfin.xcodeproj">
             </BuildableReference>
          </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "NO"
+            buildForProfiling = "NO"
+            buildForArchiving = "NO"
+            buildForAnalyzing = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "94246B288E505F188EDE1B10"
+               BuildableName = "SwiftfinTests.xctest"
+               BlueprintName = "SwiftfinTests"
+               ReferencedContainer = "container:Swiftfin.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
       </BuildActionEntries>
    </BuildAction>
    <TestAction
@@ -28,6 +42,16 @@
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       shouldUseLaunchSchemeArgsEnv = "YES">
       <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "94246B288E505F188EDE1B10"
+               BuildableName = "SwiftfinTests.xctest"
+               BlueprintName = "SwiftfinTests"
+               ReferencedContainer = "container:Swiftfin.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
       </Testables>
    </TestAction>
    <LaunchAction

--- a/Tests/SwiftfinTVOSTests/SwiftfinTVOSTests.swift
+++ b/Tests/SwiftfinTVOSTests/SwiftfinTVOSTests.swift
@@ -1,0 +1,20 @@
+//
+// Swiftfin is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, you can obtain one at https://mozilla.org/MPL/2.0/.
+//
+// Copyright (c) 2026 Jellyfin & Jellyfin Contributors
+//
+
+import XCTest
+
+/// Smoke test for the SwiftfinTVOSTests bundle. Pure-logic shared code is
+/// covered in `SwiftfinTests`; this target exists so tvOS-specific
+/// behavior (player overlay, focus engine logic) can be tested as it
+/// lands.
+final class SwiftfinTVOSTests: XCTestCase {
+
+    func testTestTargetIsWired() {
+        XCTAssertTrue(true, "Verifies the SwiftfinTVOSTests target is wired into the Swiftfin tvOS scheme.")
+    }
+}

--- a/Tests/SwiftfinTests/DurationExtensionsTests.swift
+++ b/Tests/SwiftfinTests/DurationExtensionsTests.swift
@@ -1,0 +1,51 @@
+//
+// Swiftfin is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, you can obtain one at https://mozilla.org/MPL/2.0/.
+//
+// Copyright (c) 2026 Jellyfin & Jellyfin Contributors
+//
+
+@testable import Swiftfin_iOS
+import XCTest
+
+/// Covers the `Duration` extensions. Jellyfin's API encodes durations
+/// as 100-nanosecond ticks (10 ticks per microsecond, 10_000_000 per
+/// second). The conversion is used everywhere runtime is decoded from
+/// the server, so a regression here would shift every displayed time.
+final class DurationExtensionsTests: XCTestCase {
+
+    func testTicksConvertsTenMillionToOneSecond() {
+        XCTAssertEqual(Duration.ticks(10_000_000), .seconds(1))
+    }
+
+    func testTicksRoundsBelowOneMicrosecondToZero() {
+        // Integer division by 10 truncates: anything under 10 ticks
+        // collapses to zero microseconds.
+        XCTAssertEqual(Duration.ticks(0), .seconds(0))
+        XCTAssertEqual(Duration.ticks(9), .microseconds(0))
+        XCTAssertEqual(Duration.ticks(10), .microseconds(1))
+    }
+
+    func testMinutesIntegerOverloadProducesExactSeconds() {
+        XCTAssertEqual(Duration.minutes(1 as Int), .seconds(60))
+        XCTAssertEqual(Duration.minutes(90 as Int), .seconds(5400))
+    }
+
+    func testHoursIntegerOverloadProducesExactSeconds() {
+        XCTAssertEqual(Duration.hours(1 as Int), .seconds(3600))
+        XCTAssertEqual(Duration.hours(24 as Int), .seconds(86400))
+    }
+
+    func testSecondsAccessorRoundTripsForWholeValues() {
+        // Whole-second durations must round-trip without floating-point drift.
+        XCTAssertEqual(Duration.seconds(0).seconds, 0, accuracy: 1e-9)
+        XCTAssertEqual(Duration.seconds(3600).seconds, 3600, accuracy: 1e-9)
+        XCTAssertEqual(Duration.minutes(45 as Int).seconds, 2700, accuracy: 1e-9)
+    }
+
+    func testMinutesAccessorDividesSeconds() {
+        XCTAssertEqual(Duration.seconds(120).minutes, 2, accuracy: 1e-9)
+        XCTAssertEqual(Duration.seconds(90).minutes, 1.5, accuracy: 1e-9)
+    }
+}

--- a/Tests/SwiftfinTests/IntTimeLabelTests.swift
+++ b/Tests/SwiftfinTests/IntTimeLabelTests.swift
@@ -1,0 +1,47 @@
+//
+// Swiftfin is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, you can obtain one at https://mozilla.org/MPL/2.0/.
+//
+// Copyright (c) 2026 Jellyfin & Jellyfin Contributors
+//
+
+@testable import Swiftfin_iOS
+import XCTest
+
+/// Covers `FixedWidthInteger.timeLabel` — the playback-position formatter
+/// shown in the player overlay. The output format conditionally includes
+/// hours, so the boundary at exactly 1h is the high-risk case.
+final class IntTimeLabelTests: XCTestCase {
+
+    func testZeroSeconds() {
+        XCTAssertEqual(0.timeLabel, "0:00")
+    }
+
+    func testUnderOneMinute() {
+        XCTAssertEqual(7.timeLabel, "0:07")
+        XCTAssertEqual(59.timeLabel, "0:59")
+    }
+
+    func testUnderOneHourDoesNotShowHours() {
+        XCTAssertEqual(60.timeLabel, "1:00")
+        XCTAssertEqual(599.timeLabel, "9:59")
+        XCTAssertEqual(3599.timeLabel, "59:59")
+    }
+
+    func testOneHourBoundaryShowsHours() {
+        // Exactly 1h must include the hours field and zero-pad minutes.
+        XCTAssertEqual(3600.timeLabel, "1:00:00")
+    }
+
+    func testOverOneHourPadsMinutesAndSeconds() {
+        XCTAssertEqual(3661.timeLabel, "1:01:01")
+        XCTAssertEqual(7261.timeLabel, "2:01:01")
+    }
+
+    func testHoursDoNotRollOverAtTwentyFour() {
+        // Some content (live streams, audiobooks) can exceed 24 hours.
+        XCTAssertEqual(86399.timeLabel, "23:59:59")
+        XCTAssertEqual(360_000.timeLabel, "100:00:00")
+    }
+}

--- a/Tests/SwiftfinTests/README.md
+++ b/Tests/SwiftfinTests/README.md
@@ -1,0 +1,39 @@
+# SwiftfinTests / SwiftfinTVOSTests
+
+Unit tests for Swiftfin. Two bundles, hosted on their respective apps:
+
+- `SwiftfinTests` — hosted on `Swiftfin iOS`. Covers shared, pure-logic code
+  imported via `@testable import Swiftfin`.
+- `SwiftfinTVOSTests` — hosted on `Swiftfin tvOS`. Reserved for tvOS-specific
+  behavior (player overlay, focus engine, click-only remote handling).
+
+## Running
+
+From Xcode, select the matching scheme (`Swiftfin` or `Swiftfin tvOS`) and
+hit `⌘U`.
+
+From the command line:
+
+```sh
+xcodebuild test \
+  -project Swiftfin.xcodeproj \
+  -scheme "Swiftfin" \
+  -destination "platform=iOS Simulator,name=iPhone 17"
+
+xcodebuild test \
+  -project Swiftfin.xcodeproj \
+  -scheme "Swiftfin tvOS" \
+  -destination "platform=tvOS Simulator,name=Apple TV"
+```
+
+## Adding tests
+
+Drop `*.swift` files into `Tests/SwiftfinTests/` (iOS) or
+`Tests/SwiftfinTVOSTests/` (tvOS) and run `ruby Scripts/add_test_target.rb`
+to pick up new files into the matching target's source build phase. The
+script is idempotent.
+
+Tests use `@testable import Swiftfin_iOS` (or `@testable import Swiftfin_tvOS`).
+The module names are derived from `PRODUCT_MODULE_NAME` which Xcode
+produces from `PRODUCT_NAME = $(TARGET_NAME)`. Prefer `internal` access
+on symbols you want covered.

--- a/Tests/SwiftfinTests/RuntimeFormatStyleTests.swift
+++ b/Tests/SwiftfinTests/RuntimeFormatStyleTests.swift
@@ -1,0 +1,51 @@
+//
+// Swiftfin is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, you can obtain one at https://mozilla.org/MPL/2.0/.
+//
+// Copyright (c) 2026 Jellyfin & Jellyfin Contributors
+//
+
+@testable import Swiftfin_iOS
+import XCTest
+
+/// Covers `RuntimeFormatStyle` which switches between minute:second and
+/// hour:minute:second patterns based on a 3600-second threshold. The
+/// format-style selection is the high-risk piece — a regression here
+/// would silently mis-format runtime everywhere it's displayed.
+final class RuntimeFormatStyleTests: XCTestCase {
+
+    private let style = RuntimeFormatStyle()
+
+    func testZeroDuration() {
+        XCTAssertEqual(style.format(.seconds(0)), "0:00")
+    }
+
+    func testJustUnderOneHourUsesMinuteSecondPattern() {
+        XCTAssertEqual(style.format(.seconds(3599)), "59:59")
+    }
+
+    func testExactlyOneHourSwitchesToHourMinuteSecond() {
+        // The threshold is `>= 3600` seconds; this exact value must
+        // produce the three-component output.
+        let formatted = style.format(.seconds(3600))
+        XCTAssertTrue(
+            formatted.contains(":00:00"),
+            "Expected hour:minute:second output at the 1h boundary, got '\(formatted)'"
+        )
+    }
+
+    func testOverOneHourUsesHourMinuteSecond() {
+        let formatted = style.format(.seconds(7261))
+        XCTAssertTrue(
+            formatted.contains(":01:01"),
+            "Expected runtime to format with seconds zero-padded, got '\(formatted)'"
+        )
+    }
+
+    func testWholeSecondInputProducesPaddedOutput() {
+        // Single-digit minute and second values are zero-padded to two
+        // characters in the minute:second branch.
+        XCTAssertEqual(style.format(.seconds(65)), "1:05")
+    }
+}

--- a/Tests/SwiftfinTests/StringTrimmingSuffixTests.swift
+++ b/Tests/SwiftfinTests/StringTrimmingSuffixTests.swift
@@ -1,0 +1,39 @@
+//
+// Swiftfin is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, you can obtain one at https://mozilla.org/MPL/2.0/.
+//
+// Copyright (c) 2026 Jellyfin & Jellyfin Contributors
+//
+
+@testable import Swiftfin_iOS
+import XCTest
+
+/// Covers `String.trimmingSuffix(_:)`. Used in display-name normalization
+/// (e.g. stripping codec/quality suffixes from media titles). The
+/// character-by-character compare is the high-risk piece — a regression
+/// would either over-strip or under-strip user-visible text.
+final class StringTrimmingSuffixTests: XCTestCase {
+
+    func testTrimsExactSuffixAtEnd() {
+        XCTAssertEqual("hello.txt".trimmingSuffix(".txt"), "hello")
+    }
+
+    func testReturnsOriginalWhenSuffixDoesNotMatch() {
+        XCTAssertEqual("hello.mkv".trimmingSuffix(".txt"), "hello.mkv")
+    }
+
+    func testReturnsOriginalWhenSuffixIsLongerThanString() {
+        XCTAssertEqual("ab".trimmingSuffix("longer-than-input"), "ab")
+    }
+
+    func testTrimsOnlyMatchingTrailingCharacters() {
+        // Only the characters that match from the end are removed; a
+        // partial mismatch in the middle stops the trim.
+        XCTAssertEqual("file.tar.gz".trimmingSuffix(".gz"), "file.tar")
+    }
+
+    func testEmptySuffixIsNoop() {
+        XCTAssertEqual("payload".trimmingSuffix(""), "payload")
+    }
+}

--- a/Tests/SwiftfinTests/SwiftfinTests.swift
+++ b/Tests/SwiftfinTests/SwiftfinTests.swift
@@ -1,0 +1,16 @@
+//
+// Swiftfin is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, you can obtain one at https://mozilla.org/MPL/2.0/.
+//
+// Copyright (c) 2026 Jellyfin & Jellyfin Contributors
+//
+
+import XCTest
+
+final class SwiftfinTests: XCTestCase {
+
+    func testTestTargetIsWired() {
+        XCTAssertTrue(true, "Verifies the SwiftfinTests target is wired into the Swiftfin scheme.")
+    }
+}


### PR DESCRIPTION
Discussion: jellyfin/Swiftfin#2006

## Summary

Adds a unit-test bundle for each host app and seeds 23 tests against pure-logic shared code so behavior changes can land alongside the unit tests that prove them.

- `SwiftfinTests` (host: `Swiftfin iOS`)
- `SwiftfinTVOSTests` (host: `Swiftfin tvOS`)

Both targets are wired into the matching shared schemes, so `xcodebuild test -scheme "Swiftfin"` and `-scheme "Swiftfin tvOS"` each run their suites locally and in CI without any further configuration.

## Why

There is currently no test target in the project — `xcodebuild test` is a no-op because no `*Tests` bundle exists. Without one, every behavior change has to ship as a changes-only PR, and regressions in pure-logic code (formatters, parsers, model adapters) only surface when a user files an issue. Seeding the test target is the prerequisite for landing fixes alongside the unit tests that catch their regressions.

## What's in this PR

### Test target wiring

- `Scripts/add_test_target.rb` — idempotent script using the `xcodeproj` ruby gem to register both targets, set their build settings, and update the schemes. Re-running on an already-scaffolded project is a no-op. Future contributors who add `*.swift` files under `Tests/SwiftfinTests/` or `Tests/SwiftfinTVOSTests/` can run the script to pick them up into the source build phase.
- `Swiftfin.xcodeproj/project.pbxproj` — new `PBXNativeTarget` entries for both test bundles, with `TEST_HOST` / `BUNDLE_LOADER` pointing at the matching app, `GENERATE_INFOPLIST_FILE = YES`, and `CODE_SIGN_STYLE = Automatic`.
- `Swiftfin.xcscheme` and `Swiftfin tvOS.xcscheme` — `BuildAction` entries (build-for-testing only) plus `TestAction` testable references.

### Seeded tests

Tests target the highest-leverage shared logic in `Shared/Extensions/`. Each suite asserts behavior the current code already produces — no production code is touched in this PR, so this is purely additive coverage on stable APIs.

| File | Suite | Coverage |
|---|---|---|
| `Tests/SwiftfinTests/IntTimeLabelTests.swift` | `FixedWidthInteger.timeLabel` | 6 cases — playback-position formatter, including the 1h boundary at exactly 3600s, three-digit hour labels for >24h durations, and zero-padding rules |
| `Tests/SwiftfinTests/RuntimeFormatStyleTests.swift` | `RuntimeFormatStyle` | 5 cases — `Duration → String` format selector that switches between `MM:SS` and `H:MM:SS` at the `>= 3600s` threshold |
| `Tests/SwiftfinTests/DurationExtensionsTests.swift` | `Duration` extensions | 6 cases — Jellyfin's 100-nanosecond tick decoder (used everywhere runtime is decoded from the server), the `minutes`/`hours` integer overloads, and the `seconds`/`minutes` accessors |
| `Tests/SwiftfinTests/StringTrimmingSuffixTests.swift` | `String.trimmingSuffix(_:)` | 5 cases — exact-match, no-match, longer-than-input, partial-trail, and empty-suffix paths |
| `Tests/SwiftfinTVOSTests/SwiftfinTVOSTests.swift` | smoke | 1 case — proves the bundle is wired so tvOS-specific tests can land alongside whatever tvOS work follows |

`Tests/SwiftfinTests/README.md` documents how to run the suites from Xcode and the command line, and the convention for adding new tests.

## Test plan

Verified locally:

- iPhone 16e (iOS Simulator 26.2): `xcodebuild test -scheme "Swiftfin"` — **23 of 23 tests pass** in ~6ms.
- Apple TV 4K (tvOS Simulator 26.2): `xcodebuild test -scheme "Swiftfin tvOS"` — **1 of 1 tests passes**.
- `xcodebuild build -scheme "Swiftfin"` and `-scheme "Swiftfin tvOS"` still succeed (no behavior or build-graph regressions).

To run after pulling:

```sh
xcodebuild test \
  -project Swiftfin.xcodeproj \
  -scheme "Swiftfin" \
  -destination "platform=iOS Simulator,name=iPhone 16e"

xcodebuild test \
  -project Swiftfin.xcodeproj \
  -scheme "Swiftfin tvOS" \
  -destination "platform=tvOS Simulator,name=Apple TV 4K (3rd generation)"
```

## Notes for review

- Diff is dominated by `project.pbxproj` boilerplate (new targets, build configurations, build phases, file references). Reviewing the script and the test sources is the higher-signal read; the pbxproj diff is what `xcodeproj` generates from those.
- The seeded tests skip a known crash case in `String.trimmingSuffix(_:)` (calling it with self == suffix triggers `removeLast()` on an empty string). I left that out of this PR to keep the scope to scaffolding + safe coverage; happy to send it as a follow-up bug-fix PR with a regression test.
- If you'd prefer iOS and tvOS targets land in separate PRs, or want me to drop the seeded tests entirely so the scaffolding lands first, say the word in the discussion thread and I'll restructure.

Marked as draft for review feedback before flipping to ready.
