### PR TITLE
Fix Text Subtitle Conversion

### DIFF
--- a/Documentation/players.md
+++ b/Documentation/players.md
@@ -139,7 +139,6 @@ Swiftfin offers two player options: **Swiftfin** (VLCKit) and **Native** (AVPlay
 | [CC_DEC](https://en.wikipedia.org/wiki/Closed_captioning)                       | ✅                | ✅                |
 | [DVBSub](https://en.wikipedia.org/wiki/DVB_subtitles)                           | ✅ [1]            | 🔶 [2]            |
 | [DVDSub](https://en.wikipedia.org/wiki/VobSub)                                  | ✅ [1]            | 🔶 [2]            |
-| [JacoSub](https://en.wikipedia.org/wiki/JACOsub)                                | ✅                | ❌                |
 | [MOV_Text](https://en.wikipedia.org/wiki/MPEG-4_Part_17)                        | ✅                | ❌                |
 | [MPL2](https://en.wikipedia.org/wiki/MPL2)                                      | ✅                | ❌                |
 | [PGSSub](https://en.wikipedia.org/wiki/Presentation_Graphic_Stream)             | ✅ [1]            | 🔶 [2]            |

--- a/Shared/Objects/MediaComponents/SubtitleFormat.swift
+++ b/Shared/Objects/MediaComponents/SubtitleFormat.swift
@@ -14,7 +14,6 @@ enum SubtitleFormat: String, CaseIterable, Codable, Displayable, Storable {
     case cc_dec
     case dvdsub
     case dvbsub
-    case jacosub
     case libzvbi_teletextdec
     case mov_text
     case mpl2
@@ -52,8 +51,6 @@ enum SubtitleFormat: String, CaseIterable, Codable, Displayable, Storable {
             L10n.dvdSubtitle
         case .dvbsub:
             L10n.dvbSubtitle
-        case .jacosub:
-            L10n.jacosub
         case .libzvbi_teletextdec:
             L10n.dvbTeletext
         case .mov_text:
@@ -100,8 +97,6 @@ enum SubtitleFormat: String, CaseIterable, Codable, Displayable, Storable {
             "sub"
         case .dvbsub:
             "dvbsub"
-        case .jacosub:
-            "jss"
         case .libzvbi_teletextdec:
             "txt"
         case .mov_text:
@@ -150,7 +145,7 @@ enum SubtitleFormat: String, CaseIterable, Codable, Displayable, Storable {
     /// Whether this format is a text-based subtitle
     var isText: Bool {
         switch self {
-        case .ass, .cc_dec, .jacosub, .libzvbi_teletextdec, .mov_text,
+        case .ass, .cc_dec, .libzvbi_teletextdec, .mov_text,
              .mpl2, .pjs, .realtext, .sami, .ssa, .subrip, .subviewer,
              .subviewer1, .text, .ttml, .vplayer, .vtt:
             true

--- a/Shared/Objects/VideoPlayerType/VideoPlayerType+Swiftfin.swift
+++ b/Shared/Objects/VideoPlayerType/VideoPlayerType+Swiftfin.swift
@@ -160,7 +160,6 @@ extension VideoPlayerType {
             SubtitleFormat.cc_dec
             SubtitleFormat.dvbsub
             SubtitleFormat.dvdsub
-            SubtitleFormat.jacosub
             SubtitleFormat.libzvbi_teletextdec
             SubtitleFormat.mov_text
             SubtitleFormat.mpl2
@@ -175,12 +174,14 @@ extension VideoPlayerType {
             SubtitleFormat.text
             SubtitleFormat.ttml
             SubtitleFormat.vplayer
+            SubtitleFormat.vtt
             SubtitleFormat.xsub
         }
 
+        /// - Note: Unmatched text subtitles (ex: VTT) are converted to the first option (subrip)
         SubtitleProfile.build(method: .external) {
+            SubtitleFormat.subrip
             SubtitleFormat.ass
-            SubtitleFormat.jacosub
             SubtitleFormat.libzvbi_teletextdec
             SubtitleFormat.mpl2
             SubtitleFormat.pjs

--- a/Shared/Objects/VideoPlayerType/VideoPlayerType+Swiftfin.swift
+++ b/Shared/Objects/VideoPlayerType/VideoPlayerType+Swiftfin.swift
@@ -175,7 +175,6 @@ extension VideoPlayerType {
             SubtitleFormat.text
             SubtitleFormat.ttml
             SubtitleFormat.vplayer
-            SubtitleFormat.vtt
             SubtitleFormat.xsub
         }
 
@@ -194,13 +193,13 @@ extension VideoPlayerType {
             SubtitleFormat.text
             SubtitleFormat.ttml
             SubtitleFormat.vplayer
-            SubtitleFormat.vtt
         }
 
         SubtitleProfile.build(method: .encode) {
             SubtitleFormat.dvbsub
             SubtitleFormat.dvdsub
             SubtitleFormat.pgssub
+            SubtitleFormat.vtt
             SubtitleFormat.xsub
         }
     }

--- a/Shared/Objects/VideoPlayerType/VideoPlayerType+Swiftfin.swift
+++ b/Shared/Objects/VideoPlayerType/VideoPlayerType+Swiftfin.swift
@@ -188,7 +188,6 @@ extension VideoPlayerType {
             SubtitleFormat.realtext
             SubtitleFormat.sami
             SubtitleFormat.ssa
-            SubtitleFormat.subrip
             SubtitleFormat.subviewer
             SubtitleFormat.subviewer1
             SubtitleFormat.text

--- a/Shared/Strings/ProperNouns.swift
+++ b/Shared/Strings/ProperNouns.swift
@@ -109,7 +109,6 @@ extension L10n {
     static let dvbTeletext = "DVB Teletext"
     static let dvdSubtitle = "DVD Subtitle"
     static let eia608 = "EIA-608"
-    static let jacosub = "Jacosub"
     static let mpeg4TimedText = "MPEG-4 Timed Text"
     static let mpl2 = "MPL2"
     static let pgsSubtitle = "PGS Subtitle"


### PR DESCRIPTION
### Summary

Resolves: https://github.com/jellyfin/Swiftfin/issues/2153

This was an interesting one. So, VLC can play embedded WebVTT but not external file VTT. Removing VTT from the external options didn't resolve this. This is because Jellyfin converts Text Subtitles to the FIRST subtitle in the device profiles for Text for external. In our case, jacosub because someone (me) thought it looked better alphabetically... Jellyfin attempts to convert the WebVTT into jacosub which VLC then cannot handle. I don't think Jellyfin can convert WebVTT into jacosub but starting from a raw jacosub it works in desktop VLC but will not play in VLCKit.

For this reason, I've removed jacosub from the list. Doing some research, I think this will be fine:

<img width="214" height="33" alt="Screenshot 2026-08-01 at 01 59 24" src="https://github.com/user-attachments/assets/baa3e1b8-053f-4b37-96a4-e785cb5f28f1" />

### Before

https://github.com/user-attachments/assets/59ac7a4d-6bff-4344-9fe0-64a76905a9c3

### After

Not including the embedded WebVTT in the simulator video because embedded WebVTT on simulator causes crashes due to a weird VideoToolbox error that doesn't show up on real hardware or AVKit.

https://github.com/user-attachments/assets/f575572c-846d-49ac-bea6-16183f15d01c