### PR TITLE
Fix tvOS episode state card corner radius

### DIFF
--- a/Shared/Objects/ContentGroup/SeriesEpisodeContentGroup/SeriesEpisodeContentGroup+EpisodeCard.swift
+++ b/Shared/Objects/ContentGroup/SeriesEpisodeContentGroup/SeriesEpisodeContentGroup+EpisodeCard.swift
@@ -114,6 +114,9 @@ extension SeriesEpisodeContentGroup {
                         }
                     }
                     .posterStyle(.landscape)
+                #if os(tvOS)
+                    .posterCornerRadius(.landscape)
+                #endif
                     .subtleShadow()
             }
         }


### PR DESCRIPTION
Episode loading and other state cards on tvOS had square artwork corners while normal episode cards are rounded.

This uses the existing `posterCornerRadius(.landscape)` helper so loading, empty, and error states match visually.

| Before | After |
| --- | --- |
| <img width="3840" height="2160" alt="before" src="https://github.com/user-attachments/assets/fb83321f-1627-485f-8979-4b27a1d71e88" /> | <img width="3840" height="2160" alt="after" src="https://github.com/user-attachments/assets/50540e82-d480-484a-9c7b-f3c38e2ab09d" /> |