### PR TITLE
Fix playback of in-progress live tv recordings

### DIFF
--- a/Shared/Objects/MediaPlayerManager/MediaPlayerItem/MediaPlayerItem+Build.swift
+++ b/Shared/Objects/MediaPlayerManager/MediaPlayerItem/MediaPlayerItem+Build.swift
@@ -80,7 +80,7 @@ extension MediaPlayerItem {
         playbackInfo.audioStreamIndex = audioStreamIndex
         playbackInfo.subtitleStreamIndex = subtitleStreamIndex
 
-        if !item.isLiveStream {
+        if !item.isLiveStream, initialMediaSource.type != .placeholder {
             playbackInfo.mediaSourceID = initialMediaSource.id
         }
 


### PR DESCRIPTION
Fixes "Unable to load this item" playback error on live tv recordings that are still in progress.

The item's only listed source is a placeholder which the server filters out of playback sources, so sending it returns no sources.

This fix skips the media source id when the initial source is a placeholder. 

Tested on iOS and tvOS against Jellyfin 12 RC7.
