### PR TITLE
Use images tags

### DIFF
--- a/Shared/Extensions/JellyfinAPI/BaseItemDto/BaseItemDto+Images.swift
+++ b/Shared/Extensions/JellyfinAPI/BaseItemDto/BaseItemDto+Images.swift
@@ -16,12 +16,16 @@ extension BaseItemDto {
     /// Image source for this `BaseItemDto`
     func imageSource(
         _ type: ImageType,
+        tag: String? = nil,
         environment: some WithImageSourceOptions
     ) -> ImageSource {
-        makeImageSource(
+        let resolvedTag = tag ?? imageTag(for: type)
+
+        return makeImageSource(
             itemID: id,
             type: type,
-            blurHash: blurHash(for: type),
+            tag: resolvedTag,
+            blurHash: blurHash(for: type, tag: resolvedTag),
             environment: environment
         )
     }
@@ -30,11 +34,13 @@ extension BaseItemDto {
     func imageSource(
         itemID: String?,
         _ type: ImageType,
+        tag: String? = nil,
         environment: some WithImageSourceOptions
     ) -> ImageSource {
         makeImageSource(
             itemID: itemID,
             type: type,
+            tag: tag,
             blurHash: nil,
             environment: environment
         )
@@ -43,6 +49,7 @@ extension BaseItemDto {
     private func makeImageSource(
         itemID: String?,
         type: ImageType,
+        tag: String?,
         blurHash: String?,
         environment: some WithImageSourceOptions
     ) -> ImageSource {
@@ -51,6 +58,7 @@ extension BaseItemDto {
                 imageURL(
                     itemID: $0,
                     type,
+                    tag: tag,
                     environment: environment
                 )
             },
@@ -58,11 +66,11 @@ extension BaseItemDto {
         )
     }
 
-    private func blurHash(for type: ImageType) -> String? {
+    private func blurHash(for type: ImageType, tag: String?) -> String? {
         guard type != .logo,
               let blurHashes = imageBlurHashes?[type] else { return nil }
 
-        if let tag = imageTag(for: type), let taggedBlurHash = blurHashes[tag] {
+        if let tag, let taggedBlurHash = blurHashes[tag] {
             return taggedBlurHash
         }
 
@@ -84,6 +92,7 @@ extension BaseItemDto {
         itemID: String? = nil,
         _ type: ImageType,
         index: Int? = nil,
+        tag: String? = nil,
         environment: some WithImageSourceOptions
     ) -> URL? {
         guard let itemID else { return nil }
@@ -101,7 +110,7 @@ extension BaseItemDto {
             maxWidth: scaleWidth,
             maxHeight: scaleHeight,
             quality: validQuality,
-            tag: nil,
+            tag: tag,
             format: type == .logo ? .png : nil,
             imageIndex: index
         )

--- a/Shared/Extensions/JellyfinAPI/BaseItemDto/BaseItemDto+Poster.swift
+++ b/Shared/Extensions/JellyfinAPI/BaseItemDto/BaseItemDto+Poster.swift
@@ -109,9 +109,16 @@ extension BaseItemDto: Poster {
                 environment: environment
             )
         case .boxSet, .channel, .liveTvChannel, .movie, .musicArtist, .person, .series, .tvChannel:
-            imageSource(.primary, environment: environment)
+            imageSource(
+                .primary,
+                environment: environment
+            )
         case .season:
-            imageSource(.primary, environment: environment)
+            imageSource(
+                .primary,
+                environment: environment
+            )
+
             imageSource(
                 itemID: seriesID,
                 .primary,
@@ -138,18 +145,29 @@ extension BaseItemDto: Poster {
                         environment: environment
                     )
                 }
+
                 imageSource(
                     itemID: seriesID,
                     .backdrop,
                     tag: parentBackdropImageTags?.first,
                     environment: environment
                 )
-                imageSource(.primary, environment: environment)
+
+                imageSource(
+                    .primary,
+                    environment: environment
+                )
             } else {
-                imageSource(.primary, environment: environment)
+                imageSource(
+                    .primary,
+                    environment: environment
+                )
             }
         case .collectionFolder, .folder, .liveTvProgram, .musicVideo, .program, .userView, .video:
-            imageSource(.primary, environment: environment)
+            imageSource(
+                .primary,
+                environment: environment
+            )
         case .season:
             if environment.viewContext.contains(.isThumb) {
                 imageSource(
@@ -159,6 +177,7 @@ extension BaseItemDto: Poster {
                     environment: environment
                 )
             }
+
             imageSource(
                 itemID: seriesID,
                 .backdrop,
@@ -167,9 +186,17 @@ extension BaseItemDto: Poster {
             )
         default:
             if environment.viewContext.contains(.isThumb) {
-                imageSource(.thumb, environment: environment)
+                imageSource(
+                    .thumb,
+                    environment: environment
+                )
             }
-            imageSource(.backdrop, environment: environment)
+
+            imageSource(
+                .backdrop,
+                tag: backdropImageTags?.first,
+                environment: environment
+            )
         }
     }
 
@@ -179,7 +206,11 @@ extension BaseItemDto: Poster {
     ) -> [ImageSource] {
         switch type {
         case .audio:
-            imageSource(.primary, environment: environment)
+            imageSource(
+                .primary,
+                environment: environment
+            )
+
             imageSource(
                 itemID: albumID,
                 .primary,
@@ -187,7 +218,10 @@ extension BaseItemDto: Poster {
                 environment: environment
             )
         case .channel, .musicAlbum, .tvChannel:
-            imageSource(.primary, environment: environment)
+            imageSource(
+                .primary,
+                environment: environment
+            )
         case .program:
             if let channelID {
                 imageSource(

--- a/Shared/Extensions/JellyfinAPI/BaseItemDto/BaseItemDto+Poster.swift
+++ b/Shared/Extensions/JellyfinAPI/BaseItemDto/BaseItemDto+Poster.swift
@@ -93,19 +93,10 @@ extension BaseItemDto: Poster {
     ) -> [ImageSource] {
         switch type {
         case .episode:
-            if environment.useParent {
-                imageSource(
-                    itemID: seriesID,
-                    .primary,
-                    tag: seriesPrimaryImageTag,
-                    environment: environment
-                )
-            }
-
             imageSource(
-                itemID: seasonID,
+                itemID: seriesID,
                 .primary,
-                tag: parentPrimaryImageTag,
+                tag: seriesPrimaryImageTag,
                 environment: environment
             )
         case .boxSet, .channel, .liveTvChannel, .movie, .musicArtist, .person, .series, .tvChannel:
@@ -145,13 +136,6 @@ extension BaseItemDto: Poster {
                         environment: environment
                     )
                 }
-
-                imageSource(
-                    itemID: seriesID,
-                    .backdrop,
-                    tag: parentBackdropImageTags?.first,
-                    environment: environment
-                )
 
                 imageSource(
                     .primary,

--- a/Shared/Extensions/JellyfinAPI/BaseItemDto/BaseItemDto+Poster.swift
+++ b/Shared/Extensions/JellyfinAPI/BaseItemDto/BaseItemDto+Poster.swift
@@ -94,15 +94,30 @@ extension BaseItemDto: Poster {
         switch type {
         case .episode:
             if environment.useParent {
-                imageSource(itemID: seriesID, .primary, environment: environment)
+                imageSource(
+                    itemID: seriesID,
+                    .primary,
+                    tag: seriesPrimaryImageTag,
+                    environment: environment
+                )
             }
 
-            imageSource(itemID: seasonID, .primary, environment: environment)
+            imageSource(
+                itemID: seasonID,
+                .primary,
+                tag: parentPrimaryImageTag,
+                environment: environment
+            )
         case .boxSet, .channel, .liveTvChannel, .movie, .musicArtist, .person, .series, .tvChannel:
             imageSource(.primary, environment: environment)
         case .season:
             imageSource(.primary, environment: environment)
-            imageSource(itemID: seriesID, .primary, environment: environment)
+            imageSource(
+                itemID: seriesID,
+                .primary,
+                tag: seriesPrimaryImageTag,
+                environment: environment
+            )
         default:
             []
         }
@@ -116,9 +131,19 @@ extension BaseItemDto: Poster {
         case .episode:
             if environment.useParent {
                 if environment.viewContext.contains(.isThumb) {
-                    imageSource(itemID: seriesID, .thumb, environment: environment)
+                    imageSource(
+                        itemID: seriesID,
+                        .thumb,
+                        tag: seriesThumbImageTag,
+                        environment: environment
+                    )
                 }
-                imageSource(itemID: seriesID, .backdrop, environment: environment)
+                imageSource(
+                    itemID: seriesID,
+                    .backdrop,
+                    tag: parentBackdropImageTags?.first,
+                    environment: environment
+                )
                 imageSource(.primary, environment: environment)
             } else {
                 imageSource(.primary, environment: environment)
@@ -127,9 +152,19 @@ extension BaseItemDto: Poster {
             imageSource(.primary, environment: environment)
         case .season:
             if environment.viewContext.contains(.isThumb) {
-                imageSource(itemID: seriesID, .thumb, environment: environment)
+                imageSource(
+                    itemID: seriesID,
+                    .thumb,
+                    tag: seriesThumbImageTag,
+                    environment: environment
+                )
             }
-            imageSource(itemID: seriesID, .backdrop, environment: environment)
+            imageSource(
+                itemID: seriesID,
+                .backdrop,
+                tag: parentBackdropImageTags?.first,
+                environment: environment
+            )
         default:
             if environment.viewContext.contains(.isThumb) {
                 imageSource(.thumb, environment: environment)
@@ -148,6 +183,7 @@ extension BaseItemDto: Poster {
             imageSource(
                 itemID: albumID,
                 .primary,
+                tag: albumPrimaryImageTag,
                 environment: environment
             )
         case .channel, .musicAlbum, .tvChannel:
@@ -157,6 +193,7 @@ extension BaseItemDto: Poster {
                 imageSource(
                     itemID: channelID,
                     .primary,
+                    tag: channelPrimaryImageTag,
                     environment: environment
                 )
             }

--- a/Shared/Extensions/Nuke/ImagePipeline.swift
+++ b/Shared/Extensions/Nuke/ImagePipeline.swift
@@ -20,6 +20,9 @@ extension ImagePipeline {
         guard var components = url.components else { return nil }
 
         var maxWidthValue: String?
+        
+        // TODO: maxHeight
+        // TODO: cache reset
 
         if let maxWidth = components.queryItems?.first(where: { $0.name == "maxWidth" }) {
             maxWidthValue = maxWidth.value

--- a/Shared/Extensions/Nuke/ImagePipeline.swift
+++ b/Shared/Extensions/Nuke/ImagePipeline.swift
@@ -20,7 +20,7 @@ extension ImagePipeline {
         guard var components = url.components else { return nil }
 
         var maxWidthValue: String?
-        
+
         // TODO: maxHeight
         // TODO: cache reset
 

--- a/Swiftfin tvOS/Objects/ContentGroup/CinematicSelectionContentGroup.swift
+++ b/Swiftfin tvOS/Objects/ContentGroup/CinematicSelectionContentGroup.swift
@@ -55,6 +55,7 @@ struct CinematicSelectionContentGroup: ContentGroup {
                 return item.imageSource(
                     itemID: item.seriesID,
                     .logo,
+                    tag: item.parentLogoImageTag,
                     environment: ImageSourceOptions(
                         maxWidth: maxWidth,
                         maxHeight: CinematicSelectionLayout.logoMaxHeight


### PR DESCRIPTION
Closes #2092

Use image tags when retrieving images. Will still require views to reload to get the new tag and reload the image view. Fix parent usage in episode images.