### PR TITLE
Render markdown in the login disclaimer

### DIFF
--- a/Shared/Views/UserSignInView.swift
+++ b/Shared/Views/UserSignInView.swift
@@ -92,6 +92,21 @@ struct UserSignInView: View {
         return evaluatedPolicy
     }
 
+    private func disclaimerText(_ disclaimer: String) -> Text {
+        let options = AttributedString.MarkdownParsingOptions(
+            interpretedSyntax: .inlineOnlyPreservingWhitespace
+        )
+
+        if let attributedString = try? AttributedString(
+            markdown: disclaimer,
+            options: options
+        ) {
+            return Text(attributedString)
+        } else {
+            return Text(disclaimer)
+        }
+    }
+
     // MARK: - Sign In Section
 
     @ViewBuilder
@@ -184,7 +199,7 @@ struct UserSignInView: View {
 
         if let disclaimer = viewModel.serverDisclaimer {
             Section(L10n.disclaimer) {
-                Text(disclaimer)
+                disclaimerText(disclaimer)
                     .font(.callout)
             }
         }

--- a/Shared/Views/UserSignInView.swift
+++ b/Shared/Views/UserSignInView.swift
@@ -92,18 +92,15 @@ struct UserSignInView: View {
         return evaluatedPolicy
     }
 
-    private func disclaimerText(_ disclaimer: String) -> Text {
-        let options = AttributedString.MarkdownParsingOptions(
-            interpretedSyntax: .inlineOnlyPreservingWhitespace
-        )
-
+    @ViewBuilder
+    private func disclaimerText(_ disclaimer: String) -> some View {
         if let attributedString = try? AttributedString(
             markdown: disclaimer,
-            options: options
+            options: .init(interpretedSyntax: .inlineOnlyPreservingWhitespace)
         ) {
-            return Text(attributedString)
+            Text(attributedString)
         } else {
-            return Text(disclaimer)
+            Text(disclaimer)
         }
     }
 


### PR DESCRIPTION
## Summary

The login disclaimer now renders markdown. The server's `BrandingOptions.loginDisclaimer` is configured on the Jellyfin server and supports markdown, so a disclaimer that contains a markdown link (for example, a link to a Jellyseerr instance) renders as a tappable link instead of raw `[text](url)` syntax.

In `Shared/Views/UserSignInView.swift`, the `serverDisclaimer` section previously used `Text(disclaimer)`, which renders the string as plain text. This adds a small `disclaimerText(_:)` helper that builds an `AttributedString(markdown:)` using `.inlineOnlyPreservingWhitespace` parsing options, and falls back to the plain string if parsing fails. Because this is a single shared view, the change covers both iOS and tvOS. The `Section(L10n.disclaimer)` wrapper is unchanged.

## Why this matters

Closes the gap reported in #2039, where the disclaimer showed raw markdown syntax in Swiftfin. Jellyfin Web and the Jellyfin mobile app both render the disclaimer as markdown, and the reporter confirmed this with a screenshot, so this brings Swiftfin to parity with the other clients.

## Testing

- A disclaimer containing a markdown link renders as a tappable link rather than raw `[text](url)`.
- A plain-text disclaimer with no markdown renders unchanged, with whitespace preserved via `.inlineOnlyPreservingWhitespace`.
- An empty or nil disclaimer hides the section as before (the `if let disclaimer` guard is untouched).
- Malformed markdown falls back to the raw string instead of crashing or rendering nothing.
- `swiftformat --lint` passes on the changed file.

Fixes #2039
