### PR TITLE
Merge cast & crew posters for people with multiple crew roles

### DIFF
--- a/Shared/Extensions/JellyfinAPI/BaseItemDto/BaseItemDto+Poster.swift
+++ b/Shared/Extensions/JellyfinAPI/BaseItemDto/BaseItemDto+Poster.swift
@@ -45,7 +45,7 @@ extension BaseItemDto: Poster {
         case .episode:
             seasonEpisodeLabel
         case .person:
-            people?.first?.firstRole
+            people?.first?.displayRole
         case .video:
             extraType?.displayTitle
         default:

--- a/Shared/Extensions/JellyfinAPI/BaseItemDto/BaseItemDto.swift
+++ b/Shared/Extensions/JellyfinAPI/BaseItemDto/BaseItemDto.swift
@@ -137,6 +137,30 @@ extension BaseItemDto {
         return L10n.episodeNumber(episodeNo)
     }
 
+    /// Merges crew credits
+    var mergedPeople: [BaseItemPerson]? {
+        guard let people else { return nil }
+
+        let crew = Dictionary(grouping: people.filter(\.isCrew), by: \.id)
+        var seen: Set<String> = []
+
+        return people.compactMap { person in
+            guard person.isCrew, let id = person.id, let credits = crew[id], credits.count > 1 else {
+                return person
+            }
+            guard seen.insert(id).inserted else { return nil }
+
+            let roles = credits.compactMap(\.role)
+                .filter(\.isNotEmpty)
+                .uniqued()
+                .joined(separator: " / ")
+
+            var person = person
+            person.role = roles.isEmpty ? nil : roles
+            return person
+        }
+    }
+
     var itemGenres: [ItemGenre]? {
         guard let genres else { return nil }
         return genres.map(ItemGenre.init)

--- a/Shared/Extensions/JellyfinAPI/BaseItemPerson/BaseItemPerson+Poster.swift
+++ b/Shared/Extensions/JellyfinAPI/BaseItemPerson/BaseItemPerson+Poster.swift
@@ -29,13 +29,7 @@ extension BaseItemPerson: Poster {
     }
 
     var subtitle: String? {
-        // Crew roles are job names that may have been combined into a single credit,
-        // so they are shown in full instead of being cut at the first "/"
-        guard let type, mergeableCrewKinds.contains(type) else {
-            return firstRole
-        }
-
-        return role
+        displayRole
     }
 
     var systemImage: String {

--- a/Shared/Extensions/JellyfinAPI/BaseItemPerson/BaseItemPerson+Poster.swift
+++ b/Shared/Extensions/JellyfinAPI/BaseItemPerson/BaseItemPerson+Poster.swift
@@ -29,7 +29,13 @@ extension BaseItemPerson: Poster {
     }
 
     var subtitle: String? {
-        firstRole
+        // Crew roles are job names that may have been combined into a single credit,
+        // so they are shown in full instead of being cut at the first "/"
+        guard let type, mergeableCrewKinds.contains(type) else {
+            return firstRole
+        }
+
+        return role
     }
 
     var systemImage: String {

--- a/Shared/Extensions/JellyfinAPI/BaseItemPerson/BaseItemPerson.swift
+++ b/Shared/Extensions/JellyfinAPI/BaseItemPerson/BaseItemPerson.swift
@@ -47,3 +47,52 @@ extension BaseItemPerson {
         return final
     }
 }
+
+/// The person kinds the server sends one credit per job for, meaning someone credited for
+/// multiple jobs is sent as multiple people.
+let mergeableCrewKinds: Set<PersonKind> = [.director, .writer, .producer]
+
+extension Collection where Element == BaseItemPerson {
+
+    /// Combines the credits of a person holding multiple crew jobs into a single element listing
+    /// all of their roles, like "Director / Producer". Kinds outside `mergeableCrewKinds` are never
+    /// combined, so an actor playing multiple characters keeps one element per character. The
+    /// combined element keeps the position of the first credit.
+    func mergingCrewRoles() -> [BaseItemPerson] {
+        var people: [BaseItemPerson] = []
+        var indices: [String: Int] = [:]
+
+        for person in self {
+            guard let type = person.type,
+                  mergeableCrewKinds.contains(type),
+                  let id = person.id
+            else {
+                people.append(person)
+                continue
+            }
+
+            guard let index = indices[id] else {
+                indices[id] = people.count
+                people.append(person)
+                continue
+            }
+
+            people[index].role = mergedRole(people[index].role, person.role)
+        }
+
+        return people
+    }
+}
+
+/// Joins two roles, keeping each role listed once.
+private func mergedRole(_ role: String?, _ other: String?) -> String? {
+    let roles = [role, other]
+        .compactMap { $0 }
+        .filter { $0.isNotEmpty }
+        .reduce(into: [String]()) { unique, next in
+            guard !unique.contains(next) else { return }
+            unique.append(next)
+        }
+
+    return roles.isEmpty ? nil : roles.joined(separator: " / ")
+}

--- a/Shared/Extensions/JellyfinAPI/BaseItemPerson/BaseItemPerson.swift
+++ b/Shared/Extensions/JellyfinAPI/BaseItemPerson/BaseItemPerson.swift
@@ -11,6 +11,7 @@ import JellyfinAPI
 import UIKit
 
 extension BaseItemPerson: Displayable {
+
     var displayTitle: String {
         name ?? .emptyDash
     }
@@ -25,17 +26,20 @@ extension BaseItemPerson: LibraryParent {
 
 extension BaseItemPerson {
 
-    // Jellyfin will grab all roles the person played in the show which makes the role
-    //    text too long. This will grab the first role which:
-    //      - assumes that the most important role is the first
-    //      - will also grab the last "(<text>)" instance, like "(voice)"
-    var firstRole: String? {
-        guard let role = self.role else { return nil }
+    var isCrew: Bool {
+        type == .director || type == .writer || type == .producer
+    }
+
+    /// Shows crew jobs, or first role in a multi-role string
+    var displayRole: String? {
+        guard let role else { return nil }
+        guard !isCrew else { return role }
+
         let split = role.split(separator: "/")
         guard split.count > 1 else { return role }
 
-        guard let firstRole = split.first?.trimmingCharacters(in: CharacterSet(charactersIn: .space)),
-              let lastRole = split.last?.trimmingCharacters(in: CharacterSet(charactersIn: .space)) else { return role }
+        guard let firstRole = split.first?.trimmingCharacters(in: String.space),
+              let lastRole = split.last?.trimmingCharacters(in: String.space) else { return role }
 
         var final = firstRole
 
@@ -46,53 +50,4 @@ extension BaseItemPerson {
 
         return final
     }
-}
-
-/// The person kinds the server sends one credit per job for, meaning someone credited for
-/// multiple jobs is sent as multiple people.
-let mergeableCrewKinds: Set<PersonKind> = [.director, .writer, .producer]
-
-extension Collection where Element == BaseItemPerson {
-
-    /// Combines the credits of a person holding multiple crew jobs into a single element listing
-    /// all of their roles, like "Director / Producer". Kinds outside `mergeableCrewKinds` are never
-    /// combined, so an actor playing multiple characters keeps one element per character. The
-    /// combined element keeps the position of the first credit.
-    func mergingCrewRoles() -> [BaseItemPerson] {
-        var people: [BaseItemPerson] = []
-        var indices: [String: Int] = [:]
-
-        for person in self {
-            guard let type = person.type,
-                  mergeableCrewKinds.contains(type),
-                  let id = person.id
-            else {
-                people.append(person)
-                continue
-            }
-
-            guard let index = indices[id] else {
-                indices[id] = people.count
-                people.append(person)
-                continue
-            }
-
-            people[index].role = mergedRole(people[index].role, person.role)
-        }
-
-        return people
-    }
-}
-
-/// Joins two roles, keeping each role listed once.
-private func mergedRole(_ role: String?, _ other: String?) -> String? {
-    let roles = [role, other]
-        .compactMap { $0 }
-        .filter { $0.isNotEmpty }
-        .reduce(into: [String]()) { unique, next in
-            guard !unique.contains(next) else { return }
-            unique.append(next)
-        }
-
-    return roles.isEmpty ? nil : roles.joined(separator: " / ")
 }

--- a/Shared/Extensions/String.swift
+++ b/Shared/Extensions/String.swift
@@ -241,3 +241,10 @@ extension CharacterSet {
     // Character that appears on tvOS with voice input
     static var objectReplacement: CharacterSet = .init(charactersIn: "\u{fffc}")
 }
+
+extension StringProtocol {
+
+    func trimmingCharacters(in string: String) -> String {
+        trimmingCharacters(in: CharacterSet(charactersIn: string))
+    }
+}

--- a/Shared/Objects/MediaPlayerManager/MediaPlayerManager.swift
+++ b/Shared/Objects/MediaPlayerManager/MediaPlayerManager.swift
@@ -151,7 +151,8 @@ final class MediaPlayerManager: ViewModel {
             case .queue:
                 return queue
             case .people:
-                guard let people = item.people?.filter({ $0.type?.isSupported == true }).mergingCrewRoles(), people.isNotEmpty else { return nil }
+                guard let people = item.mergedPeople?.filter({ $0.type?.isSupported == true }),
+                      people.isNotEmpty else { return nil }
                 return MediaPeopleSupplement(people: people)
             case .playbackInformation:
                 guard let itemID = item.id else { return nil }

--- a/Shared/Objects/MediaPlayerManager/MediaPlayerManager.swift
+++ b/Shared/Objects/MediaPlayerManager/MediaPlayerManager.swift
@@ -151,7 +151,7 @@ final class MediaPlayerManager: ViewModel {
             case .queue:
                 return queue
             case .people:
-                guard let people = item.people?.filter({ $0.type?.isSupported == true }), people.isNotEmpty else { return nil }
+                guard let people = item.people?.filter({ $0.type?.isSupported == true }).mergingCrewRoles(), people.isNotEmpty else { return nil }
                 return MediaPeopleSupplement(people: people)
             case .playbackInformation:
                 guard let itemID = item.id else { return nil }

--- a/Shared/Objects/MediaPlayerManager/Supplements/MediaPeopleSupplement.swift
+++ b/Shared/Objects/MediaPlayerManager/Supplements/MediaPeopleSupplement.swift
@@ -124,7 +124,7 @@ extension MediaPeopleSupplement {
                     .lineLimit(1)
                     .foregroundStyle(.primary)
 
-                if let role = person.firstRole {
+                if let role = person.displayRole {
                     Text(role)
                         .font(.caption)
                         .foregroundStyle(.secondary)

--- a/Shared/Views/ItemContentGroupView/ItemContentGroupProvider.swift
+++ b/Shared/Views/ItemContentGroupView/ItemContentGroupProvider.swift
@@ -205,7 +205,7 @@ final class ItemContentGroupProvider: ViewModel, ContentGroupProvider {
             )
         }
 
-        if let castAndCrew = item.people, castAndCrew.isNotEmpty {
+        if let castAndCrew = item.people?.mergingCrewRoles(), castAndCrew.isNotEmpty {
             PosterGroup(
                 id: "cast-and-crew",
                 library: StaticLibrary(

--- a/Shared/Views/ItemContentGroupView/ItemContentGroupProvider.swift
+++ b/Shared/Views/ItemContentGroupView/ItemContentGroupProvider.swift
@@ -205,7 +205,7 @@ final class ItemContentGroupProvider: ViewModel, ContentGroupProvider {
             )
         }
 
-        if let castAndCrew = item.people?.mergingCrewRoles(), castAndCrew.isNotEmpty {
+        if let castAndCrew = item.mergedPeople, castAndCrew.isNotEmpty {
             PosterGroup(
                 id: "cast-and-crew",
                 library: StaticLibrary(


### PR DESCRIPTION
**Changes**

The server sends one `People` entry per credit, so a person credited for several crew jobs on the same item gets one poster per job — a director who also produced appears twice in Cast & Crew, same photo, one saying "Director" and another saying "Producer". This combines the director, writer and producer credits belonging to the same person into a single poster listing every role, e.g. "Director / Producer". Actors are left alone, so someone playing two characters keeps a poster per character.

It follows what jellyfin-web does since https://github.com/jellyfin/jellyfin-web/pull/8209 (shipped in 12.0), using the same merged kinds — director, writer, producer, which is `PersonKind.supportedCases` minus actor, and also what the server keeps in `TmdbUtils.WantedCrewKinds` — and the same `" / "` separator.

Merging lives in `mergingCrewRoles()` on `Collection where Element == BaseItemPerson`, applied where `item.people` is read for display: the Cast & Crew poster group in `ItemContentGroupProvider` and the people supplement in `MediaPlayerManager`.

One related change worth calling out: `BaseItemPerson.subtitle` used `firstRole`, which cuts a role at the first `"/"` so that an actor's many characters stay short. That would hide everything after the first job of a combined credit, so crew subtitles now use `role` directly. For an uncombined crew credit this is identical, since job names do not contain `"/"`.

**Testing**

Being upfront: **I develop on Linux and have no macOS machine, so this has not been compiled or run.** Please treat it as unverified and build it before merging — I would rather say so than imply a test I did not do.

What supports it:

- The identical change on Android TV, where I could run it, behaves as intended against a real library: on *Scott Pilgrim vs. the World*, Edgar Wright collapses from three cards (Director, Screenplay, Producer) into one reading "Director / Screenplay / Producer", and actors are unaffected.
- The same logic on jellyfin-vue, also verified against a live server.

I am happy to iterate on anything CI flags, or to close this if you would rather implement it yourselves.

**Code assistance**

Written with Claude Code using the Opus 5 model. It audited which clients were missing the behavior and wrote the extension and the call sites. I reviewed the change myself. As noted above, no build or on-device verification was possible on my machine.

I originally hit the duplicate cards on Android TV, but the same gap exists here, in jellyfin-roku and in jellyfin-vue, so I am opening the equivalent PR against each of those rather than leaving the fix partial across clients.

**Issues**

N/A — no existing issue. Follows up on https://github.com/jellyfin/jellyfin-web/pull/8209.
