### PR TITLE
Fix video player freezing when the window may rotate

### DIFF
--- a/Shared/Views/VideoPlayer/VideoPlayerContainerView/VideoPlayerContainerView.swift
+++ b/Shared/Views/VideoPlayer/VideoPlayerContainerView/VideoPlayerContainerView.swift
@@ -74,7 +74,9 @@ extension VideoPlayer {
         func updateUIViewController(
             _ uiViewController: UIVideoPlayerContainerViewController,
             context: Context
-        ) {}
+        ) {
+            uiViewController.refreshPlayerContent()
+        }
     }
 
     // MARK: - UIVideoPlayerContainerViewController
@@ -218,12 +220,30 @@ extension VideoPlayer {
             return view
         }()
 
+        private func makePlayerContent() -> AnyView {
+            PlayerContainerView(player: player)
+                .environmentObject(containerState)
+                .environmentObject(manager)
+                .eraseToAnyView()
+        }
+
+        /// Re-hosts the player content.
+        ///
+        /// The hosted view is created once, so its only route to a new playback
+        /// item is the `@EnvironmentObject` subscription baked in at creation.
+        /// That subscription does not survive every geometry pass — notably
+        /// when the window is allowed to rotate — and once it is lost the view
+        /// is frozen on stale state with no way to recover: the manager reaches
+        /// `.playback` with an item ready and the player is never built.
+        /// Pushing fresh content gives it an input path that does not depend on
+        /// observation.
+        func refreshPlayerContent() {
+            playerViewController.content = makePlayerContent()
+        }
+
         private lazy var playerViewController: HostingController<AnyView> = {
             let controller = HostingController(
-                content: PlayerContainerView(player: player)
-                    .environmentObject(containerState)
-                    .environmentObject(manager)
-                    .eraseToAnyView()
+                content: makePlayerContent()
             )
             controller.disableSafeArea = true
             controller.automaticallyAllowUIKitAnimationsForNextUpdate = true

--- a/Swiftfin/App/AppDelegate.swift
+++ b/Swiftfin/App/AppDelegate.swift
@@ -23,16 +23,11 @@ class AppDelegate: NSObject, UIApplicationDelegate {
         supportedInterfaceOrientationsFor window: UIWindow?
     ) -> UIInterfaceOrientationMask {
 
-        guard UIDevice.isPhone else {
-            return .allButUpsideDown
-        }
-
-        if let presentedViewController = window?.rootViewController?.presentedViewController,
-           let preferencesHostingController = presentedViewController as? UIPreferencesHostingController
-        {
-            return preferencesHostingController.supportedInterfaceOrientations
-        }
-
-        return .portrait
+        // UIKit intersects this window-level mask with the top view
+        // controller's own `supportedInterfaceOrientations`, which
+        // `PreferencesView` already resolves per screen. Reporting a narrower
+        // mask here clamped that intersection and locked the video player to
+        // portrait on iPhone.
+        .allButUpsideDown
     }
 }


### PR DESCRIPTION
Fixes #2165.

## The visible bug

On iPhone, the video player cannot rotate to landscape on `main`. It rotates correctly on 1.5.

## Why the current code locks it

`AppDelegate` reports `.portrait` for the window unless the root's immediate `presentedViewController` casts to `UIPreferencesHostingController`. The player is presented inside Transmission's hosting controller, so that cast never succeeds and the window is clamped to portrait.

The obvious fix — report the player's actual mask — **breaks playback**. I tried three variants (walk to the topmost presented controller, search descendants for the preferences controller, and a static `.allButUpsideDown`); all three left the player unable to start: black screen, no VLC state events, no stream requested from the server. Details and results table in #2165.

## The actual cause

The clamp was hiding a second defect.

`VideoPlayerContainerView` erases the player to `AnyView` and hosts it once in `makeUIViewController`, and `updateUIViewController` does nothing. After creation, the hosted view's only route to a new playback item is the `@EnvironmentObject` subscription captured at that moment. That subscription does not survive every geometry pass, and permitting rotation reliably triggers one.

Once it is lost the hosted view never re-evaluates. Instrumenting both sides shows the manager working perfectly while the child is frozen:

```
PARENT received playbackItem: true     <- publisher fires, parent observes it
Playing new item                       <- item built, URL valid
PARENT received state: playback        <- gate condition satisfied
(VLCPlayerView.body never re-runs)     <- player never constructed
```

`/Sessions/Playing` is reported to the server, so the session looks live, but no stream is ever requested. That also explains intermittent black screens in portrait: the same freeze, just triggered less often. In one user's logs, 8 of 9 playback attempts on device never constructed the player, all in portrait.

## The fix

1. Re-host the player content in `updateUIViewController`, giving it an input path that does not depend on an observation that can be dropped.
2. Let `AppDelegate` report the full mask, so `PreferencesView` resolves orientation per screen as it did before the delegate was reintroduced.

(1) is what makes (2) safe. With only (2), playback breaks as described above.

## Testing

iPhone 13, iOS 26.5.2, Swiftfin player, direct play and transcode:

- Movie and Live TV / IPTV playback
- Rotation to landscape and back, mid-playback
- Background and return mid-playback (the #2149 scenario the delegate was restored for)
- Seeking and scrubbing, which exercise the new `updateUIViewController` path repeatedly

Not tested: iPad, tvOS (unaffected — the delegate path is `UIDevice.isPhone` only), PiP (Native player only).

---

*Disclosure: this change was developed with the assistance of an AI coding tool. All diagnosis and testing was done on a physical device.*
