### PR TITLE
Remove restriction on Swiftfin player AVC/H264 interlaced video

### DIFF
--- a/Shared/Objects/VideoPlayerType/VideoPlayerType+Native.swift
+++ b/Shared/Objects/VideoPlayerType/VideoPlayerType+Native.swift
@@ -181,6 +181,12 @@ extension VideoPlayerType {
                     VideoRangeType.sdr
                     VideoRangeType.doviWithSDR
                 }
+                ProfileCondition(
+                    condition: .notEquals,
+                    isRequired: false,
+                    property: .isInterlaced,
+                    value: "true"
+                )
             }
         )
 

--- a/Shared/Objects/VideoPlayerType/VideoPlayerType+Shared.swift
+++ b/Shared/Objects/VideoPlayerType/VideoPlayerType+Shared.swift
@@ -49,12 +49,6 @@ extension VideoPlayerType {
             property: .videoLevel,
             value: "80"
         )
-        ProfileCondition(
-            condition: .notEquals,
-            isRequired: false,
-            property: .isInterlaced,
-            value: "true"
-        )
     }
 
     @ArrayBuilder<ProfileCondition>


### PR DESCRIPTION
Summary:

Resolves https://github.com/jellyfin/Swiftfin/issues/2127 by removing the shared restriction on interlaced AVC/H264 video and moving it solely to the Native player. VLCKit/Swiftfin player supports interlaced video, at least encoded by AVC/H264 and this will allow DirectPlaying and DirectStreaming of this content instead of forcing the server to transcode it.

Compiled and tested on iPhone X. Given that playback was smooth, I am not worried about whether interlaced video might not be hardware decoded. Also worked for DirectStream when audio codec can't be DirectPlayed.