### PR TITLE
tvOS Stepper Cleanup

### DIFF
--- a/Shared/Views/SettingsView/CustomizeSettingsView.swift
+++ b/Shared/Views/SettingsView/CustomizeSettingsView.swift
@@ -249,20 +249,13 @@ struct CustomizeSettingsView: View {
             PlatformPicker(L10n.defaultLayout, selection: $libraryDisplayType)
 
             if libraryDisplayType == .list, UIDevice.isPad || UIDevice.isTV {
-                #if os(tvOS)
                 Stepper(L10n.columns, value: $listColumnCount, in: 1 ... 3, step: 1) {
-                    Text(L10n.columns)
-                } content: {
-                    Text(listColumnCount.description)
+                    LabeledContent(L10n.columns) {
+                        Text(listColumnCount.description)
+                            .foregroundStyle(.secondary)
+                    }
                 }
-                #else
-                Stepper(L10n.columns, value: $listColumnCount, in: 1 ... 3, step: 1) {
-                    LabeledContent(
-                        L10n.columns,
-                        value: listColumnCount.description
-                    )
-                }
-                #endif
+                .foregroundStyle(.primary, .secondary)
             }
 
             Toggle(L10n.rememberLayout, isOn: $rememberLibraryLayout)

--- a/Shared/Views/SettingsView/VideoPlayerSettingsView.swift
+++ b/Shared/Views/SettingsView/VideoPlayerSettingsView.swift
@@ -174,6 +174,7 @@ struct VideoPlayerSettingsView: View {
             Stepper(L10n.resumeOffset, value: $resumeOffset, in: 0 ... 30, step: 1) {
                 LabeledContent(L10n.resumeOffset) {
                     Text(resumeOffset, format: SecondFormatter())
+                        .foregroundStyle(.secondary)
                 }
             }
 
@@ -321,6 +322,7 @@ struct VideoPlayerSettingsView: View {
             Stepper(L10n.subtitleSize, value: $subtitleSize, in: 1 ... 20, step: 1) {
                 LabeledContent(L10n.subtitleSize) {
                     Text(subtitleSize.description)
+                        .foregroundStyle(.secondary)
                 }
             }
 

--- a/Swiftfin tvOS/Components/Stepper.swift
+++ b/Swiftfin tvOS/Components/Stepper.swift
@@ -62,11 +62,7 @@ struct Stepper<
         ChevronButton {
             isPresented = true
         } label: {
-            LabeledContent {
-                content()
-            } label: {
-                label()
-            }
+            label()
         }
         ._alert(title, isPresented: $isPresented) {
             VStack {


### PR DESCRIPTION
### Summary

The stepper on tvOS should be secondary for the value we are stepping. We also have some spacing differences where some are more centered where they should be more trailing aligned. This PR aligns these steppers on tvOS with the other `ChevronButton`. See below:

<img width="543" height="138" alt="Columns" src="https://github.com/user-attachments/assets/4b653006-34ca-4273-b39b-6afb05bba769" />

<img width="541" height="82" alt="Resume" src="https://github.com/user-attachments/assets/37b8d128-0be9-45e7-8a20-ce2184d7e736" />

<img width="535" height="95" alt="Subtitles" src="https://github.com/user-attachments/assets/cda09b55-9826-4717-bcd6-f0e01540f8c9" />

Also better shares the `listColumnCount` stepper API because iOS and tvOS should be able to share that instead of the build flags.
