### PR TITLE
fix #1885 Native Player not saving playback progress

### DIFF
--- a/Shared/Components/NativeVideoPlayer.swift
+++ b/Shared/Components/NativeVideoPlayer.swift
@@ -67,6 +67,9 @@ struct NativeVideoPlayer: View {
         } message: {
             Text(L10n.unableToLoadThisItem)
         }
+        .onFinalDisappear {
+            manager.stop()
+        }
     }
 }
 


### PR DESCRIPTION
fix #1885 

Beyond what described in the original ticket, I also found these bugs that are also fixed by this PR: 
- you don't need 720p for this bug to appear 
- When closing the player by flicking down or tap top left X, the player continues to play in background (at least on my iPad)
- `sendStopReport` never get called
