### PR TITLE
Hide Empty `Runtime`s

### DIFF
--- a/Shared/Extensions/JellyfinAPI/BaseItemDto/BaseItemDto.swift
+++ b/Shared/Extensions/JellyfinAPI/BaseItemDto/BaseItemDto.swift
@@ -260,7 +260,7 @@ extension BaseItemDto {
     }
 
     var runtime: Duration? {
-        guard let ticks = runTimeTicks else { return nil }
+        guard let ticks = runTimeTicks, ticks > 0 else { return nil }
         return Duration.ticks(ticks)
     }
 


### PR DESCRIPTION
### Summary

Resolves: https://github.com/jellyfin/Swiftfin/issues/2159

If the `runtimeTicks` on the series is 0 we shouldn't use it.