### PR TITLE
fix: restore AppDelegate to fix orientation lock regression on app foreground

### DIFF
--- a/Swiftfin/App/AppDelegate.swift
+++ b/Swiftfin/App/AppDelegate.swift
@@ -1,0 +1,38 @@
+//
+// Swiftfin is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, you can obtain one at https://mozilla.org/MPL/2.0/.
+//
+// Copyright (c) 2026 Jellyfin & Jellyfin Contributors
+//
+
+import PreferencesView
+import UIKit
+
+class AppDelegate: NSObject, UIApplicationDelegate {
+
+    func application(
+        _ application: UIApplication,
+        didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]? = nil
+    ) -> Bool {
+        true
+    }
+
+    func application(
+        _ application: UIApplication,
+        supportedInterfaceOrientationsFor window: UIWindow?
+    ) -> UIInterfaceOrientationMask {
+
+        guard UIDevice.isPhone else {
+            return .allButUpsideDown
+        }
+
+        if let presentedViewController = window?.rootViewController?.presentedViewController,
+           let preferencesHostingController = presentedViewController as? UIPreferencesHostingController
+        {
+            return preferencesHostingController.supportedInterfaceOrientations
+        }
+
+        return .portrait
+    }
+}

--- a/Swiftfin/App/SwiftfinApp.swift
+++ b/Swiftfin/App/SwiftfinApp.swift
@@ -13,6 +13,9 @@ import UIKit
 @main
 struct SwiftfinApp: App {
 
+    @UIApplicationDelegateAdaptor(AppDelegate.self)
+    var appDelegate
+
     init() {
         Self.configure()
 


### PR DESCRIPTION
PR #2059 removed the AppDelegate that had the orientation fix from PR #1959. Without it, the video player gets stuck in portrait mode after backgrounding the app or using PiP on iPhone.

This re-adds the AppDelegate with the `supportedInterfaceOrientationsFor` delegate method that checks the presented `UIPreferencesHostingController` for the correct orientation mask.

Closes #1898 (regression).

---

*AI disclosure: This code and PR were created with assistance from an AI coding assistant (opencode). The changes were reviewed and tested before submission.*