### PR TITLE
Allow DOVIWithEL video to DirectPlay

### DIFF
--- a/Shared/Objects/VideoPlayerType/VideoPlayerType+Native.swift
+++ b/Shared/Objects/VideoPlayerType/VideoPlayerType+Native.swift
@@ -265,6 +265,7 @@ extension VideoPlayerType {
         if PlaybackCapabilities.supportsHDR10 || PlaybackCapabilities.supportsDolbyVision {
             VideoRangeType.doviWithHDR10
             VideoRangeType.doviWithHDR10Plus
+            VideoRangeType.doviWithEL
             VideoRangeType.doviWithELHDR10Plus
         }
 

--- a/Shared/Objects/VideoPlayerType/VideoPlayerType+Swiftfin.swift
+++ b/Shared/Objects/VideoPlayerType/VideoPlayerType+Swiftfin.swift
@@ -325,6 +325,7 @@ extension VideoPlayerType {
             VideoRangeType.doviWithHLG
             VideoRangeType.doviWithHDR10
             VideoRangeType.doviWithHDR10Plus
+            VideoRangeType.doviWithEL
             VideoRangeType.doviWithELHDR10Plus
         }
     }


### PR DESCRIPTION
Summary:

Resolves #2131. Adds doviWithEL to both swiftfinHDRProfiles and nativeHDRProfiles.

This allows videos that are single track dual layer Dolby Vision Profile 7.6 to play directly if all else is in order, utilizing the HDR10 BL. The MEL and FEL is not utilized in this situation, but it is also not utilized by the server, so DirectPlay is preferred. I'm not familiar with a situation where this could cause playback issues because DOVIWithEL should always have a HDR10 BL AFAIK.

If at some point the server starts handling the MEL or FEL, it might be worth revisiting, but that raises questions as well about the whole way client capability is indicated and acted upon by the server. Likely the nativeHDRProfiles logic should be reworked because some of the DOVI ranges like this I believe might actually require HDR10 capability - but it also likely doesn't really matter right now because anything that supports DOVI should support HDR10 as well. In other words, I think PlaybackCapabilities.supportsDolbyVision is a superset of PlaybackCapabilities.supportsHDR10. This means _I believe_ (but am not confident enough at the moment to change anything, and it won't affect playback anyway given the current logic) the only DOVI videoRangeType that requires Dolby Vision support is VideoRangeType.dovi since all the other DOVI ones have a base layer of either SDR, HDR10, or HLG.

Compiled and tested on iPhone X and Apple TV HD. Tested with DOVIWithEL single track dual layer dv profile 7 .mkv and .mp4. MKV DirectPlayed on Swiftfin and MP4 DirectPlayed on Native as expected.