### PR TITLE
No audio on iOS after alarm or timer goes off (issue #1975)

### DIFF
--- a/Shared/Objects/MediaPlayerManager/NowPlayable/NowPlayableObserver.swift
+++ b/Shared/Objects/MediaPlayerManager/NowPlayable/NowPlayableObserver.swift
@@ -183,6 +183,7 @@ class NowPlayableObserver: ViewModel, MediaPlayerObserver {
                 if playbackRequestStateBeforeInterruption == .playing {
                     if options.contains(.shouldResume) {
                         manager?.setPlaybackRequestStatus(status: .playing)
+                        manager?.proxy?.play()
                     } else {
                         manager?.setPlaybackRequestStatus(status: .paused)
                     }

--- a/Shared/Services/Notifications.swift
+++ b/Shared/Services/Notifications.swift
@@ -230,12 +230,8 @@ extension Notifications.Key {
             else {
                 return nil
             }
-            guard let optionsUInt = userInfo[AVAudioSessionInterruptionOptionKey] as? UInt
-            else {
-                return nil
-            }
-
-            let options = AVAudioSession.InterruptionOptions(rawValue: optionsUInt)
+            let options = (userInfo[AVAudioSessionInterruptionOptionKey] as? UInt)
+                .map(AVAudioSession.InterruptionOptions.init(rawValue:)) ?? []
 
             return (type, options)
         }


### PR DESCRIPTION
fix issue #1975
the original `guard let` was too strict, remove so it accepts `AVAudioSessionInterruptionOptionKey`
resume playing on `.shouldResume`