### PR TITLE
Remove mediaSources from listing MinimumFields

### DIFF
--- a/Shared/Extensions/JellyfinAPI/ItemFields.swift
+++ b/Shared/Extensions/JellyfinAPI/ItemFields.swift
@@ -14,8 +14,11 @@ extension ItemFields {
     /// The minimum cases to use when retrieving an item or items
     /// for basic presentation. Depending on the context, using
     /// more fields and including user data may also be necessary.
+    ///
+    /// `mediaSources` is intentionally omitted: it inflates listing
+    /// responses when items have multiple versions. Playback paths
+    /// load sources via `getFullItem` / `MediaPlayerItem.build`.
     static let MinimumFields: [ItemFields] = [
-        .mediaSources,
         .parentID,
     ]
 }

--- a/Shared/Objects/MediaPlayerManager/Supplements/EpisodeMediaPlayerQueue.swift
+++ b/Shared/Objects/MediaPlayerManager/Supplements/EpisodeMediaPlayerQueue.swift
@@ -176,11 +176,8 @@ extension EpisodeMediaPlayerQueue {
 
         private func select(episode: BaseItemDto) {
             let provider = MediaPlayerItemProvider(item: episode) { [manager] item, modifyItem in
-                let mediaSource = item.mediaSources?.first
-
-                return try await MediaPlayerItem.build(
+                try await MediaPlayerItem.build(
                     for: item,
-                    mediaSource: mediaSource!,
                     requestedBitrate: manager.playbackBitrate,
                     modifyItem: modifyItem
                 )

--- a/Shared/Views/ItemContentGroupView/ItemContentGroupProvider.swift
+++ b/Shared/Views/ItemContentGroupView/ItemContentGroupProvider.swift
@@ -295,9 +295,11 @@ final class ItemContentGroupProvider: ViewModel, ContentGroupProvider {
         return playbackItem?.getPlaybackItemProvider(userSession: userSession)
     }
 
+    // Play-button item is a single episode; keep mediaSources so the
+    // version menu still has data. Listings continue to use MinimumFields.
     private func nextUpItem(for item: BaseItemDto) async throws -> BaseItemDto? {
         var parameters = Paths.GetNextUpParameters()
-        parameters.fields = .MinimumFields
+        parameters.fields = .MinimumFields.appending(.mediaSources)
         parameters.seriesID = item.id
 
         let request = Paths.getNextUp(parameters: parameters)
@@ -312,7 +314,7 @@ final class ItemContentGroupProvider: ViewModel, ContentGroupProvider {
 
     private func resumeItem(for item: BaseItemDto) async throws -> BaseItemDto? {
         var parameters = Paths.GetResumeItemsParameters()
-        parameters.fields = .MinimumFields
+        parameters.fields = .MinimumFields.appending(.mediaSources)
         parameters.limit = 1
         parameters.parentID = item.id
 
@@ -324,7 +326,7 @@ final class ItemContentGroupProvider: ViewModel, ContentGroupProvider {
 
     private func firstAvailableItem(for item: BaseItemDto) async throws -> BaseItemDto? {
         var parameters = Paths.GetItemsParameters()
-        parameters.fields = .MinimumFields
+        parameters.fields = .MinimumFields.appending(.mediaSources)
         parameters.includeItemTypes = [.episode]
         parameters.isMissing = false
         parameters.isRecursive = true


### PR DESCRIPTION
## Summary

Home, Search, and library listings currently request `mediaSources` for every item via `MinimumFields`. That field carries codec, resolution, and version payloads. On libraries with multiple versions it makes those list calls slower for data the posters never use.

Playback already reloads the item in `MediaPlayerItem.build` (`getFullItem`). Listings only need `parentID`.

## Why this is not a repeat of #1950

#1950 was closed waiting on #1752. #1752 closed without merging, and `main` still ships `.mediaSources` in `MinimumFields`. This change is against current `main` and keeps playback working without assuming listing rows include sources.

Fixes #1707

## Changes

- Drop `.mediaSources` from `MinimumFields`.
- Keep `.mediaSources` on the single next-up / resume / first-episode fetch used by the series Play button, so the version menu still has data.
- Episode overlay no longer force-unwraps `mediaSources?.first`; it uses the same `MediaPlayerItem.build` path as next/previous episode.

## Test plan

- [ ] Home, Search, and a large library with multi-version items: posters still load; list requests no longer include `MediaSources`.
- [ ] Play from a poster / search result (item without preloaded sources).
- [ ] Series page Play button, including an episode with more than one version.
- [ ] Play an episode from the in-player episode overlay, then next/previous.
- [ ] Live TV / program play still starts.