### PR TITLE
Fix Missing `ProgramsView` Routing

### DIFF
--- a/Shared/Extensions/JellyfinAPI/BaseItemDto/BaseItemDto.swift
+++ b/Shared/Extensions/JellyfinAPI/BaseItemDto/BaseItemDto.swift
@@ -206,7 +206,7 @@ extension BaseItemDto {
                 else {
                     throw ErrorMessage(L10n.unknownError)
                 }
-                return try await MediaPlayerItem.build(for: program, mediaSource: mediaSource)
+                return try await MediaPlayerItem.build(for: channel, mediaSource: mediaSource)
             }
         default:
             MediaPlayerItemProvider(item: self) { item in

--- a/Swiftfin tvOS/Views/ProgramsView/ProgramsView.swift
+++ b/Swiftfin tvOS/Views/ProgramsView/ProgramsView.swift
@@ -66,12 +66,10 @@ struct ProgramsView: View {
             title: title,
             type: .landscape,
             items: programsViewModel[keyPath: keyPath]
-        ) { _ in
-//            guard let mediaSource = channelProgram.channel.mediaSources?.first else { return }
-//            router.route(
-//                to: \.liveVideoPlayer,
-//                LiveVideoPlayerManager(item: channelProgram.channel, mediaSource: mediaSource)
-//            )
+        ) { item in
+            guard let userSession = programsViewModel.userSession else { return }
+            let provider = item.getPlaybackItemProvider(userSession: userSession)
+            router.route(to: .videoPlayer(provider: provider))
         } label: {
             ProgramButtonContent(program: $0)
         }

--- a/Swiftfin/Views/ProgramsView/ProgramsView.swift
+++ b/Swiftfin/Views/ProgramsView/ProgramsView.swift
@@ -100,10 +100,10 @@ struct ProgramsView: View {
             title: title,
             type: .landscape,
             items: programsViewModel[keyPath: keyPath]
-        ) { _, _ in
-            // router.route(
-            //     to: .liveVideoPlayer(manager: LiveVideoPlayerManager(program: item))
-            // )
+        ) { item, _ in
+            guard let userSession = programsViewModel.userSession else { return }
+            let provider = item.getPlaybackItemProvider(userSession: userSession)
+            router.route(to: .videoPlayer(provider: provider))
         } label: {
             ProgramButtonContent(program: $0)
         }


### PR DESCRIPTION
### Summary

Resolves https://github.com/jellyfin/Swiftfin/issues/2064

Post media player rework, going from program to channel content routing was commented out. This just enables the routing back and fixes a change on `BaseItemDto` where we create the channel object or error but then we use the program. This is just using the process that we use for the `SearchView` and brings this to the `ProgramView`.

### Other Considerations

I know there is a grander rework in https://github.com/jellyfin/Swiftfin/pull/1752 so I tried to make this as small as possible to just resolve the routing. I was originally trying to see what we could bring over from that branch but there are a lot of other changes the new `ProgramView` relied on so I defaulted to the minimal fix.