### PR TITLE
Update packages, runners, tvOS home fix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,10 +21,10 @@ jobs:
           - "Swiftfin"
           - "Swiftfin tvOS"
 
-    runs-on: macos-15
+    runs-on: macos-26
 
     env:
-      XCODE_VERSION: "26.3"
+      XCODE_VERSION: "26.6"
 
     steps:
       - name: Checkout

--- a/.github/workflows/testflight.yml
+++ b/.github/workflows/testflight.yml
@@ -79,11 +79,11 @@ jobs:
   test_build:
     name: Build and upload to TestFlight
     needs: resolve_platform
-    runs-on: macos-15
+    runs-on: macos-26
     strategy:
       matrix: ${{ fromJSON(needs.resolve_platform.outputs.matrix) }}
     env:
-      XCODE_VERSION: "26.3"
+      XCODE_VERSION: "26.6"
       PLATFORM: ${{ matrix.platform }}
       SCHEME: ${{ matrix.scheme }}
       BUILD_CERTIFICATE_BASE64: ${{ github.event.client_payload.BUILD_CERTIFICATE_BASE64 || secrets.BUILD_CERTIFICATE_BASE64 }}

--- a/.github/workflows/validate-pr.yaml
+++ b/.github/workflows/validate-pr.yaml
@@ -13,7 +13,7 @@ jobs:
   build:
     name: "Validate PR 🧹"
     if: github.event.pull_request.draft == false
-    runs-on: macos-14
+    runs-on: macos-26
 
     steps:
       - name: Checkout

