### PR TITLE
Fix incorrect episode selection for series

### DIFF
--- a/Shared/Objects/ContentGroup/SeriesEpisodeContentGroup/SeriesEpisodeContentGroup+EpisodeCollection.swift
+++ b/Shared/Objects/ContentGroup/SeriesEpisodeContentGroup/SeriesEpisodeContentGroup+EpisodeCollection.swift
@@ -127,6 +127,11 @@ extension SeriesEpisodeContentGroup {
         @FocusState
         private var focusedElement: EpisodeElement.ID?
 
+        #if os(iOS)
+        @StateObject
+        private var proxy = CollectionHStackProxy()
+        #endif
+
         let elements: [EpisodeElement]
         let preferredElementID: EpisodeElement.ID?
         let header: Header
@@ -188,13 +193,27 @@ extension SeriesEpisodeContentGroup {
                 .insets(horizontal: EdgeInsets.edgePadding)
                 .itemSpacing(Self.itemSpacing)
                 .scrollBehavior(.continuousLeadingEdge)
-                .focusSection()
-                .focused($focusedSection, equals: .episodes)
-                .defaultFocus(
-                    $focusedElement,
-                    preferredElementID,
-                    priority: .userInitiated
-                )
+                #if os(iOS)
+                    .proxy(proxy)
+                    .task(id: preferredElementID) {
+                        guard let preferredElementID else { return }
+
+                        do {
+                            try await Task.sleep(for: .milliseconds(100))
+                        } catch {
+                            return
+                        }
+
+                        proxy.scrollTo(id: preferredElementID, animated: false)
+                    }
+                #endif
+                    .focusSection()
+                        .focused($focusedSection, equals: .episodes)
+                        .defaultFocus(
+                            $focusedElement,
+                            preferredElementID,
+                            priority: .userInitiated
+                        )
             } header: {
                 header
                     .focusSection()

--- a/Shared/Objects/ContentGroup/SeriesEpisodeContentGroup/SeriesEpisodeContentGroup+EpisodeCollection.swift
+++ b/Shared/Objects/ContentGroup/SeriesEpisodeContentGroup/SeriesEpisodeContentGroup+EpisodeCollection.swift
@@ -127,11 +127,6 @@ extension SeriesEpisodeContentGroup {
         @FocusState
         private var focusedElement: EpisodeElement.ID?
 
-        #if os(iOS)
-        @StateObject
-        private var proxy = CollectionHStackProxy()
-        #endif
-
         let elements: [EpisodeElement]
         let preferredElementID: EpisodeElement.ID?
         let header: Header
@@ -193,27 +188,13 @@ extension SeriesEpisodeContentGroup {
                 .insets(horizontal: EdgeInsets.edgePadding)
                 .itemSpacing(Self.itemSpacing)
                 .scrollBehavior(.continuousLeadingEdge)
-                #if os(iOS)
-                    .proxy(proxy)
-                    .task(id: preferredElementID) {
-                        guard let preferredElementID else { return }
-
-                        do {
-                            try await Task.sleep(for: .milliseconds(100))
-                        } catch {
-                            return
-                        }
-
-                        proxy.scrollTo(id: preferredElementID, animated: false)
-                    }
-                #endif
-                    .focusSection()
-                        .focused($focusedSection, equals: .episodes)
-                        .defaultFocus(
-                            $focusedElement,
-                            preferredElementID,
-                            priority: .userInitiated
-                        )
+                .focusSection()
+                .focused($focusedSection, equals: .episodes)
+                .defaultFocus(
+                    $focusedElement,
+                    preferredElementID,
+                    priority: .userInitiated
+                )
             } header: {
                 header
                     .focusSection()

--- a/Shared/Objects/ContentGroup/SeriesEpisodeContentGroup/SeriesEpisodeContentGroup+EpisodeCollection.swift
+++ b/Shared/Objects/ContentGroup/SeriesEpisodeContentGroup/SeriesEpisodeContentGroup+EpisodeCollection.swift
@@ -126,6 +126,10 @@ extension SeriesEpisodeContentGroup {
         private var focusedSection: FocusedSection?
         @FocusState
         private var focusedElement: EpisodeElement.ID?
+        @State
+        private var scrolledToPreferredElementID: EpisodeElement.ID?
+        @StateObject
+        private var proxy = CollectionHStackProxy()
 
         let elements: [EpisodeElement]
         let preferredElementID: EpisodeElement.ID?
@@ -175,6 +179,19 @@ extension SeriesEpisodeContentGroup {
             #endif
         }
 
+        private func scrollToPreferredElementIfNeeded(after element: EpisodeElement) {
+            guard case .episode = element,
+                  let preferredElementID,
+                  scrolledToPreferredElementID != preferredElementID
+            else {
+                return
+            }
+
+            scrolledToPreferredElementID = preferredElementID
+            focusedElement = preferredElementID
+            proxy.scrollTo(id: preferredElementID, animated: false)
+        }
+
         var body: some View {
             ContentGroupSection {
                 CollectionHStack(
@@ -183,10 +200,14 @@ extension SeriesEpisodeContentGroup {
                 ) { element in
                     content(element)
                         .focused($focusedElement, equals: element.id)
+                        .onFirstAppear {
+                            scrollToPreferredElementIfNeeded(after: element)
+                        }
                 }
                 .clipsToBounds(false)
                 .insets(horizontal: EdgeInsets.edgePadding)
                 .itemSpacing(Self.itemSpacing)
+                .proxy(proxy)
                 .scrollBehavior(.continuousLeadingEdge)
                 .focusSection()
                 .focused($focusedSection, equals: .episodes)

--- a/Shared/Views/ItemContentGroupView/ItemContentGroupProvider.swift
+++ b/Shared/Views/ItemContentGroupView/ItemContentGroupProvider.swift
@@ -327,18 +327,8 @@ final class ItemContentGroupProvider: ViewModel, ContentGroupProvider {
         parameters.isRecursive = true
         parameters.limit = 1
         parameters.parentID = item.id
-        parameters.sortBy = [.airedEpisodeOrder]
         parameters.sortOrder = [.ascending]
 
-        parameters.isPlayed = false
-        let unplayedRequest = Paths.getItems(parameters: parameters)
-        let unplayedResponse = try await send(unplayedRequest)
-
-        if let firstUnplayedItem = unplayedResponse.value.items?.first {
-            return firstUnplayedItem
-        }
-
-        parameters.isPlayed = nil
         let request = Paths.getItems(parameters: parameters)
         let response = try await send(request)
 

--- a/Shared/Views/ItemContentGroupView/ItemContentGroupProvider.swift
+++ b/Shared/Views/ItemContentGroupView/ItemContentGroupProvider.swift
@@ -327,8 +327,18 @@ final class ItemContentGroupProvider: ViewModel, ContentGroupProvider {
         parameters.isRecursive = true
         parameters.limit = 1
         parameters.parentID = item.id
+        parameters.sortBy = [.airedEpisodeOrder]
         parameters.sortOrder = [.ascending]
 
+        parameters.isPlayed = false
+        let unplayedRequest = Paths.getItems(parameters: parameters)
+        let unplayedResponse = try await send(unplayedRequest)
+
+        if let firstUnplayedItem = unplayedResponse.value.items?.first {
+            return firstUnplayedItem
+        }
+
+        parameters.isPlayed = nil
         let request = Paths.getItems(parameters: parameters)
         let response = try await send(request)
 

--- a/Shared/Views/ItemContentGroupView/ItemContentGroupProvider.swift
+++ b/Shared/Views/ItemContentGroupView/ItemContentGroupProvider.swift
@@ -327,8 +327,19 @@ final class ItemContentGroupProvider: ViewModel, ContentGroupProvider {
         parameters.isRecursive = true
         parameters.limit = 1
         parameters.parentID = item.id
+        parameters.sortBy = [.airedEpisodeOrder]
         parameters.sortOrder = [.ascending]
+        parameters.userID = try authenticatedUser.id
 
+        parameters.isPlayed = false
+        let unplayedRequest = Paths.getItems(parameters: parameters)
+        let unplayedResponse = try await send(unplayedRequest)
+
+        if let firstUnplayedItem = unplayedResponse.value.items?.first {
+            return firstUnplayedItem
+        }
+
+        parameters.isPlayed = nil
         let request = Paths.getItems(parameters: parameters)
         let response = try await send(request)
 


### PR DESCRIPTION
### Fixes #2143

### Summary

Series and season pages now select the earliest unplayed episode when there is no next-up or resumable item. Once the episode cards appear, the carousel scrolls to the selected episode on both iOS and tvOS.

### Testing

- Built and ran Swiftfin using the iOS 26.5 Simulator
- Verified a partially watched episode remains selected
- Verified completing an episode selects the first unplayed episode
- iOS and tvOS builds passed

# BEFORE
The selected episode is outside the visible carousel.

<img width="300" alt="swiftfin-2143-before" src="https://github.com/user-attachments/assets/93403ce1-e8d5-4f0e-8756-1d4c69c26617" />

# AFTER
The carousel scrolls to the selected episode.

<img width="300" alt="swiftfin-2143-after" src="https://github.com/user-attachments/assets/74b87803-f8f3-4d2b-b7a7-1675a284eecb" />
