### PR TITLE
Episode - Landscape: Use Backdrop if Available

### DIFF
--- a/Shared/Extensions/JellyfinAPI/BaseItemDto/BaseItemDto+Poster.swift
+++ b/Shared/Extensions/JellyfinAPI/BaseItemDto/BaseItemDto+Poster.swift
@@ -151,6 +151,14 @@ extension BaseItemDto: Poster {
                     environment: environment
                 )
             } else {
+                if let backdropTag = backdropImageTags?.first {
+                    imageSource(
+                        .backdrop,
+                        tag: backdropTag,
+                        environment: environment
+                    )
+                }
+
                 imageSource(
                     .primary,
                     environment: environment


### PR DESCRIPTION
### Summary

Some metadata providers provide a `.primary` which is a landscape poster with text on top and a `.backdrop` which is the same landscape poster without text on it. More generically, if a backdrop image type exists, use that first.

Mirrors how web handles the existence of `.backdrop` + `.primary` vs just `.primary` as well.