### PR TITLE
Compiling with Xcode 27

### DIFF
--- a/Swiftfin tvOS/Views/ItemView/Components/OverviewView.swift
+++ b/Swiftfin tvOS/Views/ItemView/Components/OverviewView.swift
@@ -65,7 +65,7 @@ extension ItemView {
 }
 
 extension ItemView.OverviewView {
-#if compiler(<6.4)
+    #if compiler(<6.4)
     init(item: BaseItemDto) {
         self.init(
             item: item,
@@ -73,7 +73,7 @@ extension ItemView.OverviewView {
             taglineLineLimit: nil
         )
     }
-#endif
+    #endif
     func overviewLineLimit(_ limit: Int) -> Self {
         copy(modifying: \.overviewLineLimit, with: limit)
     }

--- a/Swiftfin tvOS/Views/ItemView/Components/OverviewView.swift
+++ b/Swiftfin tvOS/Views/ItemView/Components/OverviewView.swift
@@ -65,7 +65,7 @@ extension ItemView {
 }
 
 extension ItemView.OverviewView {
-
+#if compiler(<6.4)
     init(item: BaseItemDto) {
         self.init(
             item: item,
@@ -73,7 +73,7 @@ extension ItemView.OverviewView {
             taglineLineLimit: nil
         )
     }
-
+#endif
     func overviewLineLimit(_ limit: Int) -> Self {
         copy(modifying: \.overviewLineLimit, with: limit)
     }

--- a/Swiftfin.xcodeproj/project.pbxproj
+++ b/Swiftfin.xcodeproj/project.pbxproj
@@ -1285,8 +1285,8 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/JohnEstropia/CoreStore.git";
 			requirement = {
-				kind = upToNextMajorVersion;
-				minimumVersion = 9.0.0;
+				branch = develop;
+				kind = branch;
 			};
 		};
 		E13DD3D127168E65009D4DAF /* XCRemoteSwiftPackageReference "Defaults" */ = {

--- a/Swiftfin.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Swiftfin.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "7ec54c37c9193d5e227efb16aa23f2cf463955649f014ffbd3610ee3e0dacd7a",
+  "originHash" : "0f98fea88b698b5a975f481b6c07f3e037d6a37d631ead73628acc99c6c0bb02",
   "pins" : [
     {
       "identity" : "blurhashkit",
@@ -42,8 +42,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/JohnEstropia/CoreStore.git",
       "state" : {
-        "revision" : "5a0d27cf343c6e341b0ef3c8d36104770b27a839",
-        "version" : "9.3.0"
+        "branch" : "develop",
+        "revision" : "332883717578c009e1e8917a647a2f6c975e8f0a"
       }
     },
     {

--- a/Swiftfin/Views/ItemView/Components/OverviewView.swift
+++ b/Swiftfin/Views/ItemView/Components/OverviewView.swift
@@ -71,7 +71,7 @@ extension ItemView {
 }
 
 extension ItemView.OverviewView {
-
+    #if compiler(<6.4)
     init(item: BaseItemDto) {
         self.init(
             item: item,
@@ -79,7 +79,7 @@ extension ItemView.OverviewView {
             taglineLineLimit: nil
         )
     }
-
+    #endif
     func overviewLineLimit(_ limit: Int) -> Self {
         copy(modifying: \.overviewLineLimit, with: limit)
     }


### PR DESCRIPTION
so far here's the problems I found, hope you find it helpful
1 - CoreStore cs_sync function, just fixed on develop branch, but looks like this repo is waiting for an official release. This branch use develop as POC only (so probably DO NOT MERGE until 9.4.0)
2. OverviewView.swift:75:5 Invalid redeclaration of synthesized memberwise 'init(item:)' , I added `#if compiler(6.4)` (Xcode 27 use Swift 6.4) so that you can merge early and still have the project working with Xcode 26.5