### PR TITLE
Use `Thumb` if Available

### DIFF
--- a/Shared/Extensions/JellyfinAPI/BaseItemDto/BaseItemDto+Poster.swift
+++ b/Shared/Extensions/JellyfinAPI/BaseItemDto/BaseItemDto+Poster.swift
@@ -157,6 +157,13 @@ extension BaseItemDto: Poster {
                 )
             }
         case .collectionFolder, .folder, .musicVideo, .userView, .video:
+            if environment.viewContext.contains(.isThumb) {
+                imageSource(
+                    .thumb,
+                    environment: environment
+                )
+            }
+
             imageSource(
                 .primary,
                 environment: environment


### PR DESCRIPTION
### Summary

Resolves: https://github.com/jellyfin/Swiftfin/issues/2231

Adds a check for `thumb` for items where the primary image should be landscape. The idea is, if you're including a `thumb` you probably want it used. The other idea here was to put the thumb as the end as a fallback if the `.primary` doesn't exist since the primary can should be landscape. Happy to go either way but to better align with Web they default back to thumb if a primary isn't available.