### PR TITLE
Allow hyphens in deep link URL segment regex

### DIFF
--- a/Shared/Services/DeepLink.swift
+++ b/Shared/Services/DeepLink.swift
@@ -23,7 +23,7 @@ struct DeepLink: Equatable {
 
     init?(_ url: URL) {
         guard let match = url.absoluteString.wholeMatch(
-            of: /^swiftfin:\/\/(?<serverID>[A-Za-z0-9]+)\/(?<userID>[A-Za-z0-9]+)\/(?<destinationType>item|library)\/(?<destinationID>[A-Za-z0-9]+)\/?$/
+            of: /^swiftfin:\/\/(?<serverID>[A-Za-z0-9-]+)\/(?<userID>[A-Za-z0-9-]+)\/(?<destinationType>item|library)\/(?<destinationID>[A-Za-z0-9-]+)\/?$/
         ) else { return nil }
 
         self.serverID = String(match.output.serverID)


### PR DESCRIPTION
Allow hyphens in deep link URL segment regex.  Jellyfin typically supports both GUIDs with hyphens and without.  This modification allows both to be supported in deep links as well.