### PR TITLE
Refresh Home and item details after playback stops

### DIFF
--- a/Shared/Objects/ContentGroup/ContentGroupProvider.swift
+++ b/Shared/Objects/ContentGroup/ContentGroupProvider.swift
@@ -14,8 +14,16 @@ protocol ContentGroupProvider: Displayable, Identifiable {
     var environment: Environment { get set }
     var id: String { get }
 
+    var refreshesOnPlaybackStop: Bool { get }
+
     @ContentGroupBuilder
     func makeGroups(environment: Environment) async throws -> [any ContentGroup]
+}
+
+extension ContentGroupProvider {
+    var refreshesOnPlaybackStop: Bool {
+        true
+    }
 }
 
 extension ContentGroupProvider where Environment == Empty {

--- a/Shared/Objects/MediaPlayerManager/MediaProgressObserver.swift
+++ b/Shared/Objects/MediaPlayerManager/MediaProgressObserver.swift
@@ -152,6 +152,8 @@ class MediaProgressObserver: ViewModel, MediaPlayerObserver {
 
             let request = Paths.reportPlaybackStopped(info)
             try await send(request)
+
+            Notifications[.didSendStopReport].post()
         }
     }
 

--- a/Shared/ViewModels/ContentGroupViewModel/ContentGroupViewModel.swift
+++ b/Shared/ViewModels/ContentGroupViewModel/ContentGroupViewModel.swift
@@ -60,6 +60,15 @@ final class ContentGroupViewModel<Provider: ContentGroupProvider>: ViewModel {
             self?.lastRefreshSignalDate = Date.now
         }
         .store(in: &cancellables)
+
+        if provider.refreshesOnPlaybackStop {
+            Notifications[.didSendStopReport]
+                .publisher
+                .sink { [weak self] in
+                    self?.refresh()
+                }
+                .store(in: &cancellables)
+        }
     }
 
     func refreshIfNeeded(
@@ -129,9 +138,6 @@ final class ContentGroupViewModel<Provider: ContentGroupProvider>: ViewModel {
     }
 
     private func fullRefresh() async throws {
-
-        self.groups = []
-        self.candidateGroups = []
 
         let newGroups = try await provider.makeGroups(environment: provider.environment)
 

--- a/Shared/Views/ContentGroupView.swift
+++ b/Shared/Views/ContentGroupView.swift
@@ -79,6 +79,8 @@ struct ContentGroupView<Provider: ContentGroupProvider>: View {
                 } else {
                     contentView
                 }
+            case .refreshing where !viewModel.groups.isEmpty:
+                contentView
             case .error:
                 viewModel.error.map(ErrorView.init)
             case .initial, .refreshing:

--- a/Shared/Views/ItemContentGroupView/ItemContentGroupProvider.swift
+++ b/Shared/Views/ItemContentGroupView/ItemContentGroupProvider.swift
@@ -6,6 +6,7 @@
 // Copyright (c) 2026 Jellyfin & Jellyfin Contributors
 //
 
+import Combine
 import Defaults
 import Get
 import JellyfinAPI
@@ -24,6 +25,8 @@ final class ItemContentGroupProvider: ViewModel, ContentGroupProvider {
 
     let id: String
 
+    let refreshesOnPlaybackStop = false
+
     var displayTitle: String {
         item.displayTitle
     }
@@ -32,12 +35,37 @@ final class ItemContentGroupProvider: ViewModel, ContentGroupProvider {
         self.id = item.id ?? "Unknown"
         self.item = item
         super.init()
+        observePlaybackStop()
     }
 
     init(id: String) {
         self.id = id
         self.item = .init(id: id)
         super.init()
+        observePlaybackStop()
+    }
+
+    private func observePlaybackStop() {
+        Notifications[.didSendStopReport]
+            .publisher
+            .sink { [weak self] in
+                Task { await self?.refreshItemUserData() }
+            }
+            .store(in: &cancellables)
+    }
+
+    private func refreshItemUserData() async {
+        guard let userSession else { return }
+        guard let refreshedItem = try? await item.getFullItem(userSession: userSession) else { return }
+
+        item = refreshedItem
+
+        if let refreshedProvider = try? await resolveMediaPlayerItemProvider(
+            for: refreshedItem,
+            userSession: userSession
+        ) {
+            mediaPlayerItemProvider = refreshedProvider
+        }
     }
 
     func makeGroups(environment: Empty) async throws -> [any ContentGroup] {


### PR DESCRIPTION
Swiftfin's player doesn't update the real playback state in real time. This is especially annoying because there's no (intuitive) way to refresh and update the watched state of each piece of content — unlike on iOS, where there is one.

This PR proposes a solution for that, without a manual refresh: everything happens automatically.

When you exit playback, didSendStopReport is posted (a notification that already existed in the code but was unused). It updates Home and other navigation menus, and it does so without the user noticing.

The content detail is updated more selectively. Instead of refreshing the whole page, it only refreshes the play button (the remaining playback time) and whether the content is marked as watched or not.

This PR was tested on a physical Apple TV 4K (tvOS) and on the iPhone 17 Pro simulator (iOS). I verified that the change feels fluid and improves the user experience.

I don't know whether there's an open issue about this, since it was something I found annoying and I decided to contribute a solution that benefits us all. Thanks.