### PR TITLE
Program Dates Fix

### DIFF
--- a/Shared/Extensions/JellyfinAPI/BaseItemDto/BaseItemDto+Poster.swift
+++ b/Shared/Extensions/JellyfinAPI/BaseItemDto/BaseItemDto+Poster.swift
@@ -453,28 +453,36 @@ private struct BaseItemDtoPosterLabel: View {
                 .foregroundStyle(.primary)
                 .lineLimit(1, reservesSpace: true)
 
-            HStack(spacing: 2) {
+            Group {
                 if let startDate = item.startDate {
-                    if !Calendar.current.isDateInToday(startDate) {
-                        Text(startDate, format: .dateTime.weekday(.abbreviated))
-                            .padding(.trailing, 2)
+                    ViewThatFits {
+                        SeparatorHStack {
+                            Text(String.hyphen)
+                        } content: {
+                            if !Calendar.current.isDateInToday(startDate) {
+                                Text(startDate, format: .dateTime.weekday(.abbreviated).hour().minute())
+                            } else {
+                                Text(startDate, style: .time)
+                            }
+
+                            if let endDate = item.endDate {
+                                Text(endDate, style: .time)
+                            }
+                        }
+
+                        if !Calendar.current.isDateInToday(startDate) {
+                            Text(startDate, format: .dateTime.weekday(.abbreviated).hour().minute())
+                        } else {
+                            Text(startDate, style: .time)
+                        }
                     }
-
-                    Text(startDate, style: .time)
                 } else {
-                    Text(String.emptyDash)
-                }
-
-                Text(String.hyphen)
-
-                if let endDate = item.endDate {
-                    Text(endDate, style: .time)
-                } else {
-                    Text(String.emptyDash)
+                    Text(String.emptyRuntime)
                 }
             }
             .font(.footnote)
             .foregroundStyle(.secondary)
+            .lineLimit(1, reservesSpace: true)
         }
     }
 


### PR DESCRIPTION
### Summary

Programs dates weren't limited to a single line. Program dates, when restricted to 1 line, would cutoff too easily on tvOS.

Uses `ViewThatFits` to go use purely the start date if the whole thing does not fit. Utilizes the existing `SeparatorHStack` instead of basically recreating it from scratch.

Logic is:

#### Same Day:

1. If no `StartTime`, use `-`
2. If `StartTime`, try to use `StartTime - EndTime`
3. If `StartTime - EndTime` doesn't fit, use `StartTime`

#### Different Day:

1. If no `StartTime`, use `-`
2. If `StartTime`, try to use `StartDOW StartTime - EndTime`
3. If `StartDOW StartTime - EndTime` doesn't fit, use `StartDOW StartTime`

### Before

<img width="822" height="424" alt="Screenshot 2026-08-12 at 11 05 58" src="https://github.com/user-attachments/assets/7359464e-9210-4c07-af1c-4ecd7b837e25" />

### After

<img width="813" height="376" alt="Screenshot 2026-08-12 at 11 03 31" src="https://github.com/user-attachments/assets/8b40a58a-d234-41e2-972b-24bea6c5b3a3" />