### PR TITLE
Keep in-progress recordings in place on resume and track their live edge

### DIFF
--- a/Shared/Objects/MediaPlayerManager/MediaPlayerItem/MediaPlayerItem+Build.swift
+++ b/Shared/Objects/MediaPlayerManager/MediaPlayerItem/MediaPlayerItem+Build.swift
@@ -125,6 +125,12 @@ extension MediaPlayerItem {
 
         item.runTimeTicks = mediaSource.runTimeTicks ?? item.runTimeTicks
 
+        // The server nulls an active recording's runtime. Seed it from when the recording
+        // file appeared; `MediaPlayerManager` keeps it tracking the live edge during playback.
+        if item.type == .recording, let created = item.dateCreated {
+            item.runTimeTicks = Duration.seconds(Date.now.timeIntervalSince(created)).ticks
+        }
+
         guard let playSessionID = response.value.playSessionID else {
             throw ErrorMessage("No associated play session ID")
         }

--- a/Shared/Objects/MediaPlayerManager/MediaPlayerItem/MediaPlayerItem+Build.swift
+++ b/Shared/Objects/MediaPlayerManager/MediaPlayerItem/MediaPlayerItem+Build.swift
@@ -84,16 +84,6 @@ extension MediaPlayerItem {
             playbackInfo.mediaSourceID = initialMediaSource.id
         }
 
-        // The players cannot seek a recording still being written (a growing HLS
-        // playlist), so the server starts the stream at the wanted position and
-        // playback time is offset by it, the way Jellyfin Web handles transcodes.
-        var timelineOffset: Duration = .zero
-
-        if item.type == .recording {
-            timelineOffset = max(.zero, (item.startSeconds ?? .zero) - .seconds(Defaults[.VideoPlayer.resumeOffset]))
-            playbackInfo.startTimeTicks = timelineOffset > .zero ? timelineOffset.ticks : nil
-        }
-
         let request = Paths.getPostedPlaybackInfo(
             itemID: itemID,
             playbackInfo
@@ -194,8 +184,7 @@ extension MediaPlayerItem {
             initialAudioStreamIndex: audioStreamIndex,
             initialSubtitleStreamIndex: subtitleStreamIndex,
             previewImageProvider: previewImageProvider,
-            thumbnailProvider: item.getNowPlayingImage,
-            timelineOffset: timelineOffset
+            thumbnailProvider: item.getNowPlayingImage
         )
     }
 

--- a/Shared/Objects/MediaPlayerManager/MediaPlayerItem/MediaPlayerItem+Build.swift
+++ b/Shared/Objects/MediaPlayerManager/MediaPlayerItem/MediaPlayerItem+Build.swift
@@ -84,6 +84,16 @@ extension MediaPlayerItem {
             playbackInfo.mediaSourceID = initialMediaSource.id
         }
 
+        // The players cannot seek a recording still being written (a growing HLS
+        // playlist), so the server starts the stream at the wanted position and
+        // playback time is offset by it, the way Jellyfin Web handles transcodes.
+        var timelineOffset: Duration = .zero
+
+        if item.type == .recording {
+            timelineOffset = max(.zero, (item.startSeconds ?? .zero) - .seconds(Defaults[.VideoPlayer.resumeOffset]))
+            playbackInfo.startTimeTicks = timelineOffset > .zero ? timelineOffset.ticks : nil
+        }
+
         let request = Paths.getPostedPlaybackInfo(
             itemID: itemID,
             playbackInfo
@@ -184,7 +194,8 @@ extension MediaPlayerItem {
             initialAudioStreamIndex: audioStreamIndex,
             initialSubtitleStreamIndex: subtitleStreamIndex,
             previewImageProvider: previewImageProvider,
-            thumbnailProvider: item.getNowPlayingImage
+            thumbnailProvider: item.getNowPlayingImage,
+            timelineOffset: timelineOffset
         )
     }
 

--- a/Shared/Objects/MediaPlayerManager/MediaPlayerItem/MediaPlayerItem.swift
+++ b/Shared/Objects/MediaPlayerManager/MediaPlayerItem/MediaPlayerItem.swift
@@ -62,16 +62,6 @@ class MediaPlayerItem: ViewModel, MediaPlayerObserver {
 
     let requestedBitrate: PlaybackBitrate
 
-    /// Seconds the server skipped before the start of this stream, so
-    /// the player's own clock starts here. Non-zero for a recording still
-    /// being written, which the players cannot seek themselves.
-    let timelineOffset: Duration
-
-    /// Seeks restart the stream on the server instead of moving the player
-    var seeksViaServer: Bool {
-        baseItem.type == .recording && mediaSource.transcodingURL != nil
-    }
-
     // MARK: init
 
     init(
@@ -84,11 +74,9 @@ class MediaPlayerItem: ViewModel, MediaPlayerObserver {
         initialAudioStreamIndex: Int? = nil,
         initialSubtitleStreamIndex: Int? = nil,
         previewImageProvider: (any PreviewImageProvider)? = nil,
-        thumbnailProvider: ThumbnailProvider? = nil,
-        timelineOffset: Duration = .zero
+        thumbnailProvider: ThumbnailProvider? = nil
     ) {
         self.baseItem = baseItem
-        self.timelineOffset = timelineOffset
         self.mediaSource = mediaSource
         self.playSessionID = playSessionID
         self.requestedBitrate = requestedBitrate

--- a/Shared/Objects/MediaPlayerManager/MediaPlayerItem/MediaPlayerItem.swift
+++ b/Shared/Objects/MediaPlayerManager/MediaPlayerItem/MediaPlayerItem.swift
@@ -62,6 +62,16 @@ class MediaPlayerItem: ViewModel, MediaPlayerObserver {
 
     let requestedBitrate: PlaybackBitrate
 
+    /// Seconds the server skipped before the start of this stream, so
+    /// the player's own clock starts here. Non-zero for a recording still
+    /// being written, which the players cannot seek themselves.
+    let timelineOffset: Duration
+
+    /// Seeks restart the stream on the server instead of moving the player
+    var seeksViaServer: Bool {
+        baseItem.type == .recording && mediaSource.transcodingURL != nil
+    }
+
     // MARK: init
 
     init(
@@ -74,9 +84,11 @@ class MediaPlayerItem: ViewModel, MediaPlayerObserver {
         initialAudioStreamIndex: Int? = nil,
         initialSubtitleStreamIndex: Int? = nil,
         previewImageProvider: (any PreviewImageProvider)? = nil,
-        thumbnailProvider: ThumbnailProvider? = nil
+        thumbnailProvider: ThumbnailProvider? = nil,
+        timelineOffset: Duration = .zero
     ) {
         self.baseItem = baseItem
+        self.timelineOffset = timelineOffset
         self.mediaSource = mediaSource
         self.playSessionID = playSessionID
         self.requestedBitrate = requestedBitrate

--- a/Shared/Objects/MediaPlayerManager/MediaPlayerManager.swift
+++ b/Shared/Objects/MediaPlayerManager/MediaPlayerManager.swift
@@ -171,7 +171,16 @@ final class MediaPlayerManager: ViewModel {
 
     var seconds: Duration {
         get { secondsBox.value }
-        set { secondsBox.value = newValue }
+        set {
+            secondsBox.value = newValue
+
+            // Workaround for in-progress recordings growing as
+            // they are played, estimate runtime from recording
+            // start (inferred from when the item appeared)
+            if item.type == .recording, let created = item.dateCreated {
+                item.runTimeTicks = max(newValue, Duration.seconds(Date.now.timeIntervalSince(created))).ticks
+            }
+        }
     }
 
     var playbackBitrate: PlaybackBitrate {

--- a/Shared/Objects/MediaPlayerManager/MediaPlayerManager.swift
+++ b/Shared/Objects/MediaPlayerManager/MediaPlayerManager.swift
@@ -55,6 +55,7 @@ final class MediaPlayerManager: ViewModel {
         case ended
         case error
         case playNewItem(provider: MediaPlayerItemProvider)
+        case seek(seconds: Duration)
         case setBitrate(bitrate: PlaybackBitrate)
         case setPlaybackRequestStatus(status: PlaybackRequestStatus)
         case setRate(rate: Float)
@@ -296,6 +297,14 @@ final class MediaPlayerManager: ViewModel {
         playbackItem = try await provider()
     }
 
+    /// Restarts the stream on the server at the given position, for media the player cannot seek itself
+    @Function(\Action.Cases.seek)
+    private func _seek(_ seconds: Duration) async throws {
+        guard let playbackItem else { return }
+
+        try await updateMediaPlayerItem(currentItem: playbackItem, seconds: seconds)
+    }
+
     @Function(\Action.Cases.setBitrate)
     private func _setBitrate(_ requestedBitrate: PlaybackBitrate) async throws {
         guard let currentItem = playbackItem else { return }
@@ -407,11 +416,12 @@ final class MediaPlayerManager: ViewModel {
         currentItem: MediaPlayerItem,
         audioStreamIndex: Int? = nil,
         subtitleStreamIndex: Int? = nil,
-        requestedBitrate: PlaybackBitrate? = nil
+        requestedBitrate: PlaybackBitrate? = nil,
+        seconds: Duration? = nil
     ) async throws {
 
         // Capture the current playback position before stopping
-        let currentSeconds = self.seconds
+        let currentSeconds = seconds ?? self.seconds
 
         logger.info(
             "Rebuilding Media Player Item",

--- a/Shared/Objects/MediaPlayerManager/MediaPlayerManager.swift
+++ b/Shared/Objects/MediaPlayerManager/MediaPlayerManager.swift
@@ -55,7 +55,6 @@ final class MediaPlayerManager: ViewModel {
         case ended
         case error
         case playNewItem(provider: MediaPlayerItemProvider)
-        case seek(seconds: Duration)
         case setBitrate(bitrate: PlaybackBitrate)
         case setPlaybackRequestStatus(status: PlaybackRequestStatus)
         case setRate(rate: Float)
@@ -297,14 +296,6 @@ final class MediaPlayerManager: ViewModel {
         playbackItem = try await provider()
     }
 
-    /// Restarts the stream on the server at the given position, for media the player cannot seek itself
-    @Function(\Action.Cases.seek)
-    private func _seek(_ seconds: Duration) async throws {
-        guard let playbackItem else { return }
-
-        try await updateMediaPlayerItem(currentItem: playbackItem, seconds: seconds)
-    }
-
     @Function(\Action.Cases.setBitrate)
     private func _setBitrate(_ requestedBitrate: PlaybackBitrate) async throws {
         guard let currentItem = playbackItem else { return }
@@ -416,12 +407,11 @@ final class MediaPlayerManager: ViewModel {
         currentItem: MediaPlayerItem,
         audioStreamIndex: Int? = nil,
         subtitleStreamIndex: Int? = nil,
-        requestedBitrate: PlaybackBitrate? = nil,
-        seconds: Duration? = nil
+        requestedBitrate: PlaybackBitrate? = nil
     ) async throws {
 
         // Capture the current playback position before stopping
-        let currentSeconds = seconds ?? self.seconds
+        let currentSeconds = self.seconds
 
         logger.info(
             "Rebuilding Media Player Item",

--- a/Shared/Objects/MediaPlayerManager/MediaPlayerProxy/MediaPlayerProxy+MPV.swift
+++ b/Shared/Objects/MediaPlayerManager/MediaPlayerProxy/MediaPlayerProxy+MPV.swift
@@ -53,26 +53,19 @@ class MPVMediaPlayerProxy: @MainActor VideoMediaPlayerProxy,
         manager?.item.type == .recording
     }
 
-    /// A seek past the playlist mpv has fetched so far. A recording still being
-    /// written grows its playlist as the server remuxes it, so the seek waits for
-    /// the reported duration to reach the target and is cleared once playback lands.
+    /// A seek on a recording still being written is kept until playback lands
+    /// near it: the server grows the playlist as it remuxes, and FFmpeg refreshes
+    /// the playlist on a seek past its known end, so a held seek is retried.
     private var pendingSeek: Duration?
+    private var lastPendingSeekAttempt: Date = .distantPast
 
     private func seekPlayer(to seconds: Duration) {
-        pendingSeek = nil
+        pendingSeek = isRecording ? seconds : nil
+        lastPendingSeekAttempt = .now
 
-        if isRecording, let duration = player.mediaInformation.duration, seconds > duration {
-            pendingSeek = seconds
-            manager?.logger.info("mpv seek to \(seconds) waits for the playlist, known duration \(duration)")
-            return
-        }
-
-        player.seek(to: seconds)
-
-        // With no duration known yet the seek may have fallen outside the playlist
-        if isRecording, player.mediaInformation.duration == nil {
-            pendingSeek = seconds
-        }
+        // The raw command: `MPVPlayer.seek(to:)` clamps to the duration mpv reported
+        // when the file opened, which for a recording is only the playlist produced so far
+        player.command("seek", arguments: [String(format: "%.3f", seconds.seconds), "absolute+exact"])
     }
 
     /// Remembers a position to seek to once the playlist reaches it
@@ -80,8 +73,9 @@ class MPVMediaPlayerProxy: @MainActor VideoMediaPlayerProxy,
         pendingSeek = seconds
     }
 
-    func applyPendingSeekIfPossible() {
-        guard let pendingSeek, let duration = player.mediaInformation.duration, pendingSeek <= duration else { return }
+    func retryPendingSeekIfNeeded() {
+        guard let pendingSeek, Date.now.timeIntervalSince(lastPendingSeekAttempt) >= 5 else { return }
+        manager?.logger.info("mpv retrying held seek to \(pendingSeek)")
         seekPlayer(to: pendingSeek)
     }
 
@@ -281,6 +275,7 @@ extension MPVMediaPlayerProxy {
                     }
                     .onChange(of: player.position) {
                         proxy.settlePendingSeek(at: player.position)
+                        proxy.retryPendingSeekIfNeeded()
 
                         if !containerState.isScrubbing {
                             containerState.scrubbedSeconds.value = player.position
@@ -293,9 +288,6 @@ extension MPVMediaPlayerProxy {
                         if player.state == .ready || player.state == .playing || player.state == .paused {
                             updateTracks(for: item)
                         }
-                    }
-                    .onChange(of: player.mediaInformation.duration) {
-                        proxy.applyPendingSeekIfPossible()
                     }
                     .onChange(of: player.mediaInformation.tracks) {
                         updateTracks(for: item)

--- a/Shared/Objects/MediaPlayerManager/MediaPlayerProxy/MediaPlayerProxy+MPV.swift
+++ b/Shared/Objects/MediaPlayerManager/MediaPlayerProxy/MediaPlayerProxy+MPV.swift
@@ -35,11 +35,22 @@ class MPVMediaPlayerProxy: @MainActor VideoMediaPlayerProxy,
         NowPlayableObserver(),
     ]
 
+    private var resumeGuard = ResumeGuard()
+
     func play() {
+        resumeGuard.willResumePlayback(isRecording: manager?.item.type == .recording, at: manager?.seconds)
         player.play()
     }
 
+    func enforceResumeGuard(_ seconds: Duration) {
+        guard let target = resumeGuard.correction(for: seconds) else { return }
+
+        // Seek the player directly: `setSeconds` would disarm the guard
+        player.seek(to: target)
+    }
+
     func pause() {
+        resumeGuard.didPausePlayback()
         player.pause()
     }
 
@@ -56,6 +67,7 @@ class MPVMediaPlayerProxy: @MainActor VideoMediaPlayerProxy,
     }
 
     func setSeconds(_ seconds: Duration) {
+        resumeGuard.disarm()
         player.seek(to: seconds)
     }
 
@@ -225,6 +237,7 @@ extension MPVMediaPlayerProxy {
                             containerState.scrubbedSeconds.value = player.position
                         }
                         manager.seconds = player.position
+                        proxy.enforceResumeGuard(player.position)
                     }
                     .onChange(of: player.state) {
                         updateState(player.state)

--- a/Shared/Objects/MediaPlayerManager/MediaPlayerProxy/MediaPlayerProxy+MPV.swift
+++ b/Shared/Objects/MediaPlayerManager/MediaPlayerProxy/MediaPlayerProxy+MPV.swift
@@ -46,7 +46,48 @@ class MPVMediaPlayerProxy: @MainActor VideoMediaPlayerProxy,
         guard let target = resumeGuard.correction(for: seconds) else { return }
 
         // Seek the player directly: `setSeconds` would disarm the guard
-        player.seek(to: target)
+        seekPlayer(to: target)
+    }
+
+    private var isRecording: Bool {
+        manager?.item.type == .recording
+    }
+
+    /// A seek past the playlist mpv has fetched so far. A recording still being
+    /// written grows its playlist as the server remuxes it, so the seek waits for
+    /// the reported duration to reach the target and is cleared once playback lands.
+    private var pendingSeek: Duration?
+
+    private func seekPlayer(to seconds: Duration) {
+        pendingSeek = nil
+
+        if isRecording, let duration = player.mediaInformation.duration, seconds > duration {
+            pendingSeek = seconds
+            manager?.logger.info("mpv seek to \(seconds) waits for the playlist, known duration \(duration)")
+            return
+        }
+
+        player.seek(to: seconds)
+
+        // With no duration known yet the seek may have fallen outside the playlist
+        if isRecording, player.mediaInformation.duration == nil {
+            pendingSeek = seconds
+        }
+    }
+
+    /// Remembers a position to seek to once the playlist reaches it
+    func deferSeek(to seconds: Duration) {
+        pendingSeek = seconds
+    }
+
+    func applyPendingSeekIfPossible() {
+        guard let pendingSeek, let duration = player.mediaInformation.duration, pendingSeek <= duration else { return }
+        seekPlayer(to: pendingSeek)
+    }
+
+    func settlePendingSeek(at seconds: Duration) {
+        guard let pendingSeek, abs((seconds - pendingSeek).seconds) < 5 else { return }
+        self.pendingSeek = nil
     }
 
     func pause() {
@@ -55,6 +96,7 @@ class MPVMediaPlayerProxy: @MainActor VideoMediaPlayerProxy,
     }
 
     func stop() {
+        pendingSeek = nil
         player.stop()
     }
 
@@ -68,7 +110,7 @@ class MPVMediaPlayerProxy: @MainActor VideoMediaPlayerProxy,
 
     func setSeconds(_ seconds: Duration) {
         resumeGuard.disarm()
-        player.seek(to: seconds)
+        seekPlayer(to: seconds)
     }
 
     func setRate(_ rate: Float) {
@@ -158,6 +200,11 @@ extension MPVMediaPlayerProxy {
 
             let start = max(.zero, (item.baseItem.startSeconds ?? .zero) - .seconds(Defaults[.VideoPlayer.resumeOffset]))
             player.load(item.url, autoPlay: manager.playbackRequestStatus == .playing, startTime: item.baseItem.isLiveStream ? nil : start)
+
+            // The playlist of a recording still being written may not reach the resume position yet
+            if item.baseItem.type == .recording, start > .zero {
+                proxy.deferSeek(to: start)
+            }
             proxy.setRate(manager.rate)
             proxy.setAspectFill(false)
         }
@@ -233,6 +280,8 @@ extension MPVMediaPlayerProxy {
                         textSubtitles.clear()
                     }
                     .onChange(of: player.position) {
+                        proxy.settlePendingSeek(at: player.position)
+
                         if !containerState.isScrubbing {
                             containerState.scrubbedSeconds.value = player.position
                         }
@@ -244,6 +293,9 @@ extension MPVMediaPlayerProxy {
                         if player.state == .ready || player.state == .playing || player.state == .paused {
                             updateTracks(for: item)
                         }
+                    }
+                    .onChange(of: player.mediaInformation.duration) {
+                        proxy.applyPendingSeekIfPossible()
                     }
                     .onChange(of: player.mediaInformation.tracks) {
                         updateTracks(for: item)

--- a/Shared/Objects/MediaPlayerManager/MediaPlayerProxy/MediaPlayerProxy+MPV.swift
+++ b/Shared/Objects/MediaPlayerManager/MediaPlayerProxy/MediaPlayerProxy+MPV.swift
@@ -37,6 +37,11 @@ class MPVMediaPlayerProxy: @MainActor VideoMediaPlayerProxy,
 
     private var resumeGuard = ResumeGuard()
 
+    /// The player's clock starts here, see `MediaPlayerItem.timelineOffset`
+    private var timelineOffset: Duration {
+        manager?.playbackItem?.timelineOffset ?? .zero
+    }
+
     func play() {
         resumeGuard.willResumePlayback(isRecording: manager?.item.type == .recording, at: manager?.seconds)
         player.play()
@@ -46,7 +51,11 @@ class MPVMediaPlayerProxy: @MainActor VideoMediaPlayerProxy,
         guard let target = resumeGuard.correction(for: seconds) else { return }
 
         // Seek the player directly: `setSeconds` would disarm the guard
-        player.seek(to: target)
+        if manager?.playbackItem?.seeksViaServer == true {
+            manager?.seek(seconds: target)
+        } else {
+            player.seek(to: target - timelineOffset)
+        }
     }
 
     func pause() {
@@ -59,16 +68,21 @@ class MPVMediaPlayerProxy: @MainActor VideoMediaPlayerProxy,
     }
 
     func jumpForward(_ seconds: Duration) {
-        setSeconds(player.position + seconds)
+        setSeconds(player.position + timelineOffset + seconds)
     }
 
     func jumpBackward(_ seconds: Duration) {
-        setSeconds(player.position - seconds)
+        setSeconds(player.position + timelineOffset - seconds)
     }
 
     func setSeconds(_ seconds: Duration) {
         resumeGuard.disarm()
-        player.seek(to: seconds)
+
+        if manager?.playbackItem?.seeksViaServer == true {
+            manager?.seek(seconds: seconds)
+        } else {
+            player.seek(to: seconds - timelineOffset)
+        }
     }
 
     func setRate(_ rate: Float) {
@@ -156,7 +170,11 @@ extension MPVMediaPlayerProxy {
             item.setTrackIndexes(.init())
             proxy.isBuffering.value = true
 
-            let start = max(.zero, (item.baseItem.startSeconds ?? .zero) - .seconds(Defaults[.VideoPlayer.resumeOffset]))
+            // Relative to the player's clock: a server-started stream starts at zero
+            let start = max(
+                .zero,
+                (item.baseItem.startSeconds ?? .zero) - .seconds(Defaults[.VideoPlayer.resumeOffset]) - item.timelineOffset
+            )
             player.load(item.url, autoPlay: manager.playbackRequestStatus == .playing, startTime: item.baseItem.isLiveStream ? nil : start)
             proxy.setRate(manager.rate)
             proxy.setAspectFill(false)
@@ -205,7 +223,7 @@ extension MPVMediaPlayerProxy {
                 manager.setPlaybackRequestStatus(status: .paused)
             case .ended:
                 guard manager.playbackItem?.baseItem.isLiveStream == false else { return }
-                manager.seconds = player.position
+                manager.seconds = player.position + (loadedItem?.timelineOffset ?? .zero)
                 manager.ended()
             case let .failed(error):
                 manager.error(error)
@@ -233,11 +251,13 @@ extension MPVMediaPlayerProxy {
                         textSubtitles.clear()
                     }
                     .onChange(of: player.position) {
+                        let seconds = player.position + item.timelineOffset
+
                         if !containerState.isScrubbing {
-                            containerState.scrubbedSeconds.value = player.position
+                            containerState.scrubbedSeconds.value = seconds
                         }
-                        manager.seconds = player.position
-                        proxy.enforceResumeGuard(player.position)
+                        manager.seconds = seconds
+                        proxy.enforceResumeGuard(seconds)
                     }
                     .onChange(of: player.state) {
                         updateState(player.state)

--- a/Shared/Objects/MediaPlayerManager/MediaPlayerProxy/MediaPlayerProxy+MPV.swift
+++ b/Shared/Objects/MediaPlayerManager/MediaPlayerProxy/MediaPlayerProxy+MPV.swift
@@ -37,11 +37,6 @@ class MPVMediaPlayerProxy: @MainActor VideoMediaPlayerProxy,
 
     private var resumeGuard = ResumeGuard()
 
-    /// The player's clock starts here, see `MediaPlayerItem.timelineOffset`
-    private var timelineOffset: Duration {
-        manager?.playbackItem?.timelineOffset ?? .zero
-    }
-
     func play() {
         resumeGuard.willResumePlayback(isRecording: manager?.item.type == .recording, at: manager?.seconds)
         player.play()
@@ -51,11 +46,7 @@ class MPVMediaPlayerProxy: @MainActor VideoMediaPlayerProxy,
         guard let target = resumeGuard.correction(for: seconds) else { return }
 
         // Seek the player directly: `setSeconds` would disarm the guard
-        if manager?.playbackItem?.seeksViaServer == true {
-            manager?.seek(seconds: target)
-        } else {
-            player.seek(to: target - timelineOffset)
-        }
+        player.seek(to: target)
     }
 
     func pause() {
@@ -68,21 +59,16 @@ class MPVMediaPlayerProxy: @MainActor VideoMediaPlayerProxy,
     }
 
     func jumpForward(_ seconds: Duration) {
-        setSeconds(player.position + timelineOffset + seconds)
+        setSeconds(player.position + seconds)
     }
 
     func jumpBackward(_ seconds: Duration) {
-        setSeconds(player.position + timelineOffset - seconds)
+        setSeconds(player.position - seconds)
     }
 
     func setSeconds(_ seconds: Duration) {
         resumeGuard.disarm()
-
-        if manager?.playbackItem?.seeksViaServer == true {
-            manager?.seek(seconds: seconds)
-        } else {
-            player.seek(to: seconds - timelineOffset)
-        }
+        player.seek(to: seconds)
     }
 
     func setRate(_ rate: Float) {
@@ -170,11 +156,7 @@ extension MPVMediaPlayerProxy {
             item.setTrackIndexes(.init())
             proxy.isBuffering.value = true
 
-            // Relative to the player's clock: a server-started stream starts at zero
-            let start = max(
-                .zero,
-                (item.baseItem.startSeconds ?? .zero) - .seconds(Defaults[.VideoPlayer.resumeOffset]) - item.timelineOffset
-            )
+            let start = max(.zero, (item.baseItem.startSeconds ?? .zero) - .seconds(Defaults[.VideoPlayer.resumeOffset]))
             player.load(item.url, autoPlay: manager.playbackRequestStatus == .playing, startTime: item.baseItem.isLiveStream ? nil : start)
             proxy.setRate(manager.rate)
             proxy.setAspectFill(false)
@@ -223,7 +205,7 @@ extension MPVMediaPlayerProxy {
                 manager.setPlaybackRequestStatus(status: .paused)
             case .ended:
                 guard manager.playbackItem?.baseItem.isLiveStream == false else { return }
-                manager.seconds = player.position + (loadedItem?.timelineOffset ?? .zero)
+                manager.seconds = player.position
                 manager.ended()
             case let .failed(error):
                 manager.error(error)
@@ -251,13 +233,11 @@ extension MPVMediaPlayerProxy {
                         textSubtitles.clear()
                     }
                     .onChange(of: player.position) {
-                        let seconds = player.position + item.timelineOffset
-
                         if !containerState.isScrubbing {
-                            containerState.scrubbedSeconds.value = seconds
+                            containerState.scrubbedSeconds.value = player.position
                         }
-                        manager.seconds = seconds
-                        proxy.enforceResumeGuard(seconds)
+                        manager.seconds = player.position
+                        proxy.enforceResumeGuard(player.position)
                     }
                     .onChange(of: player.state) {
                         updateState(player.state)

--- a/Shared/Objects/MediaPlayerManager/MediaPlayerProxy/MediaPlayerProxy+VLC.swift
+++ b/Shared/Objects/MediaPlayerManager/MediaPlayerProxy/MediaPlayerProxy+VLC.swift
@@ -58,10 +58,20 @@ class VLCMediaPlayerProxy: VideoMediaPlayerProxy,
         guard let target = resumeGuard.correction(for: seconds) else { return }
 
         // Seek the player directly: `setSeconds` would disarm the guard
-        do {
-            try player.seek(to: target)
-        } catch {
-            log(error)
+        seekPlayer(to: target)
+    }
+
+    /// libVLC reports an in-progress recording (a growing HLS event playlist)
+    /// as not seekable but still honours relative jumps within the playlist.
+    private func seekPlayer(to seconds: Duration) {
+        if player.isSeekable {
+            do {
+                try player.seek(to: seconds)
+            } catch {
+                log(error)
+            }
+        } else if !player.jump(by: seconds - player.currentTime) {
+            manager?.logger.warning("SwiftVLC refused a jump to \(seconds) on non-seekable media")
         }
     }
 
@@ -106,16 +116,9 @@ class VLCMediaPlayerProxy: VideoMediaPlayerProxy,
     }
 
     func setSeconds(_ seconds: Duration) {
-        guard player.isSeekable else { return }
-
         pendingStartTime = nil
         resumeGuard.disarm()
-
-        do {
-            try player.seek(to: seconds)
-        } catch {
-            log(error)
-        }
+        seekPlayer(to: seconds)
     }
 
     func setAudioStream(_ stream: MediaStream) {
@@ -184,16 +187,12 @@ class VLCMediaPlayerProxy: VideoMediaPlayerProxy,
     @discardableResult
     private func applyPendingStartTimeIfPossible() -> Bool {
         guard let pendingStartTime else { return false }
-        guard player.isSeekable else { return false }
+        guard player.isSeekable || player.state == .playing else { return false }
 
         self.pendingStartTime = nil
 
-        do {
-            try player.seek(to: pendingStartTime)
-            manager?.seconds = pendingStartTime
-        } catch {
-            log(error)
-        }
+        seekPlayer(to: pendingStartTime)
+        manager?.seconds = pendingStartTime
 
         return true
     }
@@ -314,6 +313,7 @@ extension VLCMediaPlayerProxy {
                         }
                     }
                     .onChange(of: proxy.player.isSeekable) { _, isSeekable in
+                        manager.logger.info("SwiftVLC seekable: \(isSeekable), duration: \(proxy.player.duration.map(\.seconds) ?? -1)")
                         guard isSeekable else { return }
                         proxy.applyPendingStartTimeIfPossible()
                     }
@@ -321,7 +321,9 @@ extension VLCMediaPlayerProxy {
                         guard didReachEnd, manager.playbackItem?.baseItem.isLiveStream == false else { return }
                         // libVLC resets its clock on stop. Report the completed
                         // timeline before the manager decides whether to advance.
-                        if let runtime = playbackItem.baseItem.runtime {
+                        // A recording still in progress ends early at its live edge,
+                        // so leave its position for the manager's near-end guard.
+                        if playbackItem.baseItem.type != .recording, let runtime = playbackItem.baseItem.runtime {
                             manager.seconds = runtime
                         }
                         proxy.isBuffering.value = false

--- a/Shared/Objects/MediaPlayerManager/MediaPlayerProxy/MediaPlayerProxy+VLC.swift
+++ b/Shared/Objects/MediaPlayerManager/MediaPlayerProxy/MediaPlayerProxy+VLC.swift
@@ -38,7 +38,17 @@ class VLCMediaPlayerProxy: VideoMediaPlayerProxy,
         NowPlayableObserver(),
     ]
 
+    private var didPause = false
+    // Unpausing live HLS playlist re-syncs to live, so user gets skipped
+    // forward. Watch first seconds after resume and drag it back
+    private var resumeGuard: (target: Duration, until: Date)?
+
     func play() {
+        if didPause, manager?.item.type == .recording, let seconds = manager?.seconds {
+            resumeGuard = (seconds, .now + 15)
+        }
+        didPause = false
+
         if player.state == .paused {
             player.resume()
         } else {
@@ -50,7 +60,23 @@ class VLCMediaPlayerProxy: VideoMediaPlayerProxy,
         }
     }
 
+    func enforceResumeGuard(_ seconds: Duration) {
+        guard let resumeGuard else { return }
+
+        if Date.now > resumeGuard.until {
+            self.resumeGuard = nil
+        } else if seconds > resumeGuard.target + .seconds(30) {
+            // Seek the player directly: `setSeconds` would clear the guard
+            do {
+                try player.seek(to: resumeGuard.target)
+            } catch {
+                log(error)
+            }
+        }
+    }
+
     func pause() {
+        didPause = true
         player.pause()
     }
 
@@ -61,6 +87,7 @@ class VLCMediaPlayerProxy: VideoMediaPlayerProxy,
     }
 
     func jumpForward(_ seconds: Duration) {
+        resumeGuard = nil
         let target: Duration
 
         if let runtime = manager?.item.runtime, let current = manager?.seconds {
@@ -76,6 +103,7 @@ class VLCMediaPlayerProxy: VideoMediaPlayerProxy,
     }
 
     func jumpBackward(_ seconds: Duration) {
+        resumeGuard = nil
         player.jump(by: .zero - seconds)
     }
 
@@ -91,6 +119,7 @@ class VLCMediaPlayerProxy: VideoMediaPlayerProxy,
         guard player.isSeekable else { return }
 
         pendingStartTime = nil
+        resumeGuard = nil
 
         do {
             try player.seek(to: seconds)
@@ -254,6 +283,7 @@ extension VLCMediaPlayerProxy {
                         if proxy.player.state == .playing {
                             proxy.isBuffering.value = false
                         }
+                        proxy.enforceResumeGuard(newSeconds)
 
                         proxy.videoSize.value = proxy.player.videoSize ?? .zero
                         if let statistics = proxy.player.statistics {

--- a/Shared/Objects/MediaPlayerManager/MediaPlayerProxy/MediaPlayerProxy+VLC.swift
+++ b/Shared/Objects/MediaPlayerManager/MediaPlayerProxy/MediaPlayerProxy+VLC.swift
@@ -61,9 +61,24 @@ class VLCMediaPlayerProxy: VideoMediaPlayerProxy,
         seekPlayer(to: target)
     }
 
-    /// libVLC reports an in-progress recording (a growing HLS event playlist)
-    /// as not seekable but still honours relative jumps within the playlist.
+    private var isRecording: Bool {
+        manager?.item.type == .recording
+    }
+
+    /// A seek past the playlist libVLC has fetched so far. A recording still being
+    /// written grows its playlist as the server remuxes it, so the seek waits for
+    /// the reported length to reach the target and is cleared once playback lands.
+    private var pendingSeek: Duration?
+
     private func seekPlayer(to seconds: Duration) {
+        pendingSeek = nil
+
+        if isRecording, let duration = player.duration, seconds > duration {
+            pendingSeek = seconds
+            manager?.logger.info("SwiftVLC seek to \(seconds) waits for the playlist, known length \(duration)")
+            return
+        }
+
         if player.isSeekable {
             do {
                 try player.seek(to: seconds)
@@ -73,6 +88,21 @@ class VLCMediaPlayerProxy: VideoMediaPlayerProxy,
         } else if !player.jump(by: seconds - player.currentTime) {
             manager?.logger.warning("SwiftVLC refused a jump to \(seconds) on non-seekable media")
         }
+
+        // With no length known yet the seek may have fallen outside the playlist
+        if isRecording, player.duration == nil {
+            pendingSeek = seconds
+        }
+    }
+
+    func applyPendingSeekIfPossible() {
+        guard let pendingSeek, let duration = player.duration, pendingSeek <= duration else { return }
+        seekPlayer(to: pendingSeek)
+    }
+
+    func settlePendingSeek(at seconds: Duration) {
+        guard let pendingSeek, abs((seconds - pendingSeek).seconds) < 5 else { return }
+        self.pendingSeek = nil
     }
 
     func pause() {
@@ -82,6 +112,7 @@ class VLCMediaPlayerProxy: VideoMediaPlayerProxy,
 
     func stop() {
         pendingStartTime = nil
+        pendingSeek = nil
         isBuffering.value = false
         player.stop()
     }
@@ -99,12 +130,21 @@ class VLCMediaPlayerProxy: VideoMediaPlayerProxy,
 
         guard target > .zero else { return }
 
-        player.jump(by: target)
+        if isRecording, let current = manager?.seconds {
+            seekPlayer(to: current + target)
+        } else {
+            player.jump(by: target)
+        }
     }
 
     func jumpBackward(_ seconds: Duration) {
         resumeGuard.disarm()
-        player.jump(by: .zero - seconds)
+
+        if isRecording, let current = manager?.seconds {
+            seekPlayer(to: max(.zero, current - seconds))
+        } else {
+            player.jump(by: .zero - seconds)
+        }
     }
 
     func setRate(_ rate: Float) {
@@ -264,6 +304,8 @@ extension VLCMediaPlayerProxy {
                               newSeconds == proxy.player.currentTime
                         else { return }
 
+                        proxy.settlePendingSeek(at: newSeconds)
+
                         if !isScrubbing {
                             containerState.scrubbedSeconds.value = newSeconds
                         }
@@ -311,6 +353,9 @@ extension VLCMediaPlayerProxy {
                         } else if fill >= 1 {
                             proxy.isBuffering.value = false
                         }
+                    }
+                    .onChange(of: proxy.player.duration) {
+                        proxy.applyPendingSeekIfPossible()
                     }
                     .onChange(of: proxy.player.isSeekable) { _, isSeekable in
                         manager.logger.info("SwiftVLC seekable: \(isSeekable), duration: \(proxy.player.duration.map(\.seconds) ?? -1)")

--- a/Shared/Objects/MediaPlayerManager/MediaPlayerProxy/MediaPlayerProxy+VLC.swift
+++ b/Shared/Objects/MediaPlayerManager/MediaPlayerProxy/MediaPlayerProxy+VLC.swift
@@ -40,11 +40,6 @@ class VLCMediaPlayerProxy: VideoMediaPlayerProxy,
 
     private var resumeGuard = ResumeGuard()
 
-    /// The player's clock starts here, see `MediaPlayerItem.timelineOffset`
-    private var timelineOffset: Duration {
-        manager?.playbackItem?.timelineOffset ?? .zero
-    }
-
     func play() {
         resumeGuard.willResumePlayback(isRecording: manager?.item.type == .recording, at: manager?.seconds)
 
@@ -63,11 +58,7 @@ class VLCMediaPlayerProxy: VideoMediaPlayerProxy,
         guard let target = resumeGuard.correction(for: seconds) else { return }
 
         // Seek the player directly: `setSeconds` would disarm the guard
-        if manager?.playbackItem?.seeksViaServer == true {
-            manager?.seek(seconds: target)
-        } else {
-            seekPlayer(to: target - timelineOffset)
-        }
+        seekPlayer(to: target)
     }
 
     /// libVLC reports an in-progress recording (a growing HLS event playlist)
@@ -127,12 +118,7 @@ class VLCMediaPlayerProxy: VideoMediaPlayerProxy,
     func setSeconds(_ seconds: Duration) {
         pendingStartTime = nil
         resumeGuard.disarm()
-
-        if manager?.playbackItem?.seeksViaServer == true {
-            manager?.seek(seconds: seconds)
-        } else {
-            seekPlayer(to: seconds - timelineOffset)
-        }
+        seekPlayer(to: seconds)
     }
 
     func setAudioStream(_ stream: MediaStream) {
@@ -206,7 +192,7 @@ class VLCMediaPlayerProxy: VideoMediaPlayerProxy,
         self.pendingStartTime = nil
 
         seekPlayer(to: pendingStartTime)
-        manager?.seconds = pendingStartTime + timelineOffset
+        manager?.seconds = pendingStartTime
 
         return true
     }
@@ -220,9 +206,7 @@ class VLCMediaPlayerProxy: VideoMediaPlayerProxy,
                 (item.baseItem.startSeconds ?? .zero) - Duration.seconds(Defaults[.VideoPlayer.resumeOffset])
             )
 
-            // Relative to the player's clock: a server-started stream needs no seek
-            let playerStartSeconds = startSeconds - item.timelineOffset
-            pendingStartTime = !item.baseItem.isLiveStream && playerStartSeconds > .zero ? playerStartSeconds : nil
+            pendingStartTime = !item.baseItem.isLiveStream && startSeconds > .zero ? startSeconds : nil
 
             if let client = manager?.userSession?.client {
                 for subtitle in item.subtitleStreams.sidecarSubtitles {
@@ -280,17 +264,15 @@ extension VLCMediaPlayerProxy {
                               newSeconds == proxy.player.currentTime
                         else { return }
 
-                        let seconds = newSeconds + playbackItem.timelineOffset
-
                         if !isScrubbing {
-                            containerState.scrubbedSeconds.value = seconds
+                            containerState.scrubbedSeconds.value = newSeconds
                         }
 
-                        manager.seconds = seconds
+                        manager.seconds = newSeconds
                         if proxy.player.state == .playing {
                             proxy.isBuffering.value = false
                         }
-                        proxy.enforceResumeGuard(seconds)
+                        proxy.enforceResumeGuard(newSeconds)
 
                         proxy.videoSize.value = proxy.player.videoSize ?? .zero
                         if let statistics = proxy.player.statistics {

--- a/Shared/Objects/MediaPlayerManager/MediaPlayerProxy/MediaPlayerProxy+VLC.swift
+++ b/Shared/Objects/MediaPlayerManager/MediaPlayerProxy/MediaPlayerProxy+VLC.swift
@@ -38,16 +38,10 @@ class VLCMediaPlayerProxy: VideoMediaPlayerProxy,
         NowPlayableObserver(),
     ]
 
-    private var didPause = false
-    // Unpausing live HLS playlist re-syncs to live, so user gets skipped
-    // forward. Watch first seconds after resume and drag it back
-    private var resumeGuard: (target: Duration, until: Date)?
+    private var resumeGuard = ResumeGuard()
 
     func play() {
-        if didPause, manager?.item.type == .recording, let seconds = manager?.seconds {
-            resumeGuard = (seconds, .now + 15)
-        }
-        didPause = false
+        resumeGuard.willResumePlayback(isRecording: manager?.item.type == .recording, at: manager?.seconds)
 
         if player.state == .paused {
             player.resume()
@@ -61,22 +55,18 @@ class VLCMediaPlayerProxy: VideoMediaPlayerProxy,
     }
 
     func enforceResumeGuard(_ seconds: Duration) {
-        guard let resumeGuard else { return }
+        guard let target = resumeGuard.correction(for: seconds) else { return }
 
-        if Date.now > resumeGuard.until {
-            self.resumeGuard = nil
-        } else if seconds > resumeGuard.target + .seconds(30) {
-            // Seek the player directly: `setSeconds` would clear the guard
-            do {
-                try player.seek(to: resumeGuard.target)
-            } catch {
-                log(error)
-            }
+        // Seek the player directly: `setSeconds` would disarm the guard
+        do {
+            try player.seek(to: target)
+        } catch {
+            log(error)
         }
     }
 
     func pause() {
-        didPause = true
+        resumeGuard.didPausePlayback()
         player.pause()
     }
 
@@ -87,7 +77,7 @@ class VLCMediaPlayerProxy: VideoMediaPlayerProxy,
     }
 
     func jumpForward(_ seconds: Duration) {
-        resumeGuard = nil
+        resumeGuard.disarm()
         let target: Duration
 
         if let runtime = manager?.item.runtime, let current = manager?.seconds {
@@ -103,7 +93,7 @@ class VLCMediaPlayerProxy: VideoMediaPlayerProxy,
     }
 
     func jumpBackward(_ seconds: Duration) {
-        resumeGuard = nil
+        resumeGuard.disarm()
         player.jump(by: .zero - seconds)
     }
 
@@ -119,7 +109,7 @@ class VLCMediaPlayerProxy: VideoMediaPlayerProxy,
         guard player.isSeekable else { return }
 
         pendingStartTime = nil
-        resumeGuard = nil
+        resumeGuard.disarm()
 
         do {
             try player.seek(to: seconds)

--- a/Shared/Objects/MediaPlayerManager/MediaPlayerProxy/MediaPlayerProxy+VLC.swift
+++ b/Shared/Objects/MediaPlayerManager/MediaPlayerProxy/MediaPlayerProxy+VLC.swift
@@ -40,6 +40,11 @@ class VLCMediaPlayerProxy: VideoMediaPlayerProxy,
 
     private var resumeGuard = ResumeGuard()
 
+    /// The player's clock starts here, see `MediaPlayerItem.timelineOffset`
+    private var timelineOffset: Duration {
+        manager?.playbackItem?.timelineOffset ?? .zero
+    }
+
     func play() {
         resumeGuard.willResumePlayback(isRecording: manager?.item.type == .recording, at: manager?.seconds)
 
@@ -58,7 +63,11 @@ class VLCMediaPlayerProxy: VideoMediaPlayerProxy,
         guard let target = resumeGuard.correction(for: seconds) else { return }
 
         // Seek the player directly: `setSeconds` would disarm the guard
-        seekPlayer(to: target)
+        if manager?.playbackItem?.seeksViaServer == true {
+            manager?.seek(seconds: target)
+        } else {
+            seekPlayer(to: target - timelineOffset)
+        }
     }
 
     /// libVLC reports an in-progress recording (a growing HLS event playlist)
@@ -118,7 +127,12 @@ class VLCMediaPlayerProxy: VideoMediaPlayerProxy,
     func setSeconds(_ seconds: Duration) {
         pendingStartTime = nil
         resumeGuard.disarm()
-        seekPlayer(to: seconds)
+
+        if manager?.playbackItem?.seeksViaServer == true {
+            manager?.seek(seconds: seconds)
+        } else {
+            seekPlayer(to: seconds - timelineOffset)
+        }
     }
 
     func setAudioStream(_ stream: MediaStream) {
@@ -192,7 +206,7 @@ class VLCMediaPlayerProxy: VideoMediaPlayerProxy,
         self.pendingStartTime = nil
 
         seekPlayer(to: pendingStartTime)
-        manager?.seconds = pendingStartTime
+        manager?.seconds = pendingStartTime + timelineOffset
 
         return true
     }
@@ -206,7 +220,9 @@ class VLCMediaPlayerProxy: VideoMediaPlayerProxy,
                 (item.baseItem.startSeconds ?? .zero) - Duration.seconds(Defaults[.VideoPlayer.resumeOffset])
             )
 
-            pendingStartTime = !item.baseItem.isLiveStream && startSeconds > .zero ? startSeconds : nil
+            // Relative to the player's clock: a server-started stream needs no seek
+            let playerStartSeconds = startSeconds - item.timelineOffset
+            pendingStartTime = !item.baseItem.isLiveStream && playerStartSeconds > .zero ? playerStartSeconds : nil
 
             if let client = manager?.userSession?.client {
                 for subtitle in item.subtitleStreams.sidecarSubtitles {
@@ -264,15 +280,17 @@ extension VLCMediaPlayerProxy {
                               newSeconds == proxy.player.currentTime
                         else { return }
 
+                        let seconds = newSeconds + playbackItem.timelineOffset
+
                         if !isScrubbing {
-                            containerState.scrubbedSeconds.value = newSeconds
+                            containerState.scrubbedSeconds.value = seconds
                         }
 
-                        manager.seconds = newSeconds
+                        manager.seconds = seconds
                         if proxy.player.state == .playing {
                             proxy.isBuffering.value = false
                         }
-                        proxy.enforceResumeGuard(newSeconds)
+                        proxy.enforceResumeGuard(seconds)
 
                         proxy.videoSize.value = proxy.player.videoSize ?? .zero
                         if let statistics = proxy.player.statistics {

--- a/Shared/Objects/MediaPlayerManager/MediaPlayerProxy/ResumeGuard.swift
+++ b/Shared/Objects/MediaPlayerManager/MediaPlayerProxy/ResumeGuard.swift
@@ -1,0 +1,48 @@
+//
+// Swiftfin is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, you can obtain one at https://mozilla.org/MPL/2.0/.
+//
+// Copyright (c) 2026 Jellyfin & Jellyfin Contributors
+//
+
+import Foundation
+
+/// Unpausing a live HLS playlist can re-sync playback to the live edge and skip
+/// the viewer forward. Remembers where an in-progress recording was paused and
+/// asks for a seek back if playback jumps ahead in the first seconds after resuming.
+struct ResumeGuard {
+
+    private var didPause = false
+    private var target: Duration?
+    private var until = Date.distantPast
+
+    mutating func didPausePlayback() {
+        didPause = true
+    }
+
+    mutating func willResumePlayback(isRecording: Bool, at seconds: Duration?) {
+        if didPause, isRecording, let seconds {
+            target = seconds
+            until = .now + 15
+        }
+
+        didPause = false
+    }
+
+    mutating func disarm() {
+        target = nil
+    }
+
+    /// The position to drag playback back to when the reported seconds jumped past the window
+    mutating func correction(for seconds: Duration) -> Duration? {
+        guard let target else { return nil }
+
+        if Date.now > until {
+            self.target = nil
+            return nil
+        }
+
+        return seconds > target + .seconds(30) ? target : nil
+    }
+}


### PR DESCRIPTION
Two playback fixes for in-progress tv recordings

Depends on #2262 which enables playback of in-progress recordings

1. Resume no longer skips ahead
When unpausing a live hls playlist, VLC 3 re-syncs to live edge. Pausing and unpausing an in-progress recording jumps ahead to where the recording had gotten to. `VLCMediaPlayerProxy` now remembers the position at unpause, and seeks back if VLC jumps more than 30 sec ahead of it. User seek, jump, scrub disarms the guard.

2. Live runtime tracking
The server will null the runtime of an active recording. The runtime is now inferred from the item's `dateCreated` and `MediaPlayerManager` keeps it at `max(position, now - dateCreated)` on every position update so it grows with the recording and prevents the slider from overshooting.

Both changes gated on `item.type == .recording` which server only sets while recording is active. Other media types not affected.

### Trade offs
- The resume guard is a client-side workaround for VLC 3. VLCKit 4 changes how live pause is handled, at which point this can be removed
- `dateCreated` can lag behind true recording start usually by a few seconds. Estimate is clamped so it can't fall below current position
- Updating `item.runTimeTicks` per position tick republishes `item` once a second while playing an active recording. I didn't encounter any issues with this in my testing but want to flag it

### Testing
Tested on iOS and tvOS, jellyfin server v12 rc7
- Paused in progress recording for ~20s, unpaused, resumed at paused position
- Slider remained under 100% as total/remaining time grew during playback
- Rewind, fast-forward, scrubbing all work and also after a resume