### PR TITLE
Fix Device Profiles for MP4 HEVC with `hev1` or `dvhe`

### DIFF
--- a/Shared/Objects/VideoPlayerType/VideoPlayerType+Native.swift
+++ b/Shared/Objects/VideoPlayerType/VideoPlayerType+Native.swift
@@ -196,6 +196,20 @@ extension VideoPlayerType {
                 ) {
                     nativeHDRProfiles
                 }
+                ProfileCondition(
+                    condition: .equalsAny,
+                    isRequired: true,
+                    property: .videoCodecTag
+                ) {
+                    "hvc1"
+                    "dvh1"
+                }
+                ProfileCondition(
+                    condition: .lessThanEqual,
+                    isRequired: true,
+                    property: .videoFramerate,
+                    value: "60"
+                )
             }
         )
 


### PR DESCRIPTION
### Summary

Resolves: https://github.com/jellyfin/Swiftfin/issues/2095

Adds checks to request transcodes for HEVC + hev1 or dvhe as MP4. Also adds a limit of 60fps. There aren't reported issues of this but Jellyfin-Web has this limitation in there and it was the only other one we were missing:

See: https://github.com/jellyfin/jellyfin-web/blob/e968e90de1a9d6de33d8b7141329044435613ae9/src/scripts/browserDeviceProfile.js#L1448-L1454