### PR TITLE
Live TV Poster & Recordings

### DIFF
--- a/Shared/Objects/Libraries/UserViewLibrary.swift
+++ b/Shared/Objects/Libraries/UserViewLibrary.swift
@@ -328,23 +328,24 @@ private extension UserViewLibraryElement {
             throw UserSessionError.missingCurrentSession
         }
 
-        if case let .userView(item) = self, item.collectionType == .livetv {
-            return []
-        }
-
         var parentID: String?
         var filters: [ItemTrait]?
+        var includeItemTypes: [BaseItemKind] = BaseItemKind.supportedCases
 
         switch self {
         case .favorites:
             filters = [.isFavorite]
         case let .userView(item):
-            parentID = item.id
+            if item.collectionType == .livetv {
+                includeItemTypes = [.tvProgram, .liveTvProgram]
+            } else {
+                parentID = item.id
+            }
         }
 
         var parameters = Paths.GetItemsParameters()
         parameters.filters = filters
-        parameters.includeItemTypes = BaseItemKind.supportedCases
+        parameters.includeItemTypes = includeItemTypes
         parameters.isRecursive = true
         parameters.limit = 3
         parameters.parentID = parentID

--- a/Shared/ViewModels/ContentGroupViewModel/LiveTVGroupProvider.swift
+++ b/Shared/ViewModels/ContentGroupViewModel/LiveTVGroupProvider.swift
@@ -10,14 +10,17 @@ import JellyfinAPI
 
 struct LiveTVGroupProvider: ContentGroupProvider {
 
-    // TODO: Add Guides & Recordings
+    // TODO: Add Guides
     private enum LiveTVPill: Displayable, SystemImageable {
         case channels
+        case recordings
 
         var displayTitle: String {
             switch self {
             case .channels:
                 L10n.channels
+            case .recordings:
+                L10n.recordings
             }
         }
 
@@ -25,6 +28,8 @@ struct LiveTVGroupProvider: ContentGroupProvider {
             switch self {
             case .channels:
                 "play.square.stack"
+            case .recordings:
+                "record.circle"
             }
         }
     }
@@ -37,7 +42,7 @@ struct LiveTVGroupProvider: ContentGroupProvider {
         PillGroup(
             displayTitle: "",
             id: "live-tv-channels",
-            elements: [LiveTVPill.channels]
+            elements: [LiveTVPill.channels, .recordings]
         ) { router, pill in
             switch pill {
             case .channels:
@@ -48,6 +53,10 @@ struct LiveTVGroupProvider: ContentGroupProvider {
                             filters: .init(itemTypes: [.liveTvChannel])
                         )
                     )
+                )
+            case .recordings:
+                router.route(
+                    to: .library(library: RecordingsLibrary())
                 )
             }
         }


### PR DESCRIPTION
### Summary

Splitting more of this out from the larger guide work. I think this is the last one before just working on the guide. This PR is two smaller items:

1. Include Live TV in the logic to pull a random images in the `MediaView`. This does this b y generically looking for programs. Again, depending on their context they can be `.tvPrograms` or `.liveTVPrograms` and in my testing one server returned with one and one returned with the other. This just uses both to prevent issues.
2. Add a pill button in the Live TV view for recordings. I originally wanted to make this a `getItems` call filtered on `.recording` but for whatever reason all my recordings of movies in Live TV show up as `.movie`s so it's not really feasible to filter on these. This instead mirrors what already exists in the `Latest Recordings` section which is disappointing but I still believe this warrants a pill button at the top.

### Video

https://github.com/user-attachments/assets/701dcee4-aa0d-419c-b06c-7b00adc26c97