### PR TITLE
Fix autofill for sign in fields

### DIFF
--- a/Shared/Views/UserSignInView.swift
+++ b/Shared/Views/UserSignInView.swift
@@ -122,6 +122,7 @@ struct UserSignInView: View {
         Section {
             TextField(L10n.username, text: $username)
                 .autocorrectionDisabled()
+                .textContentType(.username)
                 .textInputAutocapitalization(.never)
                 .focused($focusedTextField, equals: .username)
                 .onSubmit {
@@ -142,6 +143,7 @@ struct UserSignInView: View {
                 )
             }
             .autocorrectionDisabled()
+            .textContentType(.password)
             .textInputAutocapitalization(.never)
             .focused($focusedTextField, equals: .password)
         } header: {


### PR DESCRIPTION
The username and password fields on the sign in screen are missing `.textContentType` modifiers, so iOS never offers Keychain/password manager autofill. 

This PR adds `.textContentType(.username)` and `.textContentType(.password)` to the respective fields so iOS offers Keychain/password manager support