### PR TITLE
Cap tvOS Home Logo Width 

### DIFF
--- a/Swiftfin tvOS/Objects/CinematicSelectionContentGroup.swift
+++ b/Swiftfin tvOS/Objects/CinematicSelectionContentGroup.swift
@@ -48,24 +48,26 @@ struct CinematicSelectionContentGroup: ContentGroup {
             frameForParentView[.scrollView, default: .zero].frame
         }
 
-        private func itemSelectorImageSource(for item: BaseItemDto) -> ImageSource {
-            let maxWidth = max(parentFrame.width * CinematicSelectionLayout.logoMaxWidthPercentage, 1)
+        private var logoMaxWidth: CGFloat {
+            max(parentFrame.width * CinematicSelectionLayout.logoMaxWidthPercentage, 1)
+        }
 
+        private func itemSelectorImageSource(for item: BaseItemDto) -> ImageSource {
             if item.type == .episode {
-                return item.imageSource(
+                item.imageSource(
                     itemID: item.seriesID,
                     .logo,
                     tag: item.parentLogoImageTag,
                     environment: ImageSourceOptions(
-                        maxWidth: maxWidth,
+                        maxWidth: logoMaxWidth,
                         maxHeight: CinematicSelectionLayout.logoMaxHeight
                     )
                 )
             } else {
-                return item.imageSource(
+                item.imageSource(
                     .logo,
                     environment: ImageSourceOptions(
-                        maxWidth: maxWidth,
+                        maxWidth: logoMaxWidth,
                         maxHeight: CinematicSelectionLayout.logoMaxHeight
                     )
                 )
@@ -92,7 +94,8 @@ struct CinematicSelectionContentGroup: ContentGroup {
                     }
                     .edgePadding(.leading)
                     .aspectRatio(contentMode: .fit)
-                    .frame(height: CinematicSelectionLayout.logoMaxHeight, alignment: .bottomLeading)
+                    .frame(height: CinematicSelectionLayout.logoMaxHeight)
+                    .frame(maxWidth: logoMaxWidth, alignment: .bottomLeading)
             }
             .preference(
                 key: ContentGroupCustomizationKey.self,

--- a/Swiftfin tvOS/Objects/CinematicSelectionContentGroup.swift
+++ b/Swiftfin tvOS/Objects/CinematicSelectionContentGroup.swift
@@ -90,8 +90,8 @@ struct CinematicSelectionContentGroup: ContentGroup {
                     }
                     .edgePadding(.leading)
                     .aspectRatio(contentMode: .fit)
-                    .frame(height: CinematicSelectionLayout.logoMaxHeight)
-                    .frame(maxWidth: CinematicSelectionLayout.logoMaxWidth, alignment: .bottomLeading)
+                    .frame(height: CinematicSelectionLayout.logoMaxHeight, alignment: .bottomLeading)
+                    .frame(maxWidth: CinematicSelectionLayout.logoMaxWidth)
             }
             .preference(
                 key: ContentGroupCustomizationKey.self,

--- a/Swiftfin tvOS/Objects/CinematicSelectionContentGroup.swift
+++ b/Swiftfin tvOS/Objects/CinematicSelectionContentGroup.swift
@@ -48,10 +48,6 @@ struct CinematicSelectionContentGroup: ContentGroup {
             frameForParentView[.scrollView, default: .zero].frame
         }
 
-        private var logoMaxWidth: CGFloat {
-            max(parentFrame.width * CinematicSelectionLayout.logoMaxWidthPercentage, 1)
-        }
-
         private func itemSelectorImageSource(for item: BaseItemDto) -> ImageSource {
             if item.type == .episode {
                 item.imageSource(
@@ -59,7 +55,7 @@ struct CinematicSelectionContentGroup: ContentGroup {
                     .logo,
                     tag: item.parentLogoImageTag,
                     environment: ImageSourceOptions(
-                        maxWidth: logoMaxWidth,
+                        maxWidth: CinematicSelectionLayout.logoMaxWidth,
                         maxHeight: CinematicSelectionLayout.logoMaxHeight
                     )
                 )
@@ -67,7 +63,7 @@ struct CinematicSelectionContentGroup: ContentGroup {
                 item.imageSource(
                     .logo,
                     environment: ImageSourceOptions(
-                        maxWidth: logoMaxWidth,
+                        maxWidth: CinematicSelectionLayout.logoMaxWidth,
                         maxHeight: CinematicSelectionLayout.logoMaxHeight
                     )
                 )
@@ -95,7 +91,7 @@ struct CinematicSelectionContentGroup: ContentGroup {
                     .edgePadding(.leading)
                     .aspectRatio(contentMode: .fit)
                     .frame(height: CinematicSelectionLayout.logoMaxHeight)
-                    .frame(maxWidth: logoMaxWidth, alignment: .bottomLeading)
+                    .frame(maxWidth: CinematicSelectionLayout.logoMaxWidth, alignment: .bottomLeading)
             }
             .preference(
                 key: ContentGroupCustomizationKey.self,
@@ -180,5 +176,5 @@ final class CinematicSelectionContentGroupViewModel: ViewModel, WithRefresh {
 private enum CinematicSelectionLayout {
 
     static let logoMaxHeight: CGFloat = 100
-    static let logoMaxWidthPercentage: CGFloat = 0.4
+    static let logoMaxWidth: CGFloat = 450
 }


### PR DESCRIPTION
### Summary

Resolves: https://github.com/jellyfin/Swiftfin/issues/2177

Our frame for logos was always infinite max width. This mean, even though we had a 40%-of-screen width cap, it would fill as much width to retain the same ratio with the 100 height. This meant short logos would always use their full relative width to 100% and ignore the 40% limit.

To fix, I just moved the 40% math to its own var where it could be shared with the frame lower down.

### Before

<img width="1920" height="1080" alt="Simulator Screenshot - Apple TV 4K (3rd generation) (at 1080p) - 2026-08-08 at 18 09 09" src="https://github.com/user-attachments/assets/a0282438-f9e0-4025-a683-7714212bf7a9" />

### After

<img width="1920" height="1080" alt="Simulator Screenshot - Apple TV 4K (3rd generation) (at 1080p) - 2026-08-08 at 18 16 46" src="https://github.com/user-attachments/assets/e0fcbc73-da01-4768-8782-bf43f3b9510b" />