### PR TITLE
TVOS LiveTV Player Fixes

### DIFF
--- a/Shared/Coordinators/Navigation/NavigationRoute/NavigationRoute+Media.swift
+++ b/Shared/Coordinators/Navigation/NavigationRoute/NavigationRoute+Media.swift
@@ -31,6 +31,14 @@ extension NavigationRoute {
         }
     }
 
+    static var liveTVGuide: NavigationRoute {
+        NavigationRoute(
+            id: "liveTVGuide"
+        ) {
+            LiveTVGuideView()
+        }
+    }
+
     static func mediaSourceInfo(source: MediaSourceInfo) -> NavigationRoute {
         NavigationRoute(
             id: "mediaSourceInfo",

--- a/Shared/Objects/MediaPlayerManager/MediaPlayerProxy/MediaPlayerProxy+VLC.swift
+++ b/Shared/Objects/MediaPlayerManager/MediaPlayerProxy/MediaPlayerProxy+VLC.swift
@@ -9,6 +9,7 @@
 import Defaults
 import Foundation
 import JellyfinAPI
+import Logging
 import SwiftUI
 import VLCUI
 
@@ -22,6 +23,8 @@ class VLCMediaPlayerProxy: VideoMediaPlayerProxy,
     let droppedFrames: PublishedBox<Int> = .init(initialValue: 0)
     let corruptedFrames: PublishedBox<Int> = .init(initialValue: 0)
     let vlcUIProxy: VLCVideoPlayer.Proxy = .init()
+
+    private var hasRetriedCurrentItem = false
 
     weak var manager: MediaPlayerManager? {
         didSet {
@@ -131,6 +134,9 @@ extension VLCMediaPlayerProxy {
         @EnvironmentObject
         private var proxy: VLCVideoPlayer.Proxy
 
+        @State
+        private var didScheduleLiveOverlayDismissal = false
+
         private var isScrubbing: Bool {
             containerState.isScrubbing
         }
@@ -139,8 +145,40 @@ extension VLCMediaPlayerProxy {
             let baseItem = item.baseItem
             let mediaSource = item.mediaSource
 
-            var configuration = VLCVideoPlayer.Configuration(url: item.url)
+            // Normalize malformed URLs like .../stream%3F&DeviceId=... to .../stream?DeviceId=...
+            let originalURL = item.url
+            let fixedURL: URL = {
+                let s = originalURL.absoluteString
+                // Replace only the first occurrence of "%3F" (encoded question mark) with "?"
+                if let range = s.range(of: "%3F") {
+                    var corrected = s
+                    corrected.replaceSubrange(range, with: "?")
+                    if let url = URL(string: corrected) {
+                        manager.logger.warning(
+                            "Normalized malformed media URL for VLC",
+                            metadata: [
+                                "original": .stringConvertible(s),
+                                "normalized": .stringConvertible(corrected)
+                            ]
+                        )
+                        return url
+                    }
+                }
+                return originalURL
+            }()
+
+            var configuration = VLCVideoPlayer.Configuration(url: fixedURL)
             configuration.autoPlay = true
+
+            // Configure caching to better handle segmented livestreams and network variability
+            if baseItem.isLiveStream {
+                // Prefer higher live/network caching for HLS/DASH segmented livestreams
+                configuration.options["live-caching"] = 1500
+                configuration.options["network-caching"] = 2000
+            } else {
+                configuration.options["network-caching"] = 1500
+                configuration.options["file-caching"] = 1000
+            }
 
             let startSeconds = max(.zero, (baseItem.startSeconds ?? .zero) - Duration.seconds(Defaults[.VideoPlayer.resumeOffset]))
 
@@ -150,7 +188,11 @@ extension VLCMediaPlayerProxy {
                 configuration.subtitleIndex = .absolute(mediaSource.defaultSubtitleStreamIndex ?? -1)
             }
 
-            configuration.subtitleSize = .absolute(25 - Defaults[.VideoPlayer.Subtitle.subtitleSize])
+            // Compute and clamp subtitle size to a sane range
+            let computedSubtitleSize = 25 - Defaults[.VideoPlayer.Subtitle.subtitleSize]
+            let clampedSubtitleSize = max(8, min(36, computedSubtitleSize))
+            configuration.subtitleSize = .absolute(clampedSubtitleSize)
+
             configuration.subtitleColor = .absolute(Defaults[.VideoPlayer.Subtitle.subtitleColor].uiColor)
             configuration.rate = .absolute(Defaults[.VideoPlayer.Playback.playbackRate])
             if let font = UIFont(name: Defaults[.VideoPlayer.Subtitle.subtitleFontName], size: 1) {
@@ -160,6 +202,21 @@ extension VLCMediaPlayerProxy {
             configuration.playbackChildren = item.subtitleStreams
                 .filter { $0.deliveryMethod == .external }
                 .compactMap(\.asVLCPlaybackChild)
+
+            let audioIndexValue = baseItem.isLiveStream ? -1 : (mediaSource.defaultAudioStreamIndex ?? -1)
+            let subtitleIndexValue = baseItem.isLiveStream ? -1 : (mediaSource.defaultSubtitleStreamIndex ?? -1)
+            let childrenCount = configuration.playbackChildren.count
+
+            manager.logger.info(
+                "Built VLC configuration",
+                metadata: [
+                    "url": .stringConvertible(fixedURL.absoluteString),
+                    "startSeconds": .stringConvertible(startSeconds.seconds),
+                    "audioIndex": .stringConvertible(audioIndexValue),
+                    "subtitleIndex": .stringConvertible(subtitleIndexValue),
+                    "externalSubtitleChildren": .stringConvertible(childrenCount)
+                ]
+            )
 
             return configuration
         }
@@ -180,16 +237,28 @@ extension VLCMediaPlayerProxy {
                             proxy.droppedFrames.value = info.statistics.lostPictures
                             proxy.corruptedFrames.value = info.statistics.demuxCorrupted
                         }
+
+                        if playbackItem.baseItem.isLiveStream, !didScheduleLiveOverlayDismissal {
+                            didScheduleLiveOverlayDismissal = true
+                            containerState.timer.poke(interval: 3)
+                        }
                     }
                     .onStateUpdated { state, info in
                         manager.logger.trace("VLC state updated: \(state)")
 
                         switch state {
-                        case .buffering,
-                             .esAdded,
-                             .opening:
-                            // TODO: figure out when to properly set to false
+                        case .buffering:
                             manager.proxy?.isBuffering.value = true
+                        case .esAdded:
+                            manager.proxy?.isBuffering.value = true
+                        case .opening:
+                            manager.proxy?.isBuffering.value = true
+                            manager.logger.info(
+                                "VLC opening media",
+                                metadata: [
+                                    "url": .stringConvertible(manager.playbackItem?.url.absoluteString ?? "unknown")
+                                ]
+                            )
                         case .ended:
                             // Live streams will send stopped/ended events
                             guard !playbackItem.baseItem.isLiveStream else { return }
@@ -201,10 +270,58 @@ extension VLCMediaPlayerProxy {
                         // than react to the event.
                         case .error:
                             manager.proxy?.isBuffering.value = false
+                            let url = manager.playbackItem?.url.absoluteString ?? "unknown"
+                            let secs = manager.seconds.seconds
+                            manager.logger.error(
+                                "VLC reported error",
+                                metadata: [
+                                    "url": .stringConvertible(url),
+                                    "seconds": .stringConvertible(secs),
+                                    "videoSize": .stringConvertible("\(info.videoSize.width)x\(info.videoSize.height)"),
+                                    "lostPictures": .stringConvertible(info.statistics.lostPictures),
+                                    "demuxCorrupted": .stringConvertible(info.statistics.demuxCorrupted)
+                                ]
+                            )
+                            if let proxyOwner = manager.proxy as? VLCMediaPlayerProxy, proxyOwner.hasRetriedCurrentItem == false {
+                                proxyOwner.hasRetriedCurrentItem = true
+                                manager.logger.warning(
+                                    "VLC error encountered — attempting single retry with increased caching",
+                                    metadata: ["url": .stringConvertible(url), "seconds": .stringConvertible(secs)]
+                                )
+                                if let item = manager.playbackItem {
+                                    var cfg = vlcConfiguration(for: item)
+                                    // Bump caching a bit more for the retry to stabilize playback
+                                    if item.baseItem.isLiveStream {
+                                        cfg.options["live-caching"] = 2500
+                                        cfg.options["network-caching"] = 3000
+                                    } else {
+                                        cfg.options["network-caching"] = 2000
+                                        cfg.options["file-caching"] = 1500
+                                    }
+                                    proxy.playNewMedia(cfg)
+                                    return
+                                }
+                            }
                             manager.error(ErrorMessage("VLC player is unable to perform playback"))
                         case .playing:
                             manager.proxy?.isBuffering.value = false
                             manager.setPlaybackRequestStatus(status: .playing)
+                            if playbackItem.baseItem.isLiveStream {
+                                proxy.setSubtitleTrack(.absolute(playbackItem.selectedSubtitleStreamIndex ?? -1))
+
+                                if !didScheduleLiveOverlayDismissal {
+                                    didScheduleLiveOverlayDismissal = true
+                                    containerState.timer.poke(interval: 3)
+                                }
+                            }
+                            manager.logger.info(
+                                "VLC playing",
+                                metadata: [
+                                    "videoSize": .stringConvertible("\(info.videoSize.width)x\(info.videoSize.height)"),
+                                    "lostPictures": .stringConvertible(info.statistics.lostPictures),
+                                    "demuxCorrupted": .stringConvertible(info.statistics.demuxCorrupted)
+                                ]
+                            )
                         case .paused:
                             manager.setPlaybackRequestStatus(status: .paused)
                         }
@@ -214,8 +331,17 @@ extension VLCMediaPlayerProxy {
                         }
                     }
                     .onReceive(manager.$playbackItem) { playbackItem in
+                        didScheduleLiveOverlayDismissal = false
                         guard let playbackItem else { return }
+                        if let proxyOwner = manager.proxy as? VLCMediaPlayerProxy {
+                            proxyOwner.hasRetriedCurrentItem = false
+                        }
+                        manager.logger.info(
+                            "VLC playNewMedia",
+                            metadata: ["url": .stringConvertible(playbackItem.url.absoluteString)]
+                        )
                         proxy.playNewMedia(vlcConfiguration(for: playbackItem))
+                        proxy.setSubtitleTrack(.absolute(playbackItem.selectedSubtitleStreamIndex ?? -1))
                     }
                     .backport
                     .onChange(of: manager.rate) { _, newValue in

--- a/Shared/ViewModels/LiveTVGuideViewModel.swift
+++ b/Shared/ViewModels/LiveTVGuideViewModel.swift
@@ -1,0 +1,172 @@
+//
+// Swiftfin is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, you can obtain one at https://mozilla.org/MPL/2.0/.
+//
+// Copyright (c) 2026 Jellyfin & Jellyfin Contributors
+//
+
+import Foundation
+import JellyfinAPI
+
+@MainActor
+final class LiveTVGuideViewModel: ViewModel {
+
+    enum State: Hashable {
+        case content
+        case error(ErrorMessage)
+        case initial
+        case refreshing
+    }
+
+    @Published
+    private(set) var channels: [ChannelProgram] = []
+    @Published
+    private(set) var isLoadingNextPage = false
+    @Published
+    private(set) var maxDate: Date = .now
+    @Published
+    private(set) var minDate: Date = .now
+    @Published
+    private(set) var state: State = .initial
+
+    private let channelPageSize = 200
+    private let preloadThreshold = 40
+
+    private var channelStartIndex = 0
+    private var hasNextChannelPage = true
+    private var groupedPrograms: [String?: [BaseItemDto]] = [:]
+    private var nextPageTask: Task<Void, Never>?
+    private var refreshTask: Task<Void, Never>?
+
+    var hasNoResults: Bool {
+        channels.isEmpty
+    }
+
+    deinit {
+        nextPageTask?.cancel()
+        refreshTask?.cancel()
+    }
+
+    func refresh() {
+        nextPageTask?.cancel()
+        refreshTask?.cancel()
+        state = .refreshing
+
+        refreshTask = Task { [weak self] in
+            guard let self else { return }
+
+            do {
+                let guideWindow = makeGuideWindow()
+                let programs = try await getPrograms(minDate: guideWindow.minDate, maxDate: guideWindow.maxDate)
+                let channelPage = try await getChannelPage(startIndex: 0)
+
+                guard !Task.isCancelled else { return }
+
+                minDate = guideWindow.minDate
+                maxDate = guideWindow.maxDate
+                groupedPrograms = Dictionary(grouping: programs, by: \.channelID)
+                channelStartIndex = channelPage.count
+                hasNextChannelPage = channelPage.count == channelPageSize
+                channels = channelPrograms(for: channelPage)
+                state = .content
+            } catch {
+                guard !Task.isCancelled else { return }
+                state = .error(.init(error.localizedDescription))
+            }
+        }
+    }
+
+    func loadNextPageIfNeeded(currentIndex: Int) {
+        guard hasNextChannelPage, !isLoadingNextPage else { return }
+        guard channels.count - currentIndex <= preloadThreshold else { return }
+
+        loadNextPage()
+    }
+
+    private func loadNextPage() {
+        nextPageTask?.cancel()
+        isLoadingNextPage = true
+
+        let startIndex = channelStartIndex
+
+        nextPageTask = Task { [weak self] in
+            guard let self else { return }
+
+            do {
+                let channelPage = try await getChannelPage(startIndex: startIndex)
+                guard !Task.isCancelled else { return }
+
+                channelStartIndex += channelPage.count
+                hasNextChannelPage = channelPage.count == channelPageSize
+                channels = channelPrograms(for: channels.map(\.channel) + channelPage)
+                isLoadingNextPage = false
+            } catch {
+                guard !Task.isCancelled else { return }
+                isLoadingNextPage = false
+            }
+        }
+    }
+
+    private func makeGuideWindow() -> (minDate: Date, maxDate: Date) {
+        let minDate = Calendar.current.date(byAdding: .minute, value: -30, to: .now) ?? .now
+        let maxDate = Calendar.current.date(byAdding: .hour, value: 6, to: .now) ?? .now
+        return (minDate, maxDate)
+    }
+
+    private func getChannelPage(startIndex: Int) async throws -> [BaseItemDto] {
+        var parameters = Paths.GetLiveTvChannelsParameters()
+        parameters.fields = .MinimumFields
+        parameters.limit = channelPageSize
+        parameters.startIndex = startIndex
+
+        let request = Paths.getLiveTvChannels(parameters: parameters)
+        let response = try await userSession.client.send(request)
+
+        return response.value.items ?? []
+    }
+
+    private func getPrograms(minDate: Date, maxDate: Date) async throws -> [BaseItemDto] {
+        var parameters = Paths.GetLiveTvProgramsParameters()
+        parameters.fields = .MinimumFields.appending(.channelInfo)
+        parameters.limit = 2000
+        parameters.maxStartDate = maxDate
+        parameters.minEndDate = minDate
+        parameters.sortBy = [ItemSortBy.startDate]
+
+        let request = Paths.getLiveTvPrograms(parameters: parameters)
+        let response = try await userSession.client.send(request)
+
+        return response.value.items ?? []
+    }
+
+    private func channelPrograms(for channels: [BaseItemDto]) -> [ChannelProgram] {
+        channels.map { channel in
+            ChannelProgram(
+                channel: channel,
+                programs: (groupedPrograms[channel.id] ?? [])
+                    .sorted(using: \.startDate)
+            )
+        }
+        .sorted { lhs, rhs in
+            switch (lhs.channel.channelNumberValue, rhs.channel.channelNumberValue) {
+            case let (lhsNumber?, rhsNumber?) where lhsNumber != rhsNumber:
+                lhsNumber < rhsNumber
+            case (_?, nil):
+                true
+            case (nil, _?):
+                false
+            default:
+                lhs.channel.displayTitle.localizedStandardCompare(rhs.channel.displayTitle) == .orderedAscending
+            }
+        }
+    }
+}
+
+private extension BaseItemDto {
+
+    var channelNumberValue: Double? {
+        guard let number else { return nil }
+        return Double(number)
+    }
+}

--- a/Shared/Views/LiveTVGuideView.swift
+++ b/Shared/Views/LiveTVGuideView.swift
@@ -1,0 +1,266 @@
+//
+// Swiftfin is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, you can obtain one at https://mozilla.org/MPL/2.0/.
+//
+// Copyright (c) 2026 Jellyfin & Jellyfin Contributors
+//
+
+import JellyfinAPI
+import SwiftUI
+
+struct LiveTVGuideView: View {
+
+    @Router
+    private var router
+
+    @StateObject
+    private var viewModel = LiveTVGuideViewModel()
+
+    private let halfHourWidth: CGFloat = UIDevice.isTV ? 260 : 160
+    private let rowHeight: CGFloat = UIDevice.isTV ? 116 : 86
+    private let channelWidth: CGFloat = UIDevice.isTV ? 260 : 132
+
+    private var hourMarks: [Date] {
+        var marks: [Date] = []
+        var date = viewModel.minDate.roundedDownToHour
+
+        while date <= viewModel.maxDate {
+            marks.append(date)
+            date = Calendar.current.date(byAdding: .hour, value: 1, to: date) ?? date.addingTimeInterval(3600)
+        }
+
+        return marks
+    }
+
+    private var guideWidth: CGFloat {
+        max(halfHourWidth * 2, width(for: viewModel.minDate, end: viewModel.maxDate))
+    }
+
+    private func width(for start: Date, end: Date) -> CGFloat {
+        let seconds = max(900, end.timeIntervalSince(start))
+        return CGFloat(seconds / 1800) * halfHourWidth
+    }
+
+    private func playableChannel(for channel: ChannelProgram) -> BaseItemDto {
+        channel.channel
+    }
+
+    @ViewBuilder
+    private var contentView: some View {
+        ScrollView([.horizontal, .vertical], showsIndicators: true) {
+            LazyVStack(alignment: .leading, spacing: 1, pinnedViews: [.sectionHeaders]) {
+                Section {
+                    ForEach(Array(viewModel.channels.enumerated()), id: \.element.id) { index, channel in
+                        guideRow(channel: channel)
+                            .onAppear {
+                                viewModel.loadNextPageIfNeeded(currentIndex: index)
+                            }
+                    }
+
+                    if viewModel.isLoadingNextPage {
+                        HStack {
+                            ProgressView()
+                                .padding(.trailing, 8)
+                            Text("Loading channels")
+                                .foregroundStyle(.secondary)
+                        }
+                        .frame(width: channelWidth + guideWidth, height: rowHeight)
+                    }
+                } header: {
+                    timelineHeader
+                }
+            }
+            .padding(.bottom, EdgeInsets.edgePadding)
+        }
+    }
+
+    private var timelineHeader: some View {
+        HStack(spacing: 0) {
+            Text("Guide")
+                .font(.caption.weight(.semibold))
+                .foregroundStyle(.secondary)
+                .frame(width: channelWidth, height: 38, alignment: .leading)
+                .padding(.leading, EdgeInsets.edgePadding)
+                .background(Color.black.opacity(0.95))
+
+            HStack(spacing: 0) {
+                ForEach(hourMarks, id: \.self) { date in
+                    Text(date, style: .time)
+                        .font(.caption.weight(.semibold))
+                        .monospacedDigit()
+                        .foregroundStyle(.secondary)
+                        .frame(width: halfHourWidth * 2, height: 38, alignment: .leading)
+                }
+            }
+            .frame(width: guideWidth, alignment: .leading)
+            .background(Color.black.opacity(0.95))
+        }
+    }
+
+    private func guideRow(channel: ChannelProgram) -> some View {
+        HStack(spacing: 0) {
+            channelButton(channel: channel)
+                .frame(width: channelWidth, height: rowHeight)
+                .background(Color.secondarySystemFill.opacity(0.45))
+
+            HStack(spacing: 1) {
+                let visiblePrograms = channel.programs.filter { program in
+                    guard let startDate = program.startDate, let endDate = program.endDate else { return false }
+                    return endDate > viewModel.minDate && startDate < viewModel.maxDate
+                }
+
+                if visiblePrograms.isEmpty {
+                    emptyProgramCard
+                        .frame(width: guideWidth, height: rowHeight)
+                } else {
+                    ForEach(visiblePrograms, id: \.id) { program in
+                        programButton(program: program, channel: channel)
+                            .frame(
+                                width: width(
+                                    for: max(program.startDate ?? viewModel.minDate, viewModel.minDate),
+                                    end: min(program.endDate ?? viewModel.maxDate, viewModel.maxDate)
+                                ),
+                                height: rowHeight
+                            )
+                    }
+                }
+            }
+            .frame(width: guideWidth, alignment: .leading)
+        }
+    }
+
+    private func channelButton(channel: ChannelProgram) -> some View {
+        Button {
+            play(channel: channel)
+        } label: {
+            HStack(spacing: 10) {
+                PosterImage(item: channel.channel, type: .square)
+                    .frame(width: UIDevice.isTV ? 70 : 46, height: UIDevice.isTV ? 70 : 46)
+
+                VStack(alignment: .leading, spacing: 4) {
+                    if let number = channel.channel.number, number.isNotEmpty {
+                        Text(number)
+                            .font(.caption.weight(.semibold))
+                            .foregroundStyle(.secondary)
+                    }
+
+                    Text(channel.channel.displayTitle)
+                        .font(.callout.weight(.semibold))
+                        .lineLimit(2)
+                        .foregroundStyle(.primary)
+                }
+
+                Spacer(minLength: 0)
+            }
+            .padding(.horizontal, EdgeInsets.edgePadding)
+        }
+        .buttonStyle(.plain)
+    }
+
+    private func programButton(program: BaseItemDto, channel: ChannelProgram) -> some View {
+        Button {
+            play(channel: channel)
+        } label: {
+            VStack(alignment: .leading, spacing: 6) {
+                HStack(spacing: 4) {
+                    if let startDate = program.startDate {
+                        Text(startDate, style: .time)
+                    }
+
+                    if let endDate = program.endDate {
+                        Text("- " + endDate.formatted(date: .omitted, time: .shortened))
+                    }
+                }
+                .font(.caption2)
+                .monospacedDigit()
+                .foregroundStyle(.secondary)
+
+                Text(program.displayTitle)
+                    .font(.callout.weight(.semibold))
+                    .lineLimit(2)
+                    .foregroundStyle(.primary)
+
+                if let overview = program.overview, overview.isNotEmpty, UIDevice.isTV {
+                    Text(overview)
+                        .font(.caption)
+                        .lineLimit(1)
+                        .foregroundStyle(.secondary)
+                }
+
+                Spacer(minLength: 0)
+
+                if program.isAiringNow {
+                    ProgressBar(progress: CGFloat(program.programProgress ?? 0))
+                        .frame(height: 4)
+                        .foregroundStyle(Color.jellyfinPurple)
+                }
+            }
+            .padding(10)
+            .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
+            .background(program.isAiringNow ? Color.jellyfinPurple.opacity(0.16) : Color.secondarySystemFill.opacity(0.8))
+        }
+        .buttonStyle(.plain)
+    }
+
+    private var emptyProgramCard: some View {
+        Text("No program information")
+            .font(.callout)
+            .foregroundStyle(.secondary)
+            .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .leading)
+            .padding(.horizontal, EdgeInsets.edgePadding)
+            .background(Color.secondarySystemFill.opacity(0.5))
+    }
+
+    private func play(channel: ChannelProgram) {
+        let channel = playableChannel(for: channel)
+        router.route(
+            to: .videoPlayer(
+                provider: channel.getPlaybackItemProvider(userSession: viewModel.userSession)
+            )
+        )
+    }
+
+    var body: some View {
+        ZStack {
+            switch viewModel.state {
+            case .content:
+                if viewModel.hasNoResults {
+                    ContentUnavailableView(L10n.noChannels.localizedCapitalized, systemImage: "antenna.radiowaves.left.and.right")
+                } else {
+                    contentView
+                }
+            case let .error(error):
+                ErrorView(error: error)
+            case .initial, .refreshing:
+                ProgressView()
+            }
+        }
+        .navigationTitle("Guide")
+        .navigationBarTitleDisplayMode(.inline)
+        .refreshable {
+            viewModel.refresh()
+        }
+        .onFirstAppear {
+            if viewModel.state == .initial {
+                viewModel.refresh()
+            }
+        }
+    }
+}
+
+private extension BaseItemDto {
+
+    var isAiringNow: Bool {
+        guard let startDate, let endDate else { return false }
+        return startDate <= .now && endDate >= .now
+    }
+}
+
+private extension Date {
+
+    var roundedDownToHour: Date {
+        let components = Calendar.current.dateComponents([.year, .month, .day, .hour], from: self)
+        return Calendar.current.date(from: components) ?? self
+    }
+}

--- a/Swiftfin tvOS/Views/ProgramsView/ProgramsView.swift
+++ b/Swiftfin tvOS/Views/ProgramsView/ProgramsView.swift
@@ -22,9 +22,31 @@ struct ProgramsView: View {
     private var programsViewModel = ProgramsViewModel()
 
     @ViewBuilder
+    private var liveTVSectionButtons: some View {
+        HStack(spacing: 24) {
+            Button {
+                router.route(to: .liveTVGuide)
+            } label: {
+                Label("Guide", systemImage: "list.bullet.rectangle")
+            }
+
+            Button {
+                router.route(to: .channels)
+            } label: {
+                Label(L10n.channels, systemImage: "play.square.stack")
+            }
+        }
+        .font(.title3.weight(.semibold))
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .padding(.horizontal, 50)
+    }
+
+    @ViewBuilder
     private var contentView: some View {
         ScrollView(showsIndicators: false) {
             VStack(spacing: 20) {
+                liveTVSectionButtons
+
                 if programsViewModel.recommended.isNotEmpty {
                     programsSection(title: L10n.onNow, keyPath: \.recommended)
                 }

--- a/Swiftfin tvOS/Views/VideoPlayerContainerState/PlaybackControls/Components/ActionButtons/ActionButtons.swift
+++ b/Swiftfin tvOS/Views/VideoPlayerContainerState/PlaybackControls/Components/ActionButtons/ActionButtons.swift
@@ -45,7 +45,6 @@ extension VideoPlayer.PlaybackControls.NavigationBar {
                 filteredButtons.removeAll { $0 == .autoPlay }
                 filteredButtons.removeAll { $0 == .playbackSpeed }
 //                filteredButtons.removeAll { $0 == .playbackQuality }
-                filteredButtons.removeAll { $0 == .subtitles }
             }
 
             return filteredButtons

--- a/Swiftfin tvOS/Views/VideoPlayerContainerState/PlaybackControls/Components/ActionButtons/SubtitleActionButton.swift
+++ b/Swiftfin tvOS/Views/VideoPlayerContainerState/PlaybackControls/Components/ActionButtons/SubtitleActionButton.swift
@@ -33,7 +33,7 @@ extension VideoPlayer.PlaybackControls.NavigationBar.ActionButtons {
         private func content(playbackItem: MediaPlayerItem) -> some View {
             ForEach(playbackItem.subtitleStreams.prepending(.none), id: \.index) { stream in
                 Button {
-                    playbackItem.selectedSubtitleStreamIndex = stream.index ?? -1
+                    playbackItem.selectedSubtitleStreamIndex = stream.index
                 } label: {
                     if selectedSubtitleStreamIndex == stream.index {
                         Label(stream.displayTitle ?? L10n.unknown, systemImage: "checkmark")

--- a/Swiftfin tvOS/Views/VideoPlayerContainerState/PlaybackControls/PlaybackControls.swift
+++ b/Swiftfin tvOS/Views/VideoPlayerContainerState/PlaybackControls/PlaybackControls.swift
@@ -50,9 +50,17 @@ extension VideoPlayer {
             containerState.isScrubbing
         }
 
+        private var isPlayingLiveStream: Bool {
+            manager.item.isLiveStream && manager.playbackRequestStatus == .playing
+        }
+
+        private var shouldShowPlaybackChrome: Bool {
+            !isPlayingLiveStream && !isPresentingSupplement
+        }
+
         @ViewBuilder
         private var bottomContent: some View {
-            if !isPresentingSupplement {
+            if shouldShowPlaybackChrome {
 
                 NavigationBar()
                     .focusSection()
@@ -75,8 +83,9 @@ extension VideoPlayer {
                                 (location: 0, opacity: 0)
                                 (location: 1, opacity: 0.5)
                             }
-                            .isVisible(isScrubbing || isPresentingOverlay)
+                            .isVisible((isScrubbing || isPresentingOverlay) && !isPlayingLiveStream)
                             .animation(.linear(duration: 0.25), value: isPresentingOverlay)
+                            .animation(.linear(duration: 0.25), value: isPlayingLiveStream)
                     }
             }
             .animation(.linear(duration: 0.1), value: isScrubbing)
@@ -90,7 +99,7 @@ extension VideoPlayer {
                     if isPresentingSupplement {
                         containerState.selectedSupplement = nil
                     } else {
-                        manager.proxy?.stop()
+                        manager.stop()
                         router.dismiss()
                     }
                 default: ()

--- a/Swiftfin tvOS/Views/VideoPlayerContainerState/PlaybackControls/SupplementContainerView.swift
+++ b/Swiftfin tvOS/Views/VideoPlayerContainerState/PlaybackControls/SupplementContainerView.swift
@@ -29,6 +29,10 @@ struct SupplementContainerView: View {
     @State
     private var currentSupplements: IdentifiedArrayOf<AnyMediaPlayerSupplement> = []
 
+    private var isPlayingLiveStream: Bool {
+        manager.item.isLiveStream && manager.playbackRequestStatus == .playing
+    }
+
     @ViewBuilder
     private func supplementContainer(for supplement: some MediaPlayerSupplement) -> some View {
         AlternateLayoutView(alignment: .topLeading) {
@@ -67,9 +71,14 @@ struct SupplementContainerView: View {
                 }
             }
         }
-        .isVisible(containerState.isPresentingOverlay)
+        .background {
+            if !isPlayingLiveStream {
+                Color.blue.opacity(0.2)
+            }
+        }
+        .isVisible(containerState.isPresentingOverlay && !isPlayingLiveStream)
         .animation(.linear(duration: 0.2), value: containerState.isPresentingOverlay)
-        .background(Color.blue.opacity(0.2))
+        .animation(.linear(duration: 0.2), value: isPlayingLiveStream)
         .focusSection()
         .focused($isFocused)
         .onReceive(manager.$supplements) { newValue in

--- a/Swiftfin tvOS/Views/VideoPlayerContainerState/PlaybackControls/VideoPlayerContainerView.swift
+++ b/Swiftfin tvOS/Views/VideoPlayerContainerState/PlaybackControls/VideoPlayerContainerView.swift
@@ -53,13 +53,20 @@ extension VideoPlayer {
 
             @EnvironmentObject
             private var containerState: VideoPlayerContainerState
+            @EnvironmentObject
+            private var manager: MediaPlayerManager
 
             let player: AnyView
 
+            private var isPlayingLiveStream: Bool {
+                manager.item.isLiveStream && manager.playbackRequestStatus == .playing
+            }
+
             var body: some View {
                 player
-                    .overlay(Color.black.opacity(containerState.isPresentingPlaybackControls ? 0.3 : 0.0))
+                    .overlay(Color.black.opacity(containerState.isPresentingPlaybackControls && !isPlayingLiveStream ? 0.3 : 0.0))
                     .animation(.linear(duration: 0.2), value: containerState.isPresentingPlaybackControls)
+                    .animation(.linear(duration: 0.2), value: isPlayingLiveStream)
             }
         }
 

--- a/Swiftfin/Views/ProgramsView/ProgramsView.swift
+++ b/Swiftfin/Views/ProgramsView/ProgramsView.swift
@@ -27,6 +27,13 @@ struct ProgramsView: View {
         ScrollView(.horizontal, showsIndicators: false) {
             HStack {
                 liveTVSectionPill(
+                    title: "Guide",
+                    systemImage: "list.bullet.rectangle"
+                ) {
+                    router.route(to: .liveTVGuide)
+                }
+
+                liveTVSectionPill(
                     title: L10n.channels,
                     systemImage: "play.square.stack"
                 ) {

--- a/Swiftfin/Views/VideoPlayerContainerView/PlaybackControls/Components/NavigationBar/ActionButtons/ActionButtons.swift
+++ b/Swiftfin/Views/VideoPlayerContainerView/PlaybackControls/Components/NavigationBar/ActionButtons/ActionButtons.swift
@@ -47,7 +47,6 @@ extension VideoPlayer.PlaybackControls.NavigationBar {
                 filteredButtons.removeAll { $0 == .autoPlay }
                 filteredButtons.removeAll { $0 == .playbackSpeed }
 //                filteredButtons.removeAll { $0 == .playbackQuality }
-                filteredButtons.removeAll { $0 == .subtitles }
             }
 
             return filteredButtons

--- a/Swiftfin/Views/VideoPlayerContainerView/VideoPlayer+KeyCommands.swift
+++ b/Swiftfin/Views/VideoPlayerContainerView/VideoPlayer+KeyCommands.swift
@@ -46,6 +46,17 @@ extension VideoPlayer {
                     }
 
                     KeyCommandAction(
+                        title: L10n.close,
+                        input: UIKeyCommand.inputEscape
+                    ) {
+                        if containerState.isPresentingSupplement {
+                            containerState.select(supplement: nil)
+                        } else {
+                            manager.stop()
+                        }
+                    }
+
+                    KeyCommandAction(
                         title: L10n.playAndPause,
                         input: " "
                     ) {

--- a/Swiftfin/Views/VideoPlayerContainerView/VideoPlayerContainerView.swift
+++ b/Swiftfin/Views/VideoPlayerContainerView/VideoPlayerContainerView.swift
@@ -312,6 +312,26 @@ extension VideoPlayer {
             fatalError("init(coder:) has not been implemented")
         }
 
+        override func pressesBegan(_ presses: Set<UIPress>, with event: UIPressesEvent?) {
+            guard let press = presses.first else {
+                super.pressesBegan(presses, with: event)
+                return
+            }
+
+            switch press.type {
+            case .menu:
+                if containerState.isPresentingSupplement {
+                    containerState.select(supplement: nil)
+                } else {
+                    manager.stop()
+                }
+            case .playPause:
+                manager.togglePlayPause()
+            default:
+                super.pressesBegan(presses, with: event)
+            }
+        }
+
         // TODO: don't force unwrap optional, sometimes gets into weird state
         private var lastVerticalPanLocation: CGPoint?
         private var verticalPanGestureStartConstant: CGFloat?


### PR DESCRIPTION
## Normalize malformed media URLs for VLC playback.
- Normalize malformed URLs like .../stream%3F&DeviceId=... to .../stream?DeviceId=...
## Improve caching settings for live streams and network variability.
- Force a buffer for streaming content. 
## General player fixes/enhancements
- Update subtitle size computation to ensure it remains within a valid range.
-  Refactor playback controls to better manage live stream states and overlays.
- Hide overlay after live video playback starts.