### PR TITLE
Fix slow scrub getting stuck and unresponsive

### DIFF
--- a/Swiftfin/Views/VideoPlayer/Gestures/VideoPlayerContainerView+PanGesture.swift
+++ b/Swiftfin/Views/VideoPlayer/Gestures/VideoPlayerContainerView+PanGesture.swift
@@ -245,8 +245,8 @@ extension VideoPlayer.UIVideoPlayerContainerViewController {
             }
         ) { startState, handlingState, containerState in
             if handlingState.gestureState == .ended ||
-               handlingState.gestureState == .cancelled ||
-               handlingState.gestureState == .failed
+                handlingState.gestureState == .cancelled ||
+                handlingState.gestureState == .failed
             {
                 containerState.isScrubbing = false
 

--- a/Swiftfin/Views/VideoPlayer/Gestures/VideoPlayerContainerView+PanGesture.swift
+++ b/Swiftfin/Views/VideoPlayer/Gestures/VideoPlayerContainerView+PanGesture.swift
@@ -26,7 +26,7 @@ extension VideoPlayer.UIVideoPlayerContainerViewController {
             containerState.timer.stop()
         }
 
-        if state == .ended {
+        if state == .ended || state == .cancelled || state == .failed {
             containerState.timer.poke()
         }
 
@@ -90,7 +90,7 @@ extension VideoPlayer.UIVideoPlayerContainerViewController {
             )
         }
 
-        guard state != .ended else {
+        guard state != .ended, state != .cancelled, state != .failed else {
             containerState.panHandlingAction = nil
             return
         }
@@ -244,7 +244,10 @@ extension VideoPlayer.UIVideoPlayerContainerViewController {
                 containerState.scrubbedSeconds.value
             }
         ) { startState, handlingState, containerState in
-            if handlingState.gestureState == .ended {
+            if handlingState.gestureState == .ended ||
+               handlingState.gestureState == .cancelled ||
+               handlingState.gestureState == .failed
+            {
                 containerState.isScrubbing = false
 
                 if !startState.startedWithOverlay {


### PR DESCRIPTION
After doing a slow scrub (horizontal pan), the playback controls get stuck and the player becomes unresponsive. The scrub UI stays on screen and every tap is ignored until you tap the progress bar to recover.

**Issue:** fixes #2084

**Cause:** the pan gesture cleanup only handled the `.ended` state. When the pan gesture is cancelled (e.g. by `DirectionalPanGestureRecognizer` when the pan direction doesn't match, or by the system), `isScrubbing` stayed `true`, keeping the scrub UI visible and the controls hidden/unresponsive.

**Changes:** reset the overlay timer, clear `panHandlingAction`, and reset `isScrubbing` on `.cancelled` / `.failed` in addition to `.ended`.

**Testing:** built an unsigned development IPA through a GitHub Actions workflow on my fork (A13501350/Swiftfin, `.github/workflows/build-ipa.yml`), sideloaded it with AltStore, and verified on an iPhone 13 Pro Max against a real Jellyfin server — slow scrub no longer gets stuck and controls stay responsive.