### PR TITLE
Refresh an open item view from LibraryChanged socket messages

### DIFF
--- a/Shared/Services/ServerSocketManager.swift
+++ b/Shared/Services/ServerSocketManager.swift
@@ -245,6 +245,13 @@ extension ServerSocketManager {
         }
     }
 
+    var libraryUpdates: AnyPublisher<LibraryUpdateInfo, Never> {
+        commands { event in
+            guard case let .message(.libraryChangedMessage(message)) = event else { return nil }
+            return message.data
+        }
+    }
+
     private func commands<Command>(
         extract: @escaping (JellyfinSocket.Session.Event) -> Command?
     ) -> AnyPublisher<Command, Never> {

--- a/Shared/Services/UserSession/UserSessionManager+LibraryChanges.swift
+++ b/Shared/Services/UserSession/UserSessionManager+LibraryChanges.swift
@@ -1,0 +1,49 @@
+//
+// Swiftfin is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, you can obtain one at https://mozilla.org/MPL/2.0/.
+//
+// Copyright (c) 2026 Jellyfin & Jellyfin Contributors
+//
+
+import Combine
+import Foundation
+import JellyfinAPI
+
+extension UserSessionManager {
+
+    func observeLibraryChanges() {
+        $currentSession
+            .map { session -> AnyPublisher<LibraryUpdateInfo, Never> in
+                session?.serverSocketManager.libraryUpdates ?? Combine.Empty<LibraryUpdateInfo, Never>()
+                    .eraseToAnyPublisher()
+            }
+            .switchToLatest()
+            .sink { [weak self] update in
+                Task { @MainActor in
+                    self?.onReceive(libraryUpdate: update)
+                }
+            }
+            .store(in: &cancellables)
+    }
+
+    @MainActor
+    private func onReceive(libraryUpdate: LibraryUpdateInfo) {
+        for itemID in libraryUpdate.itemsUpdated ?? [] {
+            Notifications[.itemShouldRefreshMetadata].post(itemID.dashedItemID)
+        }
+    }
+}
+
+private extension String {
+
+    var dashedItemID: String {
+        guard count == 32, allSatisfy(\.isHexDigit) else { return self }
+
+        var id = self
+        for offset in [20, 16, 12, 8] {
+            id.insert("-", at: index(startIndex, offsetBy: offset))
+        }
+        return id
+    }
+}

--- a/Shared/Services/UserSession/UserSessionManager.swift
+++ b/Shared/Services/UserSession/UserSessionManager.swift
@@ -297,6 +297,7 @@ final class UserSessionManager: ObservableObject {
             .store(in: &cancellables)
 
         observeSocketCommands()
+        observeLibraryChanges()
     }
 
     @MainActor

--- a/Shared/Views/ItemContentGroupView/ItemContentGroupProvider.swift
+++ b/Shared/Views/ItemContentGroupView/ItemContentGroupProvider.swift
@@ -40,6 +40,17 @@ final class ItemContentGroupProvider: ViewModel, ContentGroupProvider {
         super.init()
     }
 
+    func reloadItem() async throws {
+        let userSession = try requireUserSession()
+        let fullItem = try await item.getFullItem(userSession: userSession)
+
+        item = fullItem
+        mediaPlayerItemProvider = try await resolveMediaPlayerItemProvider(
+            for: fullItem,
+            userSession: userSession
+        )
+    }
+
     func makeGroups(environment: Empty) async throws -> [any ContentGroup] {
         let userSession = try requireUserSession()
         let fullItem = try await item.getFullItem(userSession: userSession, sendNotification: true)

--- a/Shared/Views/ItemView/ItemView.swift
+++ b/Shared/Views/ItemView/ItemView.swift
@@ -132,6 +132,22 @@ struct ItemView: View {
         .onFirstAppear {
             viewModel.refresh()
         }
+        .onNotification(.itemShouldRefreshMetadata) { itemID in
+            guard itemID == provider.id else { return }
+
+            Task {
+                do {
+                    try await provider.reloadItem()
+                } catch {
+                    provider.logger.error(
+                        "Unable to reload item after a library change",
+                        metadata: ["error": .string(error.localizedDescription)]
+                    )
+                }
+
+                await viewModel.background.refresh()
+            }
+        }
         .environmentObject(focusCoordinator)
         #if os(tvOS)
             .toolbarVisibility(.hidden, for: .navigationBar)


### PR DESCRIPTION
### **_Summary_**


Swiftfin keeps a WebSocket open to the server but never listens for LibraryChanged, the message a server sends when items it already handed out have changed. Pressing Refresh metadata on an item is the clearest case: the request returns, the server does the work, and the open item view keeps showing the old data until you leave it and come back.

This PR listens for that message and updates the item view in place:

You press Refresh metadata on an item.
The server does the work and, when it lands, sends LibraryChanged with that item's id in ItemsUpdated.
ServerSocketManager now exposes those updates, UserSessionManager turns them into the existing itemShouldRefreshMetadata notification, and an open ItemView whose id matches re-reads its item and refreshes its groups — without a spinner over the whole screen and without leaving the view.
Everything it needs is already there: the message is in the Jellyfin API description, the SDK decodes it, and the notification exists and is already posted from elsewhere. Nothing observed it until now
