### PR TITLE
Show runtime for special features

### DIFF
--- a/Shared/Extensions/JellyfinAPI/BaseItemDto/BaseItemDto+Poster.swift
+++ b/Shared/Extensions/JellyfinAPI/BaseItemDto/BaseItemDto+Poster.swift
@@ -387,6 +387,12 @@ private struct BaseItemDtoPosterLabel: View {
             episodeLabel
         case .season:
             label(title: item.parentTitle ?? item.displayTitle, subtitle: item.displayTitle)
+        case .video where item.extraType != nil:
+            label(
+                title: item.displayTitle,
+                subtitle: item.subtitle,
+                runtime: item.runtime
+            )
         default:
             label(title: item.displayTitle, subtitle: item.subtitle)
         }
@@ -396,7 +402,7 @@ private struct BaseItemDtoPosterLabel: View {
     //       - verify layout
 
     @ViewBuilder
-    private func label(title: String, subtitle: String?) -> some View {
+    private func label(title: String, subtitle: String?, runtime: Duration? = nil) -> some View {
         VStack(alignment: .leading, spacing: 0) {
             Text(title)
                 .font(.footnote)
@@ -404,11 +410,23 @@ private struct BaseItemDtoPosterLabel: View {
                 .accessibilityLabel(item.displayTitle)
                 .lineLimit(1, reservesSpace: true)
 
-            Text(subtitle ?? " ")
-                .font(.caption)
-                .fontWeight(.medium)
-                .foregroundStyle(.secondary)
-                .lineLimit(1, reservesSpace: true)
+            Group {
+                if let subtitle {
+                    Text(subtitle)
+                }
+
+                if let runtime {
+                    Text(runtime, format: .runtime)
+                }
+
+                if subtitle == nil, runtime == nil {
+                    Text(verbatim: " ")
+                }
+            }
+            .font(.caption)
+            .fontWeight(.medium)
+            .foregroundStyle(.secondary)
+            .lineLimit(1, reservesSpace: true)
         }
     }
 

--- a/Shared/Extensions/JellyfinAPI/BaseItemDto/BaseItemDto+Poster.swift
+++ b/Shared/Extensions/JellyfinAPI/BaseItemDto/BaseItemDto+Poster.swift
@@ -388,11 +388,7 @@ private struct BaseItemDtoPosterLabel: View {
         case .season:
             label(title: item.parentTitle ?? item.displayTitle, subtitle: item.displayTitle)
         case .video where item.extraType != nil:
-            label(
-                title: item.displayTitle,
-                subtitle: item.subtitle,
-                runtime: item.runtime
-            )
+            extrasLabel
         default:
             label(title: item.displayTitle, subtitle: item.subtitle)
         }
@@ -402,7 +398,7 @@ private struct BaseItemDtoPosterLabel: View {
     //       - verify layout
 
     @ViewBuilder
-    private func label(title: String, subtitle: String?, runtime: Duration? = nil) -> some View {
+    private func label(title: String, subtitle: String?) -> some View {
         VStack(alignment: .leading, spacing: 0) {
             Text(title)
                 .font(.footnote)
@@ -410,23 +406,11 @@ private struct BaseItemDtoPosterLabel: View {
                 .accessibilityLabel(item.displayTitle)
                 .lineLimit(1, reservesSpace: true)
 
-            Group {
-                if let subtitle {
-                    Text(subtitle)
-                }
-
-                if let runtime {
-                    Text(runtime, format: .runtime)
-                }
-
-                if subtitle == nil, runtime == nil {
-                    Text(verbatim: " ")
-                }
-            }
-            .font(.caption)
-            .fontWeight(.medium)
-            .foregroundStyle(.secondary)
-            .lineLimit(1, reservesSpace: true)
+            Text(subtitle ?? " ")
+                .font(.caption)
+                .fontWeight(.medium)
+                .foregroundStyle(.secondary)
+                .lineLimit(1, reservesSpace: true)
         }
     }
 
@@ -491,6 +475,33 @@ private struct BaseItemDtoPosterLabel: View {
             }
             .font(.footnote)
             .foregroundStyle(.secondary)
+        }
+    }
+
+    @ViewBuilder
+    private var extrasLabel: some View {
+        VStack(alignment: .leading) {
+            Text(item.displayTitle)
+                .font(.footnote)
+                .foregroundStyle(.primary)
+                .accessibilityLabel(item.displayTitle)
+                .lineLimit(1, reservesSpace: true)
+
+            if let extraType = item.extraType, extraType != .unknown {
+                Text(extraType.displayTitle)
+                    .font(.caption)
+                    .fontWeight(.medium)
+                    .foregroundStyle(.secondary)
+                    .lineLimit(1, reservesSpace: true)
+            }
+
+            if let runtime = item.runtime {
+                Text(runtime, format: .runtime)
+                    .font(.caption)
+                    .fontWeight(.medium)
+                    .foregroundStyle(.secondary)
+                    .lineLimit(1, reservesSpace: true)
+            }
         }
     }
 }


### PR DESCRIPTION
I've added an `extrasLabel` for `.video` items with a non-nil `extraType`. Runtime is now shown in that label, and `.unknown` is omitted from it. Tested the implementation in the iOS Simulator and verified that the tvOS build succeeds.

Screenshots: [before](https://github.com/user-attachments/assets/537e9b5b-c115-4891-9266-d3df0e5906d1) & [after](https://github.com/user-attachments/assets/8571d9a8-9857-4590-8dc6-9ab142c60582) (+ [web](https://github.com/user-attachments/assets/f40d7d19-1cba-4d3f-919b-0fb1b5e5653a) for reference)

This is my first contribution. The [development guide](https://jellyfin.org/docs/general/contributing/development#contributorsmd) suggests adding myself to the `CONTRIBUTORS.md` file, which I could not locate.

Fixes #1691

