### PR TITLE
Pause video playback when app enters background

### DIFF
--- a/Shared/Coordinators/Navigation/NavigationRoute/NavigationRoute+Media.swift
+++ b/Shared/Coordinators/Navigation/NavigationRoute/NavigationRoute+Media.swift
@@ -97,7 +97,7 @@ struct VideoPlayerViewShim: View {
         .ignoresSafeArea()
         .persistentSystemOverlays(.hidden)
         .toolbar(.hidden, for: .navigationBar)
-        .onScenePhase(.background) {
+        .onSceneDidEnterBackground {
             if Defaults[.VideoPlayer.Transition.pauseOnBackground] {
                 manager.setPlaybackRequestStatus(status: .paused)
             }

--- a/Shared/Coordinators/Navigation/NavigationRoute/NavigationRoute+Media.swift
+++ b/Shared/Coordinators/Navigation/NavigationRoute/NavigationRoute+Media.swift
@@ -97,6 +97,11 @@ struct VideoPlayerViewShim: View {
         .ignoresSafeArea()
         .persistentSystemOverlays(.hidden)
         .toolbar(.hidden, for: .navigationBar)
+        .onScenePhase(.background) {
+            if Defaults[.VideoPlayer.Transition.pauseOnBackground] {
+                manager.setPlaybackRequestStatus(status: .paused)
+            }
+        }
         .onFrameChanged { _, safeArea in
             self.safeAreaInsets = safeArea.max(EdgeInsets.edgePadding)
         }


### PR DESCRIPTION
### Fix for #2175 

### Summary

Previously Video playback was able to continue after Swiftfin entered the background. Now we are listening to the scene-background notification and updating the media player to paused state. Returning to Swiftfin does not automatically resume the video.

### Testing

- Built and ran Swiftfin using the iOS 26.5 Simulator
- SwiftFormat passed
- SwiftLint passed


# BEFORE
the media continues playing in the background


https://github.com/user-attachments/assets/548d9b00-bbe0-4a90-85e2-89bfd0469a26



# AFTER
the media pauses


https://github.com/user-attachments/assets/0bcd4219-3abb-43f0-a6a6-8e8b25e1fa8f