### PR TITLE
Distinguish Focus from Selection in the Season Picker

### DIFF
--- a/Shared/Objects/ContentGroup/SeriesEpisodeContentGroup/SeriesEpisodeContentGroup+SeasonSelector.swift
+++ b/Shared/Objects/ContentGroup/SeriesEpisodeContentGroup/SeriesEpisodeContentGroup+SeasonSelector.swift
@@ -49,7 +49,12 @@ extension SeriesEpisodeContentGroup {
                             Button(season.library.parent.displayTitle) {
                                 selection = season.id
                             }
-                            .buttonStyle(SeasonButtonStyle(isPickerFocused: isPickerFocused))
+                            .buttonStyle(
+                                SeasonButtonStyle(
+                                    isFocused: focusedSeason == season.id,
+                                    isPickerFocused: isPickerFocused
+                                )
+                            )
                             .isSelected(isSelected)
                             .focused($focusedSeason, equals: season.id)
                             .accessibilityAddTraits(isSelected ? .isSelected : [])
@@ -94,15 +99,24 @@ extension SeriesEpisodeContentGroup {
 
         private struct SeasonButtonStyle: ButtonStyle {
 
-            @Environment(\.isFocused)
-            private var isFocused
             @Environment(\.isSelected)
             private var isSelected
 
+            /// Focus comes from the picker's own `FocusState` rather than `\.isFocused`,
+            /// so that it cannot depend on the environment reaching a `ButtonStyle` body.
+            let isFocused: Bool
             let isPickerFocused: Bool
 
+            /// Whether the button draws a filled capsule: the season being moved over
+            /// while the row has focus, or the chosen season while focus is elsewhere.
             private var isHighlighted: Bool {
                 isFocused || (!isPickerFocused && isSelected)
+            }
+
+            /// The chosen season states its case more quietly while focus is elsewhere,
+            /// so the fill reads as "where you are" once the row is entered.
+            private var inactiveSelectedOpacity: Double {
+                isSelected && !isFocused ? 0.72 : 1
             }
 
             private var glass: BackportGlass {
@@ -119,6 +133,17 @@ extension SeriesEpisodeContentGroup {
                     .padding(CapsuleLabelStyle.defaultInsets)
                     .backport
                     .glassEffect(glass, in: .capsule)
+                    // A filled capsule on its own cannot say whether the row has focus:
+                    // entering it only moves the fill from the chosen season onto the one
+                    // under focus, and entering on the chosen season moves nothing at all.
+                    .opacity(inactiveSelectedOpacity)
+                    .scaleEffect(isFocused ? 1.1 : 1)
+                    .shadow(
+                        color: .black.opacity(isFocused ? 0.5 : 0),
+                        radius: isFocused ? 10 : 0
+                    )
+                    .animation(.easeInOut(duration: 0.15), value: isFocused)
+                    .animation(.easeInOut(duration: 0.15), value: isHighlighted)
             }
         }
 


### PR DESCRIPTION
On tvOS the season picker draws focus and selection identically, so there is no way to tell that the row has been entered.

`SeasonButtonStyle` fills a capsule when `isFocused || (!isPickerFocused && isSelected)`, and both branches produce the same `.regular.selection(tint: .white)` appearance. Moving focus into the row only carries the fill from the chosen season across to the one under focus — and because the row is normally entered *on* the chosen season, the common case is that nothing changes on screen at all. From there, arrowing along the row looks like a single capsule that never clearly belongs to either "what is selected" or "where I am".

The focused season now lifts slightly and casts a shadow, and the chosen season drops to 72% opacity while focus is elsewhere, so the fill reads as position once the row is entered. This follows what `SupplementTitleButtonStyle` already does for the same problem in the player's supplement bar.

Focus is also passed down from the picker's own `FocusState` instead of being read from `\.isFocused` inside the `ButtonStyle`. Logging both values while moving through the row showed them reaching the same totals but disagreeing on individual passes — the environment value trails the focus state by a render, which let the style briefly draw a focus that had already moved on.

**Testing.** Verified in the tvOS 26.5 simulator on an Apple TV 4K (1st generation), i.e. `AppleTV6,2`, where `UIDevice.supportsLiquidGlass` is false and `BackportGlassEffectModifier` takes its legacy path. Entering the row, arrowing between seasons, and leaving the row all read correctly now. tvOS only; nothing on the iOS side of `SeasonSelector` is touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)