### PR TITLE
Fix tvOS item overview title and navigation

### DIFF
--- a/Shared/Views/ItemContentGroupView/AboutItemGroup.swift
+++ b/Shared/Views/ItemContentGroupView/AboutItemGroup.swift
@@ -87,12 +87,15 @@ struct AboutItemGroup: ContentGroup {
         @ViewBuilder
         private var descriptionCard: some View {
             let subtitle = item.taglines?.first ?? item.parentTitle
+            let hasOverviewContent = item.taglines?.first?.isNotEmpty == true || item.overview?.isNotEmpty == true
 
             AboutCard(
                 title: item.displayTitle,
                 subtitle: subtitle
             ) {
-                router.route(to: .itemOverview(item: item))
+                if hasOverviewContent {
+                    router.route(to: .itemOverview(item: item))
+                }
             } content: {
                 if let overview = item.overview, overview.isNotEmpty {
                     SeeMoreText(overview)

--- a/Shared/Views/MediaInformation/ItemOverview.swift
+++ b/Shared/Views/MediaInformation/ItemOverview.swift
@@ -19,12 +19,6 @@ struct ItemOverviewView: View {
     var body: some View {
         ScrollView {
             VStack(alignment: UIDevice.isTV ? .center : .leading, spacing: 10) {
-
-                #if os(tvOS)
-                Text(item.displayTitle)
-                    .font(.title)
-                #endif
-
                 if let firstTagline = item.taglines?.first {
                     Text(firstTagline)
                         .font(.title3)


### PR DESCRIPTION
Item overview on tvOS displayed the item title twice, while items without overview content could still open an empty screen.

This removes the duplicated title and only allows navigation when a tagline or overview is available.

### Duplicate title

| Before | After |
| --- | --- |
| <img width="1920" height="1080" alt="before" src="https://github.com/user-attachments/assets/9584bc04-ea3d-44db-9aee-0729599794bb" /> | <img width="1920" height="1080" alt="after" src="https://github.com/user-attachments/assets/c42866b5-02ae-40ac-bb5d-52da7a70d0cf" /> |

### Empty overview

Before, items without a tagline or overview could still open an empty overview screen.

<img width="1920" height="1080" alt="before-2" src="https://github.com/user-attachments/assets/17299a82-fa63-4dea-95af-88d093f051dc" />

After this change, the card no longer navigates when there is no content to display.