### PR TITLE
Non-Romantic Subtitle Fix

### DIFF
--- a/Shared/Objects/MediaPlayerManager/MediaPlayerProxy/MediaPlayerProxy+VLC.swift
+++ b/Shared/Objects/MediaPlayerManager/MediaPlayerProxy/MediaPlayerProxy+VLC.swift
@@ -94,16 +94,10 @@ class VLCMediaPlayerProxy: VideoMediaPlayerProxy,
         vlcUIProxy.setSubtitleDelay(seconds)
     }
 
-    func setSubtitleColor(_ color: Color) {
-        vlcUIProxy.setSubtitleColor(.absolute(color.uiColor))
-    }
-
-    func setSubtitleFontName(_ fontName: String) {
-        vlcUIProxy.setSubtitleFont(fontName)
-    }
-
-    func setSubtitleFontSize(_ fontSize: Int) {
-        vlcUIProxy.setSubtitleSize(.absolute(fontSize))
+    func setSubtitleConfiguration(_ configuration: SubtitleConfiguration) {
+        vlcUIProxy.setSubtitleColor(.absolute(configuration.color.uiColor))
+        vlcUIProxy.setSubtitleFont(configuration.fontName)
+        vlcUIProxy.setSubtitleSize(.absolute(25 - configuration.size))
     }
 
     @ViewBuilder
@@ -117,12 +111,8 @@ extension VLCMediaPlayerProxy {
 
     struct VLCPlayerView: View {
 
-        @Default(.VideoPlayer.Subtitle.subtitleColor)
-        private var subtitleColor
-        @Default(.VideoPlayer.Subtitle.subtitleFontName)
-        private var subtitleFontName
-        @Default(.VideoPlayer.Subtitle.subtitleSize)
-        private var subtitleSize
+        @Default(.VideoPlayer.Subtitle.configuration)
+        private var subtitleConfiguration
 
         @EnvironmentObject
         private var containerState: VideoPlayerContainerState
@@ -159,10 +149,11 @@ extension VLCMediaPlayerProxy {
                 configuration.subtitleIndex = .absolute(subtitleIndex)
             }
 
-            configuration.subtitleSize = .absolute(25 - Defaults[.VideoPlayer.Subtitle.subtitleSize])
-            configuration.subtitleColor = .absolute(Defaults[.VideoPlayer.Subtitle.subtitleColor].uiColor)
+            let subtitleConfiguration = Defaults[.VideoPlayer.Subtitle.configuration]
+            configuration.subtitleSize = .absolute(25 - subtitleConfiguration.size)
+            configuration.subtitleColor = .absolute(subtitleConfiguration.color.uiColor)
             configuration.rate = .absolute(Defaults[.VideoPlayer.Playback.playbackRate])
-            if let font = UIFont(name: Defaults[.VideoPlayer.Subtitle.subtitleFontName], size: 1) {
+            if let font = UIFont(name: subtitleConfiguration.fontName, size: 1) {
                 configuration.subtitleFont = .absolute(font)
             }
 
@@ -233,21 +224,9 @@ extension VLCMediaPlayerProxy {
                         proxy.setRate(.absolute(newValue))
                     }
                     .backport
-                    .onChange(of: subtitleColor) { _, newValue in
+                    .onChange(of: subtitleConfiguration) { _, newValue in
                         if let proxy = proxy as? MediaPlayerSubtitleConfigurable {
-                            proxy.setSubtitleColor(newValue)
-                        }
-                    }
-                    .backport
-                    .onChange(of: subtitleFontName) { _, newValue in
-                        if let proxy = proxy as? MediaPlayerSubtitleConfigurable {
-                            proxy.setSubtitleFontName(newValue)
-                        }
-                    }
-                    .backport
-                    .onChange(of: subtitleSize) { _, newValue in
-                        if let proxy = proxy as? MediaPlayerSubtitleConfigurable {
-                            proxy.setSubtitleFontSize(25 - newValue)
+                            proxy.setSubtitleConfiguration(newValue)
                         }
                     }
             }

--- a/Shared/Objects/MediaPlayerManager/MediaPlayerProxy/MediaPlayerProxy.swift
+++ b/Shared/Objects/MediaPlayerManager/MediaPlayerProxy/MediaPlayerProxy.swift
@@ -61,7 +61,5 @@ protocol MediaPlayerOffsetConfigurable {
 }
 
 protocol MediaPlayerSubtitleConfigurable {
-    func setSubtitleColor(_ color: Color)
-    func setSubtitleFontName(_ fontName: String)
-    func setSubtitleFontSize(_ fontSize: Int)
+    func setSubtitleConfiguration(_ configuration: SubtitleConfiguration)
 }

--- a/Shared/Objects/SubtitleConfiguration.swift
+++ b/Shared/Objects/SubtitleConfiguration.swift
@@ -1,0 +1,49 @@
+//
+// Swiftfin is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, you can obtain one at https://mozilla.org/MPL/2.0/.
+//
+// Copyright (c) 2026 Jellyfin & Jellyfin Contributors
+//
+
+import SwiftUI
+
+struct SubtitleConfiguration: Hashable, Storable, WithDefaultValue {
+
+    var color: Color
+    var fontName: String
+    var size: Int
+
+    /// Note: "Noto Sans CJK SC" should be our default as it successfully handles English and non-Romantic
+    static let `default`: SubtitleConfiguration = .init(
+        color: .white,
+        fontName: "Noto Sans CJK SC",
+        size: 9
+    )
+
+    private enum CodingKeys: String, CodingKey {
+        case color
+        case fontName
+        case size
+    }
+
+    init(color: Color, fontName: String, size: Int) {
+        self.color = color
+        self.fontName = fontName
+        self.size = size
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        self.color = try Color(hex: container.decode(String.self, forKey: .color))
+        self.fontName = try container.decode(String.self, forKey: .fontName)
+        self.size = try container.decode(Int.self, forKey: .size)
+    }
+
+    func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(color.hexString, forKey: .color)
+        try container.encode(fontName, forKey: .fontName)
+        try container.encode(size, forKey: .size)
+    }
+}

--- a/Shared/Resources/Fonts/NotoSansCJK-OFL.txt
+++ b/Shared/Resources/Fonts/NotoSansCJK-OFL.txt
@@ -1,0 +1,92 @@
+This Font Software is licensed under the SIL Open Font License,
+Version 1.1.
+
+This license is copied below, and is also available with a FAQ at:
+http://scripts.sil.org/OFL
+
+-----------------------------------------------------------
+SIL OPEN FONT LICENSE Version 1.1 - 26 February 2007
+-----------------------------------------------------------
+
+PREAMBLE
+The goals of the Open Font License (OFL) are to stimulate worldwide
+development of collaborative font projects, to support the font
+creation efforts of academic and linguistic communities, and to
+provide a free and open framework in which fonts may be shared and
+improved in partnership with others.
+
+The OFL allows the licensed fonts to be used, studied, modified and
+redistributed freely as long as they are not sold by themselves. The
+fonts, including any derivative works, can be bundled, embedded,
+redistributed and/or sold with any software provided that any reserved
+names are not used by derivative works. The fonts and derivatives,
+however, cannot be released under any other type of license. The
+requirement for fonts to remain under this license does not apply to
+any document created using the fonts or their derivatives.
+
+DEFINITIONS
+"Font Software" refers to the set of files released by the Copyright
+Holder(s) under this license and clearly marked as such. This may
+include source files, build scripts and documentation.
+
+"Reserved Font Name" refers to any names specified as such after the
+copyright statement(s).
+
+"Original Version" refers to the collection of Font Software
+components as distributed by the Copyright Holder(s).
+
+"Modified Version" refers to any derivative made by adding to,
+deleting, or substituting -- in part or in whole -- any of the
+components of the Original Version, by changing formats or by porting
+the Font Software to a new environment.
+
+"Author" refers to any designer, engineer, programmer, technical
+writer or other person who contributed to the Font Software.
+
+PERMISSION & CONDITIONS
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of the Font Software, to use, study, copy, merge, embed,
+modify, redistribute, and sell modified and unmodified copies of the
+Font Software, subject to the following conditions:
+
+1) Neither the Font Software nor any of its individual components, in
+Original or Modified Versions, may be sold by itself.
+
+2) Original or Modified Versions of the Font Software may be bundled,
+redistributed and/or sold with any software, provided that each copy
+contains the above copyright notice and this license. These can be
+included either as stand-alone text files, human-readable headers or
+in the appropriate machine-readable metadata fields within text or
+binary files as long as those fields can be easily viewed by the user.
+
+3) No Modified Version of the Font Software may use the Reserved Font
+Name(s) unless explicit written permission is granted by the
+corresponding Copyright Holder. This restriction only applies to the
+primary font name as presented to the users.
+
+4) The name(s) of the Copyright Holder(s) or the Author(s) of the Font
+Software shall not be used to promote, endorse or advertise any
+Modified Version, except to acknowledge the contribution(s) of the
+Copyright Holder(s) and the Author(s) or with their explicit written
+permission.
+
+5) The Font Software, modified or unmodified, in part or in whole,
+must be distributed entirely under this license, and must not be
+distributed under any other license. The requirement for fonts to
+remain under this license does not apply to any document created using
+the Font Software.
+
+TERMINATION
+This license becomes null and void if any of the above conditions are
+not met.
+
+DISCLAIMER
+THE FONT SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO ANY WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT
+OF COPYRIGHT, PATENT, TRADEMARK, OR OTHER RIGHT. IN NO EVENT SHALL THE
+COPYRIGHT HOLDER BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+INCLUDING ANY GENERAL, SPECIAL, INDIRECT, INCIDENTAL, OR CONSEQUENTIAL
+DAMAGES, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+FROM, OUT OF THE USE OR INABILITY TO USE THE FONT SOFTWARE OR FROM
+OTHER DEALINGS IN THE FONT SOFTWARE.

