### PR TITLE
Live TV Image Sources & ItemView

### DIFF
--- a/Shared/Extensions/JellyfinAPI/BaseItemDto/BaseItemDto+Poster.swift
+++ b/Shared/Extensions/JellyfinAPI/BaseItemDto/BaseItemDto+Poster.swift
@@ -108,7 +108,7 @@ extension BaseItemDto: Poster {
                 tag: seriesPrimaryImageTag,
                 environment: environment
             )
-        case .boxSet, .channel, .liveTvChannel, .movie, .musicArtist, .person, .series, .tvChannel:
+        case .boxSet, .channel, .liveTvChannel, .liveTvProgram, .movie, .musicArtist, .person, .program, .series, .tvChannel:
             imageSource(
                 .primary,
                 environment: environment
@@ -156,7 +156,7 @@ extension BaseItemDto: Poster {
                     environment: environment
                 )
             }
-        case .collectionFolder, .folder, .liveTvProgram, .musicVideo, .program, .userView, .video:
+        case .collectionFolder, .folder, .musicVideo, .userView, .video:
             imageSource(
                 .primary,
                 environment: environment

--- a/Shared/Views/ItemView/ItemView.swift
+++ b/Shared/Views/ItemView/ItemView.swift
@@ -42,7 +42,10 @@ struct ItemView: View {
             }
 
             if isCompact {
-                return provider.item.type == .movie || provider.item.type == .series
+                return provider.item.type == .movie
+                    || provider.item.type == .series
+                    || provider.item.type == .program
+                    || provider.item.type == .liveTvProgram
             }
 
             return provider.item.type != .person && provider.item.type != .season


### PR DESCRIPTION
### Summary

Live TV isn't always a Landscape image. There can be a primary, landscape, thumb, and logo. This utilizes these images and enabled programs to use the enhanced layout.

### Images

#### Library

| Before | After |
| --- | --- |
| <img width="100%" alt="Old_ItemLibrary" src="https://github.com/user-attachments/assets/9aea12b7-2c8d-4e7e-9d5b-8ac20d3d303a" /> | <img width="100%" alt="ItemLibrary" src="https://github.com/user-attachments/assets/61fe6a09-fc2b-4455-bf8f-876465af30c9" /> |

#### Movies

| Before | After |
| --- | --- |
| <img width="100%" alt="Old_Movie" src="https://github.com/user-attachments/assets/d07ecbd6-781f-4126-a544-58fc096ef2f1" /> | <img width="100%" alt="Movie" src="https://github.com/user-attachments/assets/61a36e98-3aeb-4a2d-8da8-a3183e3b7b7a" /> |

#### Shows

| Before | After |
| --- | --- |
| <img width="100%" alt="Old_Show" src="https://github.com/user-attachments/assets/f9652af6-ec7d-42e0-bd5e-2fde6c4afd96" /> | <img width="100%" alt="Show" src="https://github.com/user-attachments/assets/74f6b8c2-e5c7-450b-9661-c7ae72df3cb2" /> |