### PR TITLE
tvOS `sidebarAdaptable`

### DIFF
--- a/Shared/Coordinators/Tabs/MainTabView.swift
+++ b/Shared/Coordinators/Tabs/MainTabView.swift
@@ -123,6 +123,9 @@ struct MainTabView: View {
                 }
             }
         }
+        #if os(tvOS)
+        .tabViewStyle(.sidebarAdaptable)
+        #endif
     }
 
     var body: some View {


### PR DESCRIPTION
Use `sidebarAdaptable` on tvOS. iOS/iPadOS still need work for support.