--- a/Shared/Services/SwiftfinDefaults.swift
+++ b/Shared/Services/SwiftfinDefaults.swift
@@ -362,19 +362,10 @@ extension Defaults.Keys {
             }
         }
 
-        // TODO: transition into a SubtitleConfiguration instead of multiple types
         enum Subtitle {
 
-            static var subtitleColor: Key<Color> {
-                UserKey("subtitleColor", default: .white)
-            }
-
-            static var subtitleFontName: Key<String> {
-                UserKey("subtitleFontName", default: UIFont.systemFont(ofSize: 14).fontName)
-            }
-
-            static var subtitleSize: Key<Int> {
-                UserKey("subtitleSize", default: 9)
+            static var configuration: Key<SubtitleConfiguration> {
+                UserKey("subtitleConfiguration", default: .default)
             }
         }
 

--- a/Shared/Views/SettingsView/VideoPlayerSettingsView.swift
+++ b/Shared/Views/SettingsView/VideoPlayerSettingsView.swift
@@ -49,12 +49,8 @@ struct VideoPlayerSettingsView: View {
 
     // MARK: - Subtitle Defaults
 
-    @Default(.VideoPlayer.Subtitle.subtitleFontName)
-    private var subtitleFontName
-    @Default(.VideoPlayer.Subtitle.subtitleSize)
-    private var subtitleSize
-    @Default(.VideoPlayer.Subtitle.subtitleColor)
-    private var subtitleColor
+    @Default(.VideoPlayer.Subtitle.configuration)
+    private var subtitleConfiguration
 
     // MARK: - Timestamp Defaults
 
@@ -315,18 +311,18 @@ struct VideoPlayerSettingsView: View {
         }
 
         Section {
-            ChevronButton(L10n.subtitleFont, content: subtitleFontName) {
-                router.route(to: .fontPicker(selection: $subtitleFontName))
+            ChevronButton(L10n.subtitleFont, content: subtitleConfiguration.fontName) {
+                router.route(to: .fontPicker(selection: $subtitleConfiguration.fontName))
             }
 
-            Stepper(L10n.subtitleSize, value: $subtitleSize, in: 1 ... 20, step: 1) {
+            Stepper(L10n.subtitleSize, value: $subtitleConfiguration.size, in: 1 ... 20, step: 1) {
                 LabeledContent(L10n.subtitleSize) {
-                    Text(subtitleSize.description)
+                    Text(subtitleConfiguration.size.description)
                         .foregroundStyle(.secondary)
                 }
             }
 
-            ColorPicker(L10n.subtitleColor, selection: $subtitleColor, supportsOpacity: false)
+            ColorPicker(L10n.subtitleColor, selection: $subtitleConfiguration.color, supportsOpacity: false)
         } footer: {
             // TODO: better wording
             Text(L10n.subtitlesDisclaimer)

--- a/Swiftfin tvOS/Resources/Info.plist
+++ b/Swiftfin tvOS/Resources/Info.plist
@@ -42,6 +42,10 @@
 		<key>NSAllowsArbitraryLoads</key>
 		<true/>
 	</dict>
+	<key>UIAppFonts</key>
+	<array>
+		<string>NotoSansCJK-Regular.ttc</string>
+	</array>
 	<key>UILaunchScreen</key>
 	<dict>
 		<key>UIColorName</key>

--- a/Swiftfin/Resources/Info.plist
+++ b/Swiftfin/Resources/Info.plist
@@ -57,6 +57,10 @@
 	<string>${PRODUCT_NAME} uses your location to identify the current Wi-Fi network.</string>
 	<key>NSMicrophoneUsageDescription</key>
 	<string>${PRODUCT_NAME} uses the microphone to listen for ultrasonic tokens when pairing with nearby Cast devices.</string>
+	<key>UIAppFonts</key>
+	<array>
+		<string>NotoSansCJK-Regular.ttc</string>
+	</array>
 	<key>UIApplicationSceneManifest</key>
 	<dict>
 		<key>UIApplicationSupportsMultipleScenes</key>


### PR DESCRIPTION
### Summary

Resolves: https://github.com/jellyfin/Swiftfin/issues/2004

This does two things. 

#### Firstly:

To fix 2004, this bundles `Noto Sans CJK` into Swiftfin which resolves the rendering issue at the cost that Swiftfin will be ~19.5 MB larger. A non-insignificant increase ~175 -> ~195 is a ~11% increase but this does resolve our issue. As part of this, I am setting `Noto Sans CJK SC` as the default font. In testing, this works for Chinese, Japanese, and Korean with English and other romantic languages working with it by default as well. I'm sure there is a larger debate about which of the  `Noto Sans CJK` variants should be the default but this was recommended to me on a forum so I am willing to die on this hill /s.

As a note, I read that `Noto Sans CJK` could not render Hebrew and Arabic but in my testing **I found this to be false. This continues to render in VLCKit using this font.**

#### Secondly:

There was an outstanding TODO to turn the various subtitle settings into a `SubtitleConfiguration` object. Saving and encode/decode works as before. I haven't made a migration for this since I would argue migrating everyone to `Noto Sans CJK` as the default (since we know it works) would be beneficial to us but I'm open to migrating.

### Videos

#### Before

Please note the □ in these subtitles:

https://github.com/user-attachments/assets/2f8aa96f-df84-4d4c-a42f-342ba86ee988

#### After

Please note that the □ are now gone and render correctly:

https://github.com/user-attachments/assets/ea00d02c-6806-4aa5-905c-f8b1e20b2570

### AI Disclaimer

All work was me but the subtitles for testing were generated by Claude. Please note that I have no idea what they say so apologies if there is anything off there!