### PR TITLE
Align special feature labels

### DIFF
--- a/Shared/Components/BulletedList.swift
+++ b/Shared/Components/BulletedList.swift
@@ -15,8 +15,7 @@ func BulletedList(
     MarkedList(spacing: spacing) { _ in
         ZStack {
             // Capture local font line height
-            // swiftlint:disable:next hard_coded_display_string
-            Text(" ")
+            Text(String.space)
                 .hidden()
 
             Circle()

--- a/Shared/Components/PosterButton.swift
+++ b/Shared/Components/PosterButton.swift
@@ -86,6 +86,7 @@ struct PosterButton<Item: Poster>: View {
                 .trackingSize($posterSize)
             #endif
         }
+        .environment(\.posterDisplayType, displayType)
         .foregroundStyle(.primary, .secondary)
         .buttonStyle(.borderless)
         .buttonBorderShape(.roundedRectangle)

--- a/Shared/Extensions/EnvironmentValues.swift
+++ b/Shared/Extensions/EnvironmentValues.swift
@@ -38,6 +38,9 @@ extension EnvironmentValues {
     var playbackSpeed: Binding<Double> = .constant(1)
 
     @Entry
+    var posterDisplayType: PosterDisplayType = .portrait
+
+    @Entry
     var safeAreaInsets: EdgeInsets = UIApplication.shared.keyWindow?.safeAreaInsets.asEdgeInsets ?? .zero
 
     @Entry

--- a/Shared/Extensions/JellyfinAPI/BaseItemDto/BaseItemDto+Poster.swift
+++ b/Shared/Extensions/JellyfinAPI/BaseItemDto/BaseItemDto+Poster.swift
@@ -510,6 +510,14 @@ private struct BaseItemDtoPosterLabel: View {
                     .foregroundStyle(.secondary)
                     .lineLimit(1, reservesSpace: true)
             }
+
+            if item.extraType == .unknown {
+                Text(verbatim: " ")
+                    .font(.caption)
+                    .fontWeight(.medium)
+                    .lineLimit(1, reservesSpace: true)
+                    .accessibilityHidden(true)
+            }
         }
     }
 }

--- a/Shared/Extensions/JellyfinAPI/BaseItemDto/BaseItemDto+Poster.swift
+++ b/Shared/Extensions/JellyfinAPI/BaseItemDto/BaseItemDto+Poster.swift
@@ -381,79 +381,26 @@ private struct BaseItemDtoPosterLabel: View {
 
     var body: some View {
         switch item.type {
-        case .program:
-            programLabel
         case .episode:
-            episodeLabel
-        case .season:
-            label(title: item.parentTitle ?? item.displayTitle, subtitle: item.displayTitle)
-        case .video where item.extraType != nil:
-            extrasLabel
-        default:
-            label(title: item.displayTitle, subtitle: item.subtitle)
-        }
-    }
-
-    // TODO: allow title to expand to 2 lines if subtitle is nil?
-    //       - verify layout
-
-    @ViewBuilder
-    private func label(title: String, subtitle: String?) -> some View {
-        VStack(alignment: .leading, spacing: 0) {
-            Text(title)
-                .font(.footnote)
-                .foregroundStyle(.primary)
-                .accessibilityLabel(item.displayTitle)
-                .lineLimit(1, reservesSpace: true)
-
-            Text(subtitle ?? " ")
-                .font(.caption)
-                .fontWeight(.medium)
-                .foregroundStyle(.secondary)
-                .lineLimit(1, reservesSpace: true)
-        }
-    }
-
-    @ViewBuilder
-    private var episodeLabel: some View {
-        VStack(alignment: .leading, spacing: 0) {
-            if let seriesName = item.seriesName {
-                Text(seriesName)
-                    .font(.footnote)
-                    .fontWeight(.regular)
-                    .foregroundStyle(.primary)
-                    .lineLimit(1, reservesSpace: true)
-            }
-
-            DotHStack {
+            Label {
+                if let seriesName = item.seriesName {
+                    Text(seriesName)
+                }
                 if let indexLabel = item.seasonEpisodeLabel {
                     Text(indexLabel)
                 }
 
                 Text(item.displayTitle)
             }
-            .font(.caption)
-            .foregroundStyle(.secondary)
-            .lineLimit(1)
-        }
-    }
+        case .season:
+            Label {
+                Text(item.parentTitle ?? item.displayTitle)
+                Text(item.displayTitle)
+            }
+        case .program:
+            Label {
+                Text(item.displayTitle)
 
-    @ViewBuilder
-    private var programLabel: some View {
-        VStack(alignment: .leading) {
-            Text(item.channelName ?? .emptyDash)
-                .font(.footnote)
-                .fontWeight(.semibold)
-                .foregroundStyle(.primary)
-                .lineLimit(1, reservesSpace: true)
-
-            Text(item.displayTitle)
-                .font(.footnote)
-                .fontWeight(.regular)
-                .foregroundStyle(.primary)
-                .lineLimit(1, reservesSpace: true)
-
-            Group {
                 if let startDate = item.startDate {
                     ViewThatFits {
                         SeparatorHStack {
@@ -479,44 +426,77 @@ private struct BaseItemDtoPosterLabel: View {
                 } else {
                     Text(String.emptyRuntime)
                 }
+
+                if let channelName = item.channelName {
+                    Text(channelName)
+                }
             }
-            .font(.footnote)
-            .foregroundStyle(.secondary)
-            .lineLimit(1, reservesSpace: true)
+        case .video where item.extraType != nil:
+            Label {
+                Text(item.displayTitle)
+
+                if let extraType = item.extraType, extraType != .unknown {
+                    Text(extraType.displayTitle)
+                }
+
+                if let runtime = item.runtime {
+                    Text(runtime, format: .runtime)
+                }
+            }
+        default:
+            Label {
+                Text(item.displayTitle)
+
+                if let subtitle = item.subtitle {
+                    Text(subtitle)
+                }
+            }
         }
     }
 
-    @ViewBuilder
-    private var extrasLabel: some View {
-        VStack(alignment: .leading) {
-            Text(item.displayTitle)
+    private struct Label: View {
+
+        @Environment(\.posterDisplayType)
+        private var posterDisplayType
+
+        private let content: [AnyView]
+
+        private var details: [AnyView] {
+            let details = content.dropFirst()
+
+            return posterDisplayType == .landscape ? details.asArray : details.prefix(1).asArray
+        }
+
+        init(@ArrayBuilder<any View> content: () -> [any View]) {
+            self.content = content().map { AnyView($0) }
+        }
+
+        var body: some View {
+            AlternateLayoutView(alignment: .topLeading) {
+                VStack(spacing: 2) {
+                    Text(String.space)
+                    Text(String.space)
+                }
                 .font(.footnote)
-                .foregroundStyle(.primary)
-                .accessibilityLabel(item.displayTitle)
-                .lineLimit(1, reservesSpace: true)
+                .frame(maxWidth: .infinity)
+            } content: {
+                VStack(alignment: .leading, spacing: 2) {
+                    content.first
+                        .font(.footnote)
+                        .lineLimit(details.isEmpty ? 2 : 1, reservesSpace: true)
 
-            if let extraType = item.extraType, extraType != .unknown {
-                Text(extraType.displayTitle)
+                    DotHStack {
+                        ForEach(details.indices, id: \.self) { index in
+                            details[index]
+                                .layoutPriority(index == 0 ? 1 : 0)
+                        }
+                    }
                     .font(.caption)
                     .fontWeight(.medium)
                     .foregroundStyle(.secondary)
-                    .lineLimit(1, reservesSpace: true)
-            }
-
-            if let runtime = item.runtime {
-                Text(runtime, format: .runtime)
-                    .font(.caption)
-                    .fontWeight(.medium)
-                    .foregroundStyle(.secondary)
-                    .lineLimit(1, reservesSpace: true)
-            }
-
-            if item.extraType == .unknown {
-                Text(verbatim: " ")
-                    .font(.caption)
-                    .fontWeight(.medium)
-                    .lineLimit(1, reservesSpace: true)
-                    .accessibilityHidden(true)
+                    .lineLimit(1)
+                }
+                .frame(maxWidth: .infinity, alignment: .leading)
             }
         }
     }

--- a/Shared/Extensions/JellyfinAPI/BaseItemPerson/BaseItemPerson.swift
+++ b/Shared/Extensions/JellyfinAPI/BaseItemPerson/BaseItemPerson.swift
@@ -34,8 +34,8 @@ extension BaseItemPerson {
         let split = role.split(separator: "/")
         guard split.count > 1 else { return role }
 
-        guard let firstRole = split.first?.trimmingCharacters(in: CharacterSet(charactersIn: " ")),
-              let lastRole = split.last?.trimmingCharacters(in: CharacterSet(charactersIn: " ")) else { return role }
+        guard let firstRole = split.first?.trimmingCharacters(in: CharacterSet(charactersIn: .space)),
+              let lastRole = split.last?.trimmingCharacters(in: CharacterSet(charactersIn: .space)) else { return role }
 
         var final = firstRole
 

--- a/Shared/Extensions/JellyfinAPI/GeneralCommandType.swift
+++ b/Shared/Extensions/JellyfinAPI/GeneralCommandType.swift
@@ -15,7 +15,7 @@ extension GeneralCommandType: Displayable, SystemImageable {
     var displayTitle: String {
         rawValue.reduce(into: .empty) { result, character in
             if character.isUppercase, let last = result.last, !last.isUppercase {
-                result.append(" ")
+                result.append(.space)
             }
             result.append(character)
         }

--- a/Shared/Extensions/String.swift
+++ b/Shared/Extensions/String.swift
@@ -136,16 +136,19 @@ extension String {
     }
 
     var initials: String {
-        split(separator: " ")
+        split(separator: Self.space)
             .compactMap(\.first)
-            .reduce("", +)
+            .reduce(Self.empty, +)
     }
 
+    /// --
     static let emptyDash = "--"
-
+    /// --:--
     static let emptyRuntime = "--:--"
-
+    /// ""
     static let empty = ""
+    /// " "
+    static let space = " "
 
     static let tab = "\u{0009}"
     /// —
@@ -159,6 +162,7 @@ extension String {
     /// x
     static let multiply = "\u{00D7}"
 
+    /// A x B
     func multiply(by value: String) -> String {
         "\(self) \(Self.multiply) \(value)"
     }


### PR DESCRIPTION
Follow-up to #2204.

Special features with a known `extraType` use three label rows, while items
with `.unknown` use only two, causing inconsistent card heights.

This keeps the runtime directly below the title when the extra type is unknown,
while reserving the final row to keep neighboring cards aligned.

Screenshots: [before](https://github.com/user-attachments/assets/3affd165-3407-41ea-97be-4fcd619d9f2e) & [after](https://github.com/user-attachments/assets/3498ee22-c98b-4212-aebf-3ad4425d838e)