### PR TITLE
Fix Search Overlap

### DIFF
--- a/Shared/Views/SearchView.swift
+++ b/Shared/Views/SearchView.swift
@@ -101,7 +101,7 @@ struct SearchView: View {
         )
         .environmentObject(focusCoordinator)
         #if os(tvOS)
-        .edgePadding(.top)
+            .edgePadding(.top)
         #else
             .navigationBarFilterDrawer(
                 viewModel: viewModel.filterViewModel,

--- a/Shared/Views/SearchView.swift
+++ b/Shared/Views/SearchView.swift
@@ -100,7 +100,9 @@ struct SearchView: View {
             prompt: L10n.search
         )
         .environmentObject(focusCoordinator)
-        #if os(iOS)
+        #if os(tvOS)
+        .edgePadding(.top)
+        #else
             .navigationBarFilterDrawer(
                 viewModel: viewModel.filterViewModel,
                 types: enabledDrawerFilters


### PR DESCRIPTION
### Summary

Resolves: https://github.com/jellyfin/Swiftfin/issues/2210

`UISearchController` has built in padding in Apple's usages. Looks like it's about `.padding(.top 48)` but I thought I'd rather be a hair off and use something more dynamic than start counting pixels to try and match Apple exactly.

### Before

<img width="1920" height="1080" alt="Simulator Screenshot - Apple TV 4K (3rd generation) (at 1080p) - 2026-08-16 at 17 38 25" src="https://github.com/user-attachments/assets/86637c5e-8067-4071-a338-b9fbc808b4b1" />

### After

<img width="1920" height="1080" alt="Simulator Screenshot - Apple TV 4K (3rd generation) (at 1080p) - 2026-08-16 at 17 31 07" src="https://github.com/user-attachments/assets/ba2a415e-9b71-4b16-9a0c-862bc17a53c3" />
