### PR TITLE
Fix Video Bar Subtitle Truncation

### DIFF
--- a/Swiftfin/Views/VideoPlayerContainerView/PlaybackControls/Components/NavigationBar/NavigationBar.swift
+++ b/Swiftfin/Views/VideoPlayerContainerView/PlaybackControls/Components/NavigationBar/NavigationBar.swift
@@ -100,7 +100,7 @@ extension VideoPlayer.PlaybackControls.NavigationBar {
             Text(titleSubtitle.title)
                 .fontWeight(.semibold)
                 .lineLimit(1)
-                .frame(minWidth: max(50, subtitleContentSize.width))
+                .frame(maxWidth: .infinity, alignment: .leading)
                 .overlay(alignment: .bottomLeading) {
                     if let subtitle = titleSubtitle.subtitle {
                         _subtitle(subtitle)


### PR DESCRIPTION
If this causes a conflict with the tvOS player work I'll handle it.

Closes #2020