### PR TITLE
Follow Apple's Recommended `Long Press` Gesture Duration

### DIFF
--- a/Swiftfin/Components/GestureView.swift
+++ b/Swiftfin/Components/GestureView.swift
@@ -56,7 +56,7 @@ struct GestureView: PlatformViewRepresentable {
                 target: self,
                 action: #selector(handleLongPress)
             )
-            recognizer.minimumPressDuration = 1.2
+            recognizer.minimumPressDuration = 0.5
             return recognizer
         }()
 


### PR DESCRIPTION
### Summary

Resolves: https://github.com/jellyfin/Swiftfin/issues/2217

Apple's documentation for long press suggests 0.5s. Keeping in line with that, this changes this to 0.5 instead of the existing 1.2. There is an argument for customization, but IMO, I think it makes the most sense to just follow the Apple documentation for this to keep this consistent between apps instead of opening the door up to customization on every gesture.

https://developer.apple.com/documentation/uikit/handling-long-press-gestures

<img width="326" height="708" alt="Image" src="https://github.com/user-attachments/assets/1655542d-1a67-400d-adc6-43d6a7f996b2" />

Open for changes if we want to make this a customization but IMO, it makes sense to have that be the line as we risk the Gesture settings becoming overwhelming if we include things like `Minimum Swipe Distance`, etc.

If we prefer the 1.2s we have now, I think this is fine to document and close out as well. Just trying to clear out new smaller issues.