### PR TITLE
Filter by Language & `officialRatings`

### DIFF
--- a/Shared/Objects/ItemFilter/ItemFilterCollection.swift
+++ b/Shared/Objects/ItemFilter/ItemFilterCollection.swift
@@ -11,12 +11,15 @@ import JellyfinAPI
 /// A structure representing a collection of item filters
 struct ItemFilterCollection: Hashable, Storable {
 
+    var audioLanguages: [ItemLanguage] = []
     var categories: [ChannelCategory] = []
     var genres: [ItemGenre] = []
     var itemTypes: [BaseItemKind] = []
     var letter: [ItemLetter] = []
+    var officialRatings: [ItemOfficialRating] = []
     var sortBy: [ItemSortBy] = [ItemSortBy.sortName]
     var sortOrder: [ItemSortOrder] = [ItemSortOrder.ascending]
+    var subtitleLanguages: [ItemLanguage] = []
     var tags: [ItemTag] = []
     var traits: [ItemTrait] = []
     var years: [ItemYear] = []
@@ -51,10 +54,13 @@ struct ItemFilterCollection: Hashable, Storable {
     }
 
     var hasQueryableFilters: Bool {
-        categories.isNotEmpty ||
+        audioLanguages.isNotEmpty ||
+            categories.isNotEmpty ||
             genres.isNotEmpty ||
             itemTypes.isNotEmpty ||
             letter.isNotEmpty ||
+            officialRatings.isNotEmpty ||
+            subtitleLanguages.isNotEmpty ||
             tags.isNotEmpty ||
             traits.isNotEmpty ||
             years.isNotEmpty ||

--- a/Shared/Objects/ItemFilter/ItemFilterType.swift
+++ b/Shared/Objects/ItemFilter/ItemFilterType.swift
@@ -17,9 +17,12 @@ enum ItemFilterType: String, CaseIterable, Displayable, Identifiable, Storable, 
         selectorType: SelectorType
     )
 
+    case audioLanguage
     case genres
     case letter
+    case officialRatings
     case sortBy
+    case subtitleLanguage
     case tags
     case traits
     case years
@@ -27,14 +30,20 @@ enum ItemFilterType: String, CaseIterable, Displayable, Identifiable, Storable, 
 
     var displayTitle: String {
         switch self {
+        case .audioLanguage:
+            L10n.audio
         case .category:
             L10n.category
         case .genres:
             L10n.genres
         case .letter:
             L10n.letter
+        case .officialRatings:
+            L10n.rating
         case .sortBy:
             L10n.sort
+        case .subtitleLanguage:
+            L10n.subtitles
         case .tags:
             L10n.tags
         case .traits:
@@ -47,6 +56,13 @@ enum ItemFilterType: String, CaseIterable, Displayable, Identifiable, Storable, 
     @ArrayBuilder<Group>
     var group: [Group] {
         switch self {
+        case .audioLanguage:
+            (
+                displayTitle: displayTitle,
+                keyPath: \ItemFilterCollection.audioLanguages.asAnyItemFilter,
+                setter: { $1.currentFilters.audioLanguages = $0.map(ItemLanguage.init) },
+                selectorType: .multi
+            )
         case .category:
             (
                 displayTitle: displayTitle,
@@ -68,6 +84,13 @@ enum ItemFilterType: String, CaseIterable, Displayable, Identifiable, Storable, 
                 setter: { $1.currentFilters.letter = $0.map(ItemLetter.init) },
                 selectorType: .single
             )
+        case .officialRatings:
+            (
+                displayTitle: displayTitle,
+                keyPath: \ItemFilterCollection.officialRatings.asAnyItemFilter,
+                setter: { $1.currentFilters.officialRatings = $0.map(ItemOfficialRating.init) },
+                selectorType: .multi
+            )
         case .sortBy:
             (
                 displayTitle: L10n.order,
@@ -80,6 +103,13 @@ enum ItemFilterType: String, CaseIterable, Displayable, Identifiable, Storable, 
                 keyPath: \ItemFilterCollection.sortBy.asAnyItemFilter,
                 setter: { $1.currentFilters.sortBy = $0.map(ItemSortBy.init) },
                 selectorType: .single
+            )
+        case .subtitleLanguage:
+            (
+                displayTitle: displayTitle,
+                keyPath: \ItemFilterCollection.subtitleLanguages.asAnyItemFilter,
+                setter: { $1.currentFilters.subtitleLanguages = $0.map(ItemLanguage.init) },
+                selectorType: .multi
             )
         case .tags:
             (
@@ -111,14 +141,20 @@ enum ItemFilterType: String, CaseIterable, Displayable, Identifiable, Storable, 
 
     var systemImage: String {
         switch self {
+        case .audioLanguage:
+            "speaker.wave.2"
         case .category:
             "tv"
         case .genres:
             "theatermasks"
         case .letter:
             "character.textbox"
+        case .officialRatings:
+            "person.badge.shield.checkmark"
         case .sortBy:
             "line.3.horizontal.decrease"
+        case .subtitleLanguage:
+            "captions.bubble"
         case .tags:
             "tag"
         case .traits:

--- a/Shared/Objects/ItemFilter/ItemLanguage.swift
+++ b/Shared/Objects/ItemFilter/ItemLanguage.swift
@@ -1,0 +1,33 @@
+//
+// Swiftfin is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, you can obtain one at https://mozilla.org/MPL/2.0/.
+//
+// Copyright (c) 2026 Jellyfin & Jellyfin Contributors
+//
+
+import Foundation
+import JellyfinAPI
+
+struct ItemLanguage: Codable, Hashable, ItemFilter {
+
+    let displayTitle: String
+    let value: String
+
+    init(displayTitle: String, value: String) {
+        self.displayTitle = displayTitle
+        self.value = value
+    }
+
+    init(from anyFilter: AnyItemFilter) {
+        self.displayTitle = anyFilter.displayTitle
+        self.value = anyFilter.value
+    }
+
+    init?(_ nameValuePair: NameValuePair) {
+        guard let name = nameValuePair.name, let value = nameValuePair.value else { return nil }
+
+        self.displayTitle = name
+        self.value = value
+    }
+}

--- a/Shared/Objects/ItemFilter/ItemOfficialRating.swift
+++ b/Shared/Objects/ItemFilter/ItemOfficialRating.swift
@@ -8,16 +8,12 @@
 
 import Foundation
 
-struct ItemYear: Codable, ExpressibleByStringLiteral, Hashable, ItemFilter {
+struct ItemOfficialRating: Codable, ExpressibleByStringLiteral, Hashable, ItemFilter {
 
     let value: String
 
     var displayTitle: String {
         value
-    }
-
-    var intValue: Int {
-        Int(value)!
     }
 
     init(stringLiteral value: String) {

--- a/Shared/Objects/ItemFilter/ItemYear.swift
+++ b/Shared/Objects/ItemFilter/ItemYear.swift
@@ -8,7 +8,7 @@
 
 import Foundation
 
-struct ItemYear: Codable, ExpressibleByStringLiteral, Hashable, ItemFilter {
+struct ItemYear: Codable, ExpressibleByIntegerLiteral, Hashable, ItemFilter {
 
     let value: String
 
@@ -20,8 +20,8 @@ struct ItemYear: Codable, ExpressibleByStringLiteral, Hashable, ItemFilter {
         Int(value)!
     }
 
-    init(stringLiteral value: String) {
-        self.value = value
+    init(integerLiteral value: IntegerLiteralType) {
+        self.value = "\(value)"
     }
 
     init(from anyFilter: AnyItemFilter) {

--- a/Shared/Objects/Libraries/ItemLibrary.swift
+++ b/Shared/Objects/Libraries/ItemLibrary.swift
@@ -207,10 +207,13 @@ struct ItemLibrary: PagingLibrary, SearchablePagingLibrary, WithRandomElementLib
         isLetterFilterIncluded: Bool = true
     ) -> Paths.GetItemsParameters {
         var parameters = parameters
+        parameters.audioLanguages = filters.audioLanguages.map(\.value)
         parameters.filters = filters.traits
         parameters.genres = filters.genres.map(\.value)
+        parameters.officialRatings = filters.officialRatings.map(\.value)
         parameters.sortBy = filters.sortBy
         parameters.sortOrder = filters.sortOrder
+        parameters.subtitleLanguages = filters.subtitleLanguages.map(\.value)
         parameters.tags = filters.tags.map(\.value)
         parameters.years = filters.years.compactMap { Int($0.value) }
 

--- a/Shared/ViewModels/FilterViewModel.swift
+++ b/Shared/ViewModels/FilterViewModel.swift
@@ -69,15 +69,21 @@ final class FilterViewModel: ViewModel {
         }
 
         switch type {
+        case .audioLanguage:
+            currentFilters.audioLanguages = ItemFilterCollection.default.audioLanguages
         case .category:
             currentFilters.categories = ItemFilterCollection.default.categories
         case .genres:
             currentFilters.genres = ItemFilterCollection.default.genres
         case .letter:
             currentFilters.letter = ItemFilterCollection.default.letter
+        case .officialRatings:
+            currentFilters.officialRatings = ItemFilterCollection.default.officialRatings
         case .sortBy:
             currentFilters.sortBy = ItemFilterCollection.default.sortBy
             currentFilters.sortOrder = ItemFilterCollection.default.sortOrder
+        case .subtitleLanguage:
+            currentFilters.subtitleLanguages = ItemFilterCollection.default.subtitleLanguages
         case .tags:
             currentFilters.tags = ItemFilterCollection.default.tags
         case .traits:
@@ -90,27 +96,78 @@ final class FilterViewModel: ViewModel {
     @Function(\Action.Cases.getQueryFilters)
     private func _getQueryFilters() async throws {
 
+        try await getFilters()
+        try await getFiltersLegacy()
+        try await getYears()
+    }
+
+    private func getFiltersLegacy() async throws {
+
         let parameters = try Paths.GetQueryFiltersLegacyParameters(
             userID: authenticatedUser.id,
-            parentID: parent?.id
+            parentID: parent?.id,
+            includeItemTypes: parent?.supportedItemTypes ?? BaseItemKind.supportedCases
         )
 
         let request = Paths.getQueryFiltersLegacy(parameters: parameters)
         let response = try await send(request)
 
+        allFilters.officialRatings = (response.value.officialRatings ?? [])
+            .map(ItemOfficialRating.init)
+    }
+
+    private func getFilters() async throws {
+
+        let parameters = try Paths.GetQueryFiltersParameters(
+            userID: authenticatedUser.id,
+            parentID: parent?.id,
+            includeItemTypes: parent?.supportedItemTypes ?? BaseItemKind.supportedCases,
+            isRecursive: true
+        )
+
+        let request = Paths.getQueryFilters(parameters: parameters)
+        let response = try await send(request)
+
+        let audioLanguages: [ItemLanguage] = (response.value.audioLanguages ?? [])
+            .compactMap(ItemLanguage.init)
+            .sorted(using: \.displayTitle)
+
         let genres: [ItemGenre] = (response.value.genres ?? [])
+            .compactMap(\.name)
             .map(ItemGenre.init)
+
+        let subtitleLanguages: [ItemLanguage] = (response.value.subtitleLanguages ?? [])
+            .compactMap(ItemLanguage.init)
+            .sorted(using: \.displayTitle)
 
         let tags = (response.value.tags ?? [])
             .map(ItemTag.init)
 
-        // Manually sort so that most recent years are "first"
-        let years = (response.value.years ?? [])
-            .sorted(by: >)
+        allFilters.audioLanguages = audioLanguages
+        allFilters.genres = genres
+        allFilters.subtitleLanguages = subtitleLanguages
+        allFilters.tags = tags
+    }
+
+    private func getYears() async throws {
+
+        let parameters = try Paths.GetYearsParameters(
+            sortOrder: [SortOrder.descending],
+            parentID: parent?.id,
+            sortBy: [ItemSortBy.sortName],
+            enableUserData: false,
+            userID: authenticatedUser.id,
+            isRecursive: true,
+            enableImages: false
+        )
+
+        let request = Paths.getYears(parameters: parameters)
+        let response = try await send(request)
+
+        let years = (response.value.items ?? [])
+            .compactMap(\.name)
             .map(ItemYear.init)
 
-        allFilters.genres = genres
-        allFilters.tags = tags
         allFilters.years = years
     }
 }

--- a/Shared/ViewModels/FilterViewModel.swift
+++ b/Shared/ViewModels/FilterViewModel.swift
@@ -98,7 +98,6 @@ final class FilterViewModel: ViewModel {
 
         try await getFilters()
         try await getFiltersLegacy()
-        try await getYears()
     }
 
     private func getFiltersLegacy() async throws {
@@ -112,8 +111,16 @@ final class FilterViewModel: ViewModel {
         let request = Paths.getQueryFiltersLegacy(parameters: parameters)
         let response = try await send(request)
 
-        allFilters.officialRatings = (response.value.officialRatings ?? [])
+        let officialRatings = (response.value.officialRatings ?? [])
             .map(ItemOfficialRating.init)
+
+        // Manually sort so that most recent years are "first"
+        let years = (response.value.years ?? [])
+            .sorted(by: >)
+            .map(ItemYear.init)
+
+        allFilters.officialRatings = officialRatings
+        allFilters.years = years
     }
 
     private func getFilters() async throws {
@@ -147,27 +154,5 @@ final class FilterViewModel: ViewModel {
         allFilters.genres = genres
         allFilters.subtitleLanguages = subtitleLanguages
         allFilters.tags = tags
-    }
-
-    private func getYears() async throws {
-
-        let parameters = try Paths.GetYearsParameters(
-            sortOrder: [SortOrder.descending],
-            parentID: parent?.id,
-            sortBy: [ItemSortBy.sortName],
-            enableUserData: false,
-            userID: authenticatedUser.id,
-            isRecursive: true,
-            enableImages: false
-        )
-
-        let request = Paths.getYears(parameters: parameters)
-        let response = try await send(request)
-
-        let years = (response.value.items ?? [])
-            .compactMap(\.name)
-            .map(ItemYear.init)
-
-        allFilters.years = years
     }
 }


### PR DESCRIPTION
### Summary

Resolves: https://github.com/jellyfin/Swiftfin/issues/2083

Jellyfin 12.0 adds language filters on subtitles and audio so this adds those filters. Since those two filters exist in `getQueryFilters` but not in `getQueryFiltersLegacy`, I've moved over to fully use `getQueryFilters` but only use `getQueryFiltersLegacy` for `years` & `officialRatings` since those exist in legacy but not in `Filters2`. There are ways to get both of these via `getYears` & `getParentalRatings` that we could use if we want to fully drop `getQueryFiltersLegacy` but I've kept it since it's 1 call instead of 2 for these.

Mentioned above, but I also added `officialRatings` while I was there which is just filtering on parental ratings. I am using the `[officialRatings]` where you select the multi-select ratings that you want included. Alternatively, we could use the `minOfficialRating` / `maxOfficialRating` if we'd rather this be like "Max Rating" as a single select instead. I felt the multi-select made more sense and would be a single config instead of a `min` and `max` filter item that might be requested.

`officialRatings` works in 10.11 as well as 12.0 but the subtitle/audio language filtering needs 12.0 to test.

### Known Issues

Only items where `isRecursiveCollection` == `true` or the items contain tracks will work for filtering. So, `boxset` and `tvShow` where the the grouping is `series` doesn't filter down but `episode` & `season` grouping works. Making `series` recursive gives us some headaches for the tvOS `TV Shows` tab so I've left that change out for now to let this PR just focus on the fliters and any recursion changes ought be to handled more cautiously since that always seems to break *something* when we change it.

### Video

https://github.com/user-attachments/assets/4747955f-a20a-4e32-bdc1-a7e84d4c9500
