### PR TITLE
Report LiveStreamId in playback start, progress, and stop

### DIFF
--- a/Shared/Objects/MediaPlayerManager/MediaProgressObserver.swift
+++ b/Shared/Objects/MediaPlayerManager/MediaProgressObserver.swift
@@ -114,6 +114,7 @@ class MediaProgressObserver: ViewModel, MediaPlayerObserver {
             var info = PlaybackStateInfo()
             info.audioStreamIndex = item.selectedAudioStreamIndex
             info.itemID = item.baseItem.id
+            info.liveStreamID = item.mediaSource.liveStreamID
             info.mediaSourceID = item.mediaSource.id
             info.playSessionID = item.playSessionID
             info.positionTicks = seconds?.ticks
@@ -136,6 +137,7 @@ class MediaProgressObserver: ViewModel, MediaPlayerObserver {
         Task {
             var info = PlaybackStopInfo()
             info.itemID = item.baseItem.id
+            info.liveStreamID = item.mediaSource.liveStreamID
             info.mediaSourceID = item.mediaSource.id
             info.playSessionID = item.playSessionID
             info.positionTicks = seconds?.ticks
@@ -157,6 +159,7 @@ class MediaProgressObserver: ViewModel, MediaPlayerObserver {
             info.audioStreamIndex = item.selectedAudioStreamIndex
             info.isPaused = isPaused
             info.itemID = item.baseItem.id
+            info.liveStreamID = item.mediaSource.liveStreamID
             info.mediaSourceID = item.mediaSource.id
             info.playSessionID = item.playSessionID
             info.positionTicks = seconds?.ticks


### PR DESCRIPTION
Swiftfin doesn't send `LiveStreamId` in its playback reports, unlike the web, vue, android, androidtv, and chromecast clients. This wires it into the start, progress, and stop reports in `MediaProgressObserver`, using the media source we already have.

This isn't the root-cause fix and doesn't need to merge for the tuner leak to be solved, jellyfin/jellyfin#17178 fixes that on the server side. This is complementary: it aligns Swiftfin with the other clients and gives the server's normal close paths the id they expect.

Background: since jellyfin/jellyfin#13220 the server only closes a live stream that's tracked in its session map, and that map is only populated when the client reports `LiveStreamId`. Because Swiftfin never did, a clean stop couldn't close the stream and a force quit left the HDHomeRun tuner copying to disk until a restart. With the id present, the server closes on stop immediately, and on force quit when the transcode kill timer fires.

@theguymadmax this is a follow up to jellyfin/jellyfin#17178, this is just a client-side hardening - I understand that your server-side PR fixes this same issue for clients that don't report the `LiveStreamId` at all

Testing (HDHomeRun, transcoded, 10.11.11 server): clean stop closes the stream right away; force quit releases it when the kill timer fires. A/B on the same server confirmed an unfixed build leaks the tuner until restart while the fixed build releases it.

Related: jellyfin/jellyfin#16880, jellyfin/jellyfin#15769, jellyfin/jellyfin#17178, jellyfin/jellyfin#17177.
