### PR TITLE
Create separate VC1 Transcoding Profile for Swiftfin Player

### DIFF
--- a/Shared/Objects/VideoPlayerType/VideoPlayerType+Swiftfin.swift
+++ b/Shared/Objects/VideoPlayerType/VideoPlayerType+Swiftfin.swift
@@ -118,8 +118,33 @@ extension VideoPlayerType {
             VideoCodec.mpeg1video
             VideoCodec.mpeg2video
             VideoCodec.mpeg4
-            VideoCodec.vc1
             VideoCodec.vp9
+        } containers: {
+            MediaContainer.mp4
+        }
+
+        // Create a separate profile to allow VC1 to DirectStream to get around server-imposed HLS video restrictions in StreamBuilder _supportedHlsVideoCodecs
+        TranscodingProfile(
+            isBreakOnNonKeyFrames: true,
+            context: .streaming,
+            maxAudioChannels: "8",
+            minSegments: 2,
+            protocol: MediaStreamProtocol.hls,
+            type: .video
+        ) {
+            AudioCodec.aac
+            AudioCodec.ac3
+            AudioCodec.alac
+            AudioCodec.dts
+            AudioCodec.eac3
+            AudioCodec.flac
+            AudioCodec.mp1
+            AudioCodec.mp2
+            AudioCodec.mp3
+            AudioCodec.opus
+            AudioCodec.vorbis
+        } videoCodecs: {
+            VideoCodec.vc1
         } containers: {
             MediaContainer.mp4
         }

--- a/Shared/Objects/VideoPlayerType/VideoPlayerType+Swiftfin.swift
+++ b/Shared/Objects/VideoPlayerType/VideoPlayerType+Swiftfin.swift
@@ -123,7 +123,8 @@ extension VideoPlayerType {
             MediaContainer.mp4
         }
 
-        // Create a separate profile to allow VC1 to DirectStream to get around server-imposed HLS video restrictions in StreamBuilder _supportedHlsVideoCodecs
+        /// Create a separate profile to allow VC1 to DirectStream
+        /// Necessary to avoid server-imposed HLS video restrictions in StreamBuilder _supportedHlsVideoCodecs
         TranscodingProfile(
             isBreakOnNonKeyFrames: true,
             context: .streaming,


### PR DESCRIPTION
Summary:

Because of server-side HLS restrictions (namely, allowable codecs), VC1 is unable to be DirectStreamed using Swiftfin player. This is because it is in a transcoding profile with other codecs that the server views as allowable for HLS in StreamBuilder `_supportedHlsVideoCodecs`. In order to circumvent this restriction, it appears that a transcoding profile with no video codecs in `_supportedHlsVideoCodecs` will allow the server to pass the video through without transcoding.

I haven't dug into why exactly this works server-side, so it might not be guaranteed to continue to work, but I think it is likely the best solution for now. The main media this affects are old Blu-rays that are encoded in VC1 with Dolby TrueHD audio.

Changes:
- Remove VC1 in main Swiftfin player transcoding profile
- Add separate VC1 transcode profile to Swiftfin player to allow DirectStream

Potentially resolves #2101 at least partially.

Compiled and tested on iPhone X