### PR TITLE
Use Accent Color for Landscape Posters Progress

### DIFF
--- a/Shared/Components/PosterIndicators/ProgressIndicator.swift
+++ b/Shared/Components/PosterIndicators/ProgressIndicator.swift
@@ -37,7 +37,7 @@ struct ProgressIndicator: View {
 
             ProgressView(value: progress)
                 .progressViewStyle(.playback)
-                .foregroundStyle(.white)
+                .foregroundStyle(accentColor)
                 .frame(height: 6)
         }
         .padding(.bottom, 5)


### PR DESCRIPTION
Making the Landscape poster align with Portrait and Square by re-coloring the progress indicator with the accent color.

I've also noticed the Landscape progress indicator is styled quite differently. Should it look flat and square like it does on the Portrait poster type? If so I can tackle that in this PR as well.

### Screenshots
| Before | After |
|--------|--------|
| <img alt="IMG_9042" src="https://github.com/user-attachments/assets/6a71e5a8-44b5-447b-96d3-e0816c61aa30" /> | <img alt="IMG_9041" src="https://github.com/user-attachments/assets/354eb742-8cd6-424a-9b37-65f450d1f55d" /> | 