--- a/Scripts/Translations/FindUnusedStrings.swift
+++ b/Scripts/Translations/FindUnusedStrings.swift
@@ -39,7 +39,9 @@ for line in localizationLines {
     let trimmed = line.trimmingCharacters(in: .whitespacesAndNewlines)
 
     // Skip empty lines or comments
-    if trimmed.isEmpty || trimmed.hasPrefix("//") { continue }
+    if trimmed.isEmpty || trimmed.hasPrefix("//") {
+        continue
+    }
 
     // Match valid localization entries and add them to the dictionary
     if let match = line.firstMatch(of: localizationRegex) {
@@ -61,7 +63,9 @@ func scanDirectory(_ path: String) {
         let filePath = "\(path)/\(file)"
 
         // Skip the excluded file
-        if filePath == excludedFile { continue }
+        if filePath == excludedFile {
+            continue
+        }
 
         // Process only Swift files
         if file.hasSuffix(".swift") {

--- a/Shared/Components/FadeContentTransitionView.swift
+++ b/Shared/Components/FadeContentTransitionView.swift
@@ -63,7 +63,7 @@ struct FadeContentTransitionView<Item: Hashable, Content: View>: UIViewRepresent
     final class Coordinator {
 
         private var currentContentID: AnyHashable?
-        private var currentContent: HostedFadeContentTransitionContent<Content>?
+        private var currentContent: HostedFadeContentTransitionContent<HostingRootView<Content>>?
         private var updateGeneration = 0
         private var debounceUpdate: DispatchWorkItem?
 
@@ -121,13 +121,13 @@ struct FadeContentTransitionView<Item: Hashable, Content: View>: UIViewRepresent
             in view: UIFadeContentTransitionView
         ) {
             if currentContentID == id, let currentContent {
-                currentContent.hostingController.rootView = content
+                currentContent.hostingController.rootView.content = content
                 debounceUpdate = nil
                 return
             }
 
             let hostingController = HostingController(content: content)
-            hostingController.disablesSafeArea = true
+            hostingController.disableSafeArea = true
             hostingController.view.backgroundColor = .clear
 
             let transitionContent = HostedFadeContentTransitionContent(

--- a/Shared/Components/Pickers/JumpIntervalPicker.swift
+++ b/Shared/Components/Pickers/JumpIntervalPicker.swift
@@ -29,7 +29,11 @@ struct JumpIntervalPicker: View {
                 selection: selection
                     .map(
                         getter: {
-                            if case .custom = $0 { .zero } else { $0.rawValue }
+                            if case .custom = $0 {
+                                .zero
+                            } else {
+                                $0.rawValue
+                            }
                         },
                         setter: {
                             MediaJumpInterval(rawValue: $0)
@@ -54,7 +58,11 @@ struct JumpIntervalPicker: View {
                 selection: selection
                     .map(
                         getter: {
-                            if case .custom = $0 { .zero } else { $0.rawValue }
+                            if case .custom = $0 {
+                                .zero
+                            } else {
+                                $0.rawValue
+                            }
                         },
                         setter: {
                             MediaJumpInterval(rawValue: $0)

--- a/Shared/Components/Pickers/PlaybackSpeedPicker.swift
+++ b/Shared/Components/Pickers/PlaybackSpeedPicker.swift
@@ -29,7 +29,11 @@ struct PlaybackSpeedPicker: View {
                 selection: selection
                     .map(
                         getter: { value -> Float in
-                            if case .custom = value { Float(0) } else { value.rawValue }
+                            if case .custom = value {
+                                Float(0)
+                            } else {
+                                value.rawValue
+                            }
                         },
                         setter: {
                             PlaybackSpeed(rawValue: $0)
@@ -54,7 +58,11 @@ struct PlaybackSpeedPicker: View {
                 selection: selection
                     .map(
                         getter: { value -> Float in
-                            if case .custom = value { Float(0) } else { value.rawValue }
+                            if case .custom = value {
+                                Float(0)
+                            } else {
+                                value.rawValue
+                            }
                         },
                         setter: {
                             PlaybackSpeed(rawValue: $0)

--- a/Shared/Coordinators/Navigation/NavigationInjectionView.swift
+++ b/Shared/Coordinators/Navigation/NavigationInjectionView.swift
@@ -97,11 +97,13 @@ struct NavigationInjectionView: View {
         .presentation(
                 $coordinator.presentedFullScreen,
                 transition: .zoomIfAvailable(
-                    options: .init(
+                    .init(
                         dimmingVisualEffect: .systemThickMaterialDark,
-                        options: .init(
-                            isInteractive: isPresentationInteractive
-                        )
+                        prefersScalePresentingView: false
+                    ),
+                    options: .init(
+                        isInteractive: isPresentationInteractive,
+                        preferredPresentationSafeAreaInsets: .zero,
                     ),
                     otherwise: .slide(.init(edge: .bottom), options: .init(isInteractive: isPresentationInteractive))
                 )
@@ -115,7 +117,6 @@ struct NavigationInjectionView: View {
                     }
                 }
 
-                // TODO: presentation options for customizing background color, dimming effect, etc.
                 vc.view.backgroundColor = .black
 
                 return vc

--- a/Shared/Extensions/ProgressViewStyle/PlaybackProgressViewStyle.swift
+++ b/Shared/Extensions/ProgressViewStyle/PlaybackProgressViewStyle.swift
@@ -23,13 +23,17 @@ struct PlaybackProgressViewStyle: ProgressViewStyle {
 
     @ViewBuilder
     private func buildCapsule(for progress: Double) -> some View {
+        let width = contentSize.width.isFinite ? max(0, contentSize.width) : 0
+        let height = contentSize.height.isFinite ? max(0, contentSize.height) : 0
+        let normalizedProgress = progress.isFinite ? clamp(progress, min: 0, max: 1) : 0
+
         Rectangle()
             .cornerRadius(
-                cornerStyle == .round ? contentSize.height / 2 : 0,
+                cornerStyle == .round ? height / 2 : 0,
                 corners: [.topLeft, .bottomLeft]
             )
-            .frame(width: contentSize.width * clamp(progress, min: 0, max: 1) + contentSize.height)
-            .offset(x: -contentSize.height)
+            .frame(width: width * normalizedProgress + height)
+            .offset(x: -height)
     }
 
     func makeBody(configuration: Configuration) -> some View {

--- a/Shared/Objects/MediaPlayerManager/MediaPlayerItem/MediaPlayerItem.swift
+++ b/Shared/Objects/MediaPlayerManager/MediaPlayerItem/MediaPlayerItem.swift
@@ -133,7 +133,9 @@ class MediaPlayerItem: ViewModel, MediaPlayerObserver {
         case .audio:
 
             // Transcodes contain a single audio track and MUST rebuild.
-            if isTranscoding { return true }
+            if isTranscoding {
+                return true
+            }
 
             guard let newStream = audioStreams.first(where: { $0.index == newIndex }) else { return true }
 
@@ -149,7 +151,9 @@ class MediaPlayerItem: ViewModel, MediaPlayerObserver {
             let oldStream = oldIndex.flatMap { idx in subtitleStreams.first { $0.index == idx } }
 
             // Transitioning away from encoded subtitles always requires a rebuild so the server stops burning them into the video.
-            if oldStream?.deliveryMethod == .encode { return true }
+            if oldStream?.deliveryMethod == .encode {
+                return true
+            }
 
             // Catch if the new stream doesn't exist. If non-existent this will fallback to -1 and disable locally.
             guard let newStream = subtitleStreams.first(where: { $0.index == newIndex }) else { return false }

--- a/Shared/Objects/SwizzleDefaults.swift
+++ b/Shared/Objects/SwizzleDefaults.swift
@@ -71,7 +71,9 @@ fileprivate extension UserDefaults {
 
     @objc
     func _ds_object(forKey key: String) -> Any? {
-        if let resolved = SwizzleDefaults.resolve(key) { return resolved }
+        if let resolved = SwizzleDefaults.resolve(key) {
+            return resolved
+        }
         return _ds_object(forKey: key)
     }
 

--- a/Shared/Views/VideoPlayer/Components/PlaybackProgress/ChapterTrackMask.swift
+++ b/Shared/Views/VideoPlayer/Components/PlaybackProgress/ChapterTrackMask.swift
@@ -19,12 +19,17 @@ extension VideoPlayer.PlaybackControls.PlaybackProgress {
         private var unitPoints: [Double] {
             chapters.map { chapter in
                 guard let startSeconds = chapter.chapterInfo.startSeconds,
+                      runtime > .zero,
+                      startSeconds >= .zero,
                       startSeconds < runtime
                 else {
                     return 0
                 }
 
-                return startSeconds / runtime
+                let unitPoint = startSeconds / runtime
+                guard unitPoint.isFinite else { return 0 }
+
+                return clamp(unitPoint, min: 0, max: 1)
             }
         }
 

--- a/Shared/Views/VideoPlayer/VideoPlayerContainerView/VideoPlayerContainerView.swift
+++ b/Shared/Views/VideoPlayer/VideoPlayerContainerView/VideoPlayerContainerView.swift
@@ -226,7 +226,7 @@ extension VideoPlayer {
                     .environmentObject(manager)
                     .eraseToAnyView()
             )
-            controller.disablesSafeArea = true
+            controller.disableSafeArea = true
             controller.automaticallyAllowUIKitAnimationsForNextUpdate = true
             controller.view.translatesAutoresizingMaskIntoConstraints = false
             return controller
@@ -239,7 +239,7 @@ extension VideoPlayer {
                     .environmentObject(manager)
                     .eraseToAnyView()
             )
-            controller.disablesSafeArea = true
+            controller.disableSafeArea = true
             controller.automaticallyAllowUIKitAnimationsForNextUpdate = true
             controller.view.translatesAutoresizingMaskIntoConstraints = false
             return controller
@@ -251,7 +251,7 @@ extension VideoPlayer {
                 .environmentObject(manager)
                 .eraseToAnyView()
             let controller = HostingController(content: content)
-            controller.disablesSafeArea = true
+            controller.disableSafeArea = true
             controller.automaticallyAllowUIKitAnimationsForNextUpdate = true
             controller.view.translatesAutoresizingMaskIntoConstraints = false
             return controller

--- a/Swiftfin tvOS/Components/VideoPlayerSlider.swift
+++ b/Swiftfin tvOS/Components/VideoPlayerSlider.swift
@@ -114,7 +114,10 @@ private struct VideoPlayerSliderContent: SliderContentView {
     }
 
     private func progress(for value: Double) -> Double {
-        guard sliderState.total > 0 else {
+        guard sliderState.total.isFinite,
+              sliderState.total > 0,
+              value.isFinite
+        else {
             return 0
         }
 
@@ -123,13 +126,18 @@ private struct VideoPlayerSliderContent: SliderContentView {
 
     @ViewBuilder
     private func progressSegment(progress: Double, in size: CGSize) -> some View {
+        let width = size.width.isFinite ? max(0, size.width) : 0
+        let height = size.height.isFinite ? max(0, size.height) : 0
+        let segmentWidth = max(0, width * progress + height)
+
         Rectangle()
-            .frame(width: size.width * progress + size.height)
-            .offset(x: -size.height)
+            .frame(width: segmentWidth)
+            .offset(x: -height)
     }
 
     private func tickOffset(for progress: Double, in width: CGFloat) -> CGFloat {
-        clamp(width * progress - tickWidth / 2, min: 0, max: width - tickWidth)
+        guard progress.isFinite, width.isFinite, width > 0 else { return 0 }
+        return clamp(width * progress - tickWidth / 2, min: 0, max: max(0, width - tickWidth))
     }
 
     var body: some View {

--- a/Swiftfin tvOS/Objects/ContentGroup/CinematicSelectionContentGroup.swift
+++ b/Swiftfin tvOS/Objects/ContentGroup/CinematicSelectionContentGroup.swift
@@ -30,10 +30,74 @@ struct CinematicSelectionContentGroup: ContentGroup {
     }
 
     func body(with viewModel: CinematicSelectionContentGroupViewModel) -> some View {
-        CinematicSelectionView(
-            viewModel: viewModel,
-            source: .preferred
-        )
+        SelectionView(viewModel: viewModel)
+    }
+
+    private struct SelectionView: View {
+
+        @Environment(\.frameForParentView)
+        private var frameForParentView
+
+        @ObservedObject
+        var viewModel: CinematicSelectionContentGroupViewModel
+
+        @Router
+        private var router
+
+        private var parentFrame: CGRect {
+            frameForParentView[.scrollView, default: .zero].frame
+        }
+
+        private func itemSelectorImageSource(for item: BaseItemDto) -> ImageSource {
+            let maxWidth = max(parentFrame.width * CinematicSelectionLayout.logoMaxWidthPercentage, 1)
+
+            if item.type == .episode {
+                return item.imageSource(
+                    itemID: item.seriesID,
+                    .logo,
+                    environment: ImageSourceOptions(
+                        maxWidth: maxWidth,
+                        maxHeight: CinematicSelectionLayout.logoMaxHeight
+                    )
+                )
+            } else {
+                return item.imageSource(
+                    .logo,
+                    environment: ImageSourceOptions(
+                        maxWidth: maxWidth,
+                        maxHeight: CinematicSelectionLayout.logoMaxHeight
+                    )
+                )
+            }
+        }
+
+        var body: some View {
+            let items = viewModel.hasResumeItems ? viewModel.resumeViewModel.elements.elements : viewModel.recentlyAddedViewModel.elements
+                .elements
+
+            CinematicItemSelector(
+                items: items
+            ) { item in
+                router.route(to: .item(item: item))
+            } topContent: { item in
+                ImageView(itemSelectorImageSource(for: item))
+                    .placeholder { _ in
+                        EmptyView()
+                    }
+                    .failure {
+                        Text(item.displayTitle)
+                            .font(.largeTitle)
+                            .fontWeight(.semibold)
+                    }
+                    .edgePadding(.leading)
+                    .aspectRatio(contentMode: .fit)
+                    .frame(height: CinematicSelectionLayout.logoMaxHeight, alignment: .bottomLeading)
+            }
+            .preference(
+                key: ContentGroupCustomizationKey.self,
+                value: .ignoreSafeAreaTop
+            )
+        }
     }
 }
 
@@ -47,9 +111,9 @@ struct CinematicRecentlyAddedContentGroup: ContentGroup {
     }
 
     func body(with viewModel: CinematicSelectionContentGroupViewModel) -> some View {
-        CinematicSelectionView(
-            viewModel: viewModel,
-            source: .recentlyAdded
+        PosterHStackLibrarySection(
+            viewModel: viewModel.recentlyAddedViewModel,
+            group: viewModel.recentlyAddedGroup
         )
     }
 }
@@ -58,8 +122,12 @@ final class CinematicSelectionContentGroupViewModel: ViewModel, WithRefresh {
 
     typealias Background = CinematicSelectionContentGroupViewModel
 
-    let recentlyAddedViewModel: PagingLibraryViewModel<RecentlyAddedLibrary>
+    let recentlyAddedGroup: PosterGroup<RecentlyAddedLibrary>
     let resumeViewModel: PagingLibraryViewModel<ResumeItemsLibrary>
+
+    var recentlyAddedViewModel: PagingLibraryViewModel<RecentlyAddedLibrary> {
+        recentlyAddedGroup.viewModel
+    }
 
     var background: CinematicSelectionContentGroupViewModel {
         get { self }
@@ -79,7 +147,7 @@ final class CinematicSelectionContentGroupViewModel: ViewModel, WithRefresh {
         recentlyAddedLibrary: RecentlyAddedLibrary
     ) {
         self.resumeViewModel = PagingLibraryViewModel(library: resumeLibrary, pageSize: 20)
-        self.recentlyAddedViewModel = PagingLibraryViewModel(library: recentlyAddedLibrary, pageSize: 20)
+        self.recentlyAddedGroup = PosterGroup(library: recentlyAddedLibrary)
 
         super.init()
 
@@ -105,78 +173,8 @@ final class CinematicSelectionContentGroupViewModel: ViewModel, WithRefresh {
     }
 }
 
-private struct CinematicSelectionView: View {
+private enum CinematicSelectionLayout {
 
-    enum Source {
-        case preferred
-        case recentlyAdded
-    }
-
-    @Environment(\.frameForParentView)
-    private var frameForParentView
-
-    @ObservedObject
-    var viewModel: CinematicSelectionContentGroupViewModel
-
-    let source: Source
-
-    @Router
-    private var router
-
-    private var items: [BaseItemDto] {
-        switch source {
-        case .preferred:
-            viewModel.hasResumeItems ? viewModel.resumeViewModel.elements.elements : viewModel.recentlyAddedViewModel.elements.elements
-        case .recentlyAdded:
-            viewModel.recentlyAddedViewModel.elements.elements
-        }
-    }
-
-    private var parentFrame: CGRect {
-        frameForParentView[.scrollView, default: .zero].frame
-    }
-
-    private func itemSelectorImageSource(for item: BaseItemDto) -> ImageSource {
-        if item.type == .episode {
-            item.imageSource(
-                itemID: item.seriesID,
-                .logo,
-                environment: ImageSourceOptions(
-                    maxHeight: 100
-                )
-            )
-        } else {
-            item.imageSource(
-                .logo,
-                environment: ImageSourceOptions(
-                    maxHeight: 100
-                )
-            )
-        }
-    }
-
-    var body: some View {
-        CinematicItemSelector(
-            items: items
-        ) { item in
-            router.route(to: .item(item: item))
-        } topContent: { item in
-            ImageView(itemSelectorImageSource(for: item))
-                .placeholder { _ in
-                    EmptyView()
-                }
-                .failure {
-                    Text(item.displayTitle)
-                        .font(.largeTitle)
-                        .fontWeight(.semibold)
-                }
-                .edgePadding(.leading)
-                .aspectRatio(contentMode: .fit)
-                .frame(height: 100, alignment: .bottomLeading)
-        }
-        .preference(
-            key: ContentGroupCustomizationKey.self,
-            value: .ignoreSafeAreaTop
-        )
-    }
+    static let logoMaxHeight: CGFloat = 100
+    static let logoMaxWidthPercentage: CGFloat = 0.4
 }

--- a/Swiftfin tvOS/Views/VideoPlayer/PlaybackControls/Components/PlaybackProgress.swift
+++ b/Swiftfin tvOS/Views/VideoPlayer/PlaybackControls/Components/PlaybackProgress.swift
@@ -57,7 +57,11 @@ extension VideoPlayer.PlaybackControls {
 
         private var scrubbedProgress: Double {
             guard let runtime = manager.item.runtime, runtime > .zero else { return 0 }
-            return scrubbedSecondsBox.value / runtime
+
+            let progress = scrubbedSecondsBox.value / runtime
+            guard progress.isFinite else { return 0 }
+
+            return clamp(progress, min: 0, max: 1)
         }
 
         private var currentProgress: Double? {
@@ -69,7 +73,10 @@ extension VideoPlayer.PlaybackControls {
             }
 
             let currentSeconds = containerState.scrubOriginSeconds ?? manager.seconds
-            return clamp((currentSeconds / runtime) * 100, min: 0, max: 100)
+            let progress = (currentSeconds / runtime) * 100
+            guard progress.isFinite else { return nil }
+
+            return clamp(progress, min: 0, max: 100)
         }
 
         private var videoSizeAspectRatio: CGFloat {
@@ -77,13 +84,27 @@ extension VideoPlayer.PlaybackControls {
                 return 1.77
             }
 
-            return clamp(videoPlayerProxy.videoSize.value.aspectRatio, min: 0.25, max: 4)
+            let videoSize = videoPlayerProxy.videoSize.value
+            guard videoSize.width.isFinite,
+                  videoSize.height.isFinite,
+                  videoSize.width > 0,
+                  videoSize.height > 0
+            else {
+                return 1.77
+            }
+
+            let aspectRatio = videoSize.aspectRatio
+            guard aspectRatio.isFinite else { return 1.77 }
+
+            return clamp(aspectRatio, min: 0.25, max: 4)
         }
 
         private var previewXOffset: CGFloat {
+            guard sliderSize.width.isFinite, sliderSize.width > 0 else { return 0 }
+
             let videoWidth = previewImageHeight * videoSizeAspectRatio
             let p = (sliderSize.width * scrubbedProgress) - (videoWidth / 2)
-            return clamp(p, min: 0, max: sliderSize.width - videoWidth)
+            return clamp(p, min: 0, max: max(0, sliderSize.width - videoWidth))
         }
 
         @ViewBuilder
@@ -106,9 +127,17 @@ extension VideoPlayer.PlaybackControls {
                 value: $scrubbedSecondsBox.value.map(
                     getter: {
                         guard let runtime = manager.item.runtime, runtime > .zero else { return 0 }
-                        return clamp(($0.seconds / runtime.seconds) * 100, min: 0, max: 100)
+
+                        let seconds = $0.seconds
+                        let runtimeSeconds = runtime.seconds
+                        guard seconds.isFinite, runtimeSeconds.isFinite, runtimeSeconds > 0 else { return 0 }
+
+                        return clamp((seconds / runtimeSeconds) * 100, min: 0, max: 100)
                     },
-                    setter: { (manager.item.runtime ?? .zero) * ($0 / 100) }
+                    setter: {
+                        guard $0.isFinite else { return .zero }
+                        return (manager.item.runtime ?? .zero) * (clamp($0, min: 0, max: 100) / 100)
+                    }
                 ),
                 currentProgress: currentProgress,
                 total: 100,

--- a/Swiftfin tvOS/Views/VideoPlayer/SupplementTabView.swift
+++ b/Swiftfin tvOS/Views/VideoPlayer/SupplementTabView.swift
@@ -102,10 +102,10 @@ struct SupplementTabView<Item: Identifiable, Content: View>: UIViewControllerRep
 
             for item in items {
                 if let host = hosts[item.id] {
-                    host.rootView = content(item)
+                    host.content = content(item)
                 } else {
                     let host = HostingController(content: content(item))
-                    host.disablesSafeArea = true
+                    host.disableSafeArea = true
                     host.view.backgroundColor = .clear
                     hosts[item.id] = host
                 }

--- a/Swiftfin.xcodeproj/project.pbxproj
+++ b/Swiftfin.xcodeproj/project.pbxproj
@@ -1364,8 +1364,8 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/nathantannar4/Transmission";
 			requirement = {
-				kind = exactVersion;
-				version = 2.8.3;
+				kind = upToNextMajorVersion;
+				minimumVersion = 2.13.4;
 			};
 		};
 		E176EBDC2D050067009F4CF1 /* XCRemoteSwiftPackageReference "swift-identified-collections" */ = {

--- a/Swiftfin.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Swiftfin.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "c429eb8c40ca5c5f53d35555213920f2a1646c9a88b78079b048e4b0b41d66e9",
+  "originHash" : "7ec54c37c9193d5e227efb16aa23f2cf463955649f014ffbd3610ee3e0dacd7a",
   "pins" : [
     {
       "identity" : "blurhashkit",
@@ -51,8 +51,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/sindresorhus/Defaults",
       "state" : {
-        "revision" : "cc938ecf0bed848dc80a9726ac5455104e3f9dae",
-        "version" : "9.0.2"
+        "revision" : "00a7465a0668a87fa159e779b9d80f1f9652357e",
+        "version" : "9.0.9"
       }
     },
     {
@@ -69,8 +69,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/nathantannar4/Engine",
       "state" : {
-        "revision" : "57331268245d1b9c40670da82149805537ed8f36",
-        "version" : "2.7.0"
+        "revision" : "fabe1490fd986a66cc344f337ced2010f4adc943",
+        "version" : "2.12.4"
       }
     },
     {
@@ -78,8 +78,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/hmlongco/Factory",
       "state" : {
-        "revision" : "cacafd638e8af1dac8abd6a4ab013d53983e2703",
-        "version" : "3.2.1"
+        "revision" : "27717e148c0c1ed2998f687a8e98d9395d684abf",
+        "version" : "3.3.2"
       }
     },
     {
@@ -150,8 +150,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/guoyingtao/Mantis",
       "state" : {
-        "revision" : "584f03f879e0f6c266a03697e9a44815b09781f4",
-        "version" : "2.31.1"
+        "revision" : "b3c237aff54b8307440157a2f5956bdea2e76791",
+        "version" : "2.31.2"
       }
     },
     {
@@ -159,8 +159,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/kean/Nuke",
       "state" : {
-        "revision" : "1248465fc4e41ee2fdbe253b8b14d5225b04093b",
-        "version" : "13.0.2"
+        "revision" : "63a8fcbd6621340a2410bc3e9575ac97058615f4",
+        "version" : "13.0.6"
       }
     },
     {
@@ -168,8 +168,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/kean/Pulse",
       "state" : {
-        "revision" : "e1c7f831987cb9d3e3974ec59a67f5135535cb7a",
-        "version" : "5.2.0"
+        "revision" : "94b92731d370c129bb771e9c18f69b0a44ccca5c",
+        "version" : "5.2.3"
       }
     },
     {
@@ -222,8 +222,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-atomics.git",
       "state" : {
-        "revision" : "b601256eab081c0f92f059e12818ac1d4f178ff7",
-        "version" : "1.3.0"
+        "revision" : "0442cb5a3f98ab802acb777929fdb446bda11a34",
+        "version" : "1.3.1"
       }
     },
     {
@@ -231,8 +231,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/swift-case-paths.git",
       "state" : {
-        "revision" : "1197e80bc7e4b177051b6869ef93d8ac3ad677da",
-        "version" : "1.8.0"
+        "revision" : "5ce3b8e89d6b05e5a369c356152303a10a7608a3",
+        "version" : "1.9.0"
       }
     },
     {
@@ -240,8 +240,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-collections.git",
       "state" : {
-        "revision" : "6675bc0ff86e61436e615df6fc5174e043e57924",
-        "version" : "1.4.1"
+        "revision" : "a0cb0954ecb21e4e31b0070e6ed5674e8556685a",
+        "version" : "1.6.0"
       }
     },
     {
@@ -258,8 +258,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-log.git",
       "state" : {
-        "revision" : "5073617dac96330a486245e4c0179cb0a6fd2256",
-        "version" : "1.12.0"
+        "revision" : "a878e7f8f46cfc0e1125e565b5c08e7d5272dc9a",
+        "version" : "1.14.0"
       }
     },
     {
@@ -267,8 +267,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-nio.git",
       "state" : {
-        "revision" : "f71c8d2a5e74a2c6d11a0fbe324774b5d6084237",
-        "version" : "2.99.0"
+        "revision" : "0b18836bd8b0162e7e17a995a3fbee20ed8f3b2b",
+        "version" : "2.101.3"
       }
     },
     {
@@ -303,8 +303,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-system.git",
       "state" : {
-        "revision" : "7c6ad0fc39d0763e0b699210e4124afd5041c5df",
-        "version" : "1.6.4"
+        "revision" : "b5544ba79a70a0cb3563e75bf26dc198d6b40ed3",
+        "version" : "1.7.4"
       }
     },
     {
@@ -321,8 +321,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/nathantannar4/Transmission",
       "state" : {
-        "revision" : "6776b6b6dd2de5bb47253445ab698b700bd38175",
-        "version" : "2.8.3"
+        "revision" : "f5a531fcece5d65c75397d01cf2910b31347e0b9",
+        "version" : "2.13.4"
       }
     },
     {
@@ -348,8 +348,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/xctest-dynamic-overlay",
       "state" : {
-        "revision" : "401bf70d95bfe8db2a1dc619f9e175a85c089321",
-        "version" : "1.10.1"
+        "revision" : "8f6abcf4c8950e2679d5b2fee4ca284fd7c34886",
+        "version" : "1.11.0"
       }
     }
   ],

--- a/Swiftfin/Components/CapsuleSlider.swift
+++ b/Swiftfin/Components/CapsuleSlider.swift
@@ -42,9 +42,31 @@ struct CapsuleSlider<Value: BinaryFloatingPoint>: View {
     private let translationBinding: Binding<CGPoint>
     private let valueDamping: Double
 
+    private var gestureHeight: CGFloat {
+        guard contentSize.height.isFinite else { return 0 }
+
+        let height = contentSize.height + gesturePadding
+        guard height.isFinite else { return 0 }
+
+        return max(0, height)
+    }
+
+    private var resolvedValue: Value {
+        guard value.isFinite else { return 0 }
+        return clamp(value, min: 0, max: total)
+    }
+
     private var dragGesture: some Gesture {
         DragGesture(coordinateSpace: .global)
             .onChanged { newValue in
+                guard contentSize.width.isFinite,
+                      contentSize.width > 0,
+                      newValue.location.x.isFinite,
+                      newValue.location.y.isFinite
+                else {
+                    return
+                }
+
                 if needsToSetTranslationStartState {
                     translationStartLocation = newValue.location
                     needsToSetTranslationStartState = false
@@ -70,17 +92,26 @@ struct CapsuleSlider<Value: BinaryFloatingPoint>: View {
                     y: currentValueDampingStartTranslation.y - newValue.location.y
                 )
 
+                guard newTranslation.x.isFinite,
+                      newTranslation.y.isFinite,
+                      currentValueDampingStartValue.isFinite
+                else {
+                    return
+                }
+
                 let newProgress = currentValueDampingStartValue - Value(newTranslation.x / contentSize.width) * total
+                guard newProgress.isFinite else { return }
+
                 value = clamp(newProgress, min: 0, max: total)
             }
     }
 
     var body: some View {
-        ProgressView(value: value, total: total)
+        ProgressView(value: resolvedValue, total: total)
             .progressViewStyle(.playback)
             .overlay {
                 Color.clear
-                    .frame(height: contentSize.height + gesturePadding)
+                    .frame(height: gestureHeight)
                     .contentShape(Rectangle())
                     .highPriorityGesture(dragGesture)
                     .onLongPressGesture(minimumDuration: 0.01, perform: {}) { isPressing in
@@ -135,9 +166,9 @@ extension CapsuleSlider {
         self._value = value
         self.gesturePadding = 0
         self.onEditingChanged = { _ in }
-        self.total = total
+        self.total = total.isFinite && total > 0 ? total : 1
         self.translationBinding = translation
-        self.valueDamping = clamp(valueDamping, min: 0.01, max: 2)
+        self.valueDamping = valueDamping.isFinite ? clamp(valueDamping, min: 0.01, max: 2) : 1
     }
 
     func onEditingChanged(perform action: @escaping (Bool) -> Void) -> Self {
@@ -145,6 +176,6 @@ extension CapsuleSlider {
     }
 
     func gesturePadding(_ padding: CGFloat) -> Self {
-        copy(modifying: \.gesturePadding, with: padding)
+        copy(modifying: \.gesturePadding, with: padding.isFinite ? max(0, padding) : 0)
     }
 }

--- a/Swiftfin/Extensions/View/Modifiers/PhotoPickerModifier.swift
+++ b/Swiftfin/Extensions/View/Modifiers/PhotoPickerModifier.swift
@@ -38,10 +38,12 @@ struct PhotoPickerModifier: ViewModifier {
             }
             .sheet(isPresented: Binding<Bool>(
                 get: { selectedImage != nil },
-                set: { if !$0 {
-                    selectedImage = nil
-                    selectedItem = nil
-                } }
+                set: {
+                    if !$0 {
+                        selectedImage = nil
+                        selectedItem = nil
+                    }
+                }
             )) {
                 if let image = selectedImage {
                     NavigationView {

--- a/Swiftfin/Views/VideoPlayer/PlaybackControls/Components/PlaybackProgress.swift
+++ b/Swiftfin/Views/VideoPlayer/PlaybackControls/Components/PlaybackProgress.swift
@@ -50,19 +50,26 @@ extension VideoPlayer.PlaybackControls {
             isScrubbing && (currentTranslation.y >= 60)
         }
 
-        private var previewXOffset: CGFloat {
-            let videoWidth = 85 * videoSizeAspectRatio
-            let p = (sliderSize.width * scrubbedProgress) - (videoWidth / 2)
-            return clamp(p, min: 0, max: sliderSize.width - videoWidth)
+        private var insetSliderWidth: CGFloat {
+            guard sliderSize.width.isFinite else { return 0 }
+            return max(0, sliderSize.width - EdgeInsets.edgePadding * 2)
         }
 
-        private var progress: Double {
-            scrubbedSeconds / (manager.item.runtime ?? .seconds(1))
+        private var previewXOffset: CGFloat {
+            guard sliderSize.width.isFinite, sliderSize.width > 0 else { return 0 }
+
+            let videoWidth = 85 * videoSizeAspectRatio
+            let p = (sliderSize.width * scrubbedProgress) - (videoWidth / 2)
+            return clamp(p, min: 0, max: max(0, sliderSize.width - videoWidth))
         }
 
         private var scrubbedProgress: Double {
             guard let runtime = manager.item.runtime, runtime > .zero else { return 0 }
-            return scrubbedSeconds / runtime
+
+            let progress = scrubbedSeconds / runtime
+            guard progress.isFinite else { return 0 }
+
+            return clamp(progress, min: 0, max: 1)
         }
 
         private var scrubbedSeconds: Duration {
@@ -74,7 +81,25 @@ extension VideoPlayer.PlaybackControls {
                 return 1.77
             }
 
-            return clamp(videoPlayerProxy.videoSize.value.aspectRatio, min: 0.25, max: 4)
+            let videoSize = videoPlayerProxy.videoSize.value
+            guard videoSize.width.isFinite,
+                  videoSize.height.isFinite,
+                  videoSize.width > 0,
+                  videoSize.height > 0
+            else {
+                return 1.77
+            }
+
+            let aspectRatio = videoSize.aspectRatio
+            guard aspectRatio.isFinite else { return 1.77 }
+
+            return clamp(aspectRatio, min: 0.25, max: 4)
+        }
+
+        private var sliderTotal: Double {
+            let total = (manager.item.runtime ?? .zero).seconds
+            guard total.isFinite, total > 0 else { return 1 }
+            return total
         }
 
         @ViewBuilder
@@ -109,14 +134,14 @@ extension VideoPlayer.PlaybackControls {
                     .trackingSize($sliderSize)
             } content: {
                 // Use scale effect, slider doesn't respond well to horizontal frame changes
-                let xScale = max(1, sliderSize.width / (sliderSize.width - EdgeInsets.edgePadding * 2))
+                let xScale = insetSliderWidth > 0 ? max(1, sliderSize.width / insetSliderWidth) : 1
 
                 CapsuleSlider(
                     value: $scrubbedSecondsBox.value.map(
                         getter: { $0.seconds },
                         setter: { .seconds($0) }
                     ),
-                    total: max(1, (manager.item.runtime ?? .zero).seconds),
+                    total: sliderTotal,
                     translation: $currentTranslation,
                     valueDamping: isSlowScrubbing ? 0.1 : 1
                 )
@@ -133,7 +158,7 @@ extension VideoPlayer.PlaybackControls {
                         }
                     }
                 }
-                .frame(maxWidth: sliderSize != .zero ? sliderSize.width - EdgeInsets.edgePadding * 2 : .infinity)
+                .frame(maxWidth: sliderSize != .zero ? insetSliderWidth : .infinity)
                 .scaleEffect(x: isScrubbing ? xScale : 1, y: 1, anchor: .center)
                 .frame(height: isScrubbing ? 20 : 10)
                 .foregroundStyle(manager.state == .loadingItem ? .gray : .primary)
@@ -155,7 +180,7 @@ extension VideoPlayer.PlaybackControls {
 
                     SplitTimeStamp()
                         .offset(y: isScrubbing ? 5 : 0)
-                        .frame(maxWidth: isScrubbing ? nil : max(0, sliderSize.width - EdgeInsets.edgePadding * 2))
+                        .frame(maxWidth: isScrubbing ? nil : insetSliderWidth)
                 }
             }
             .frame(maxWidth: .infinity)

--- a/Swiftfin/Views/VideoPlayer/SupplementTabView.swift
+++ b/Swiftfin/Views/VideoPlayer/SupplementTabView.swift
@@ -119,10 +119,10 @@ struct SupplementTabView<Item: Identifiable, Content: View>: UIViewControllerRep
 
             for item in items {
                 if let host = viewControllers[item.id] {
-                    host.rootView = content(item)
+                    host.content = content(item)
                 } else {
                     let host = HostingController(content: content(item))
-                    host.disablesSafeArea = true
+                    host.disableSafeArea = true
                     host.view.backgroundColor = .clear
                     viewControllers[item.id] = host
                 }


### PR DESCRIPTION
- Update runners to macOS 26
- Update Xcode version used to 26.6
- Updates packages
	- Updates Transmission+Engine, fixes #2081
	- Using latest versions demonstrated some crashes in regards to zero/infinite values
		- Done using Codex
- Revert `CinematicSelectionContentGroup` changes
- Format against latest `swiftformat`