### PR TITLE
Allow `DirectPlay` for Remote Live TV

### DIFF
--- a/Shared/Objects/MediaPlayerManager/MediaPlayerItem/MediaPlayerItem+Build.swift
+++ b/Shared/Objects/MediaPlayerManager/MediaPlayerItem/MediaPlayerItem+Build.swift
@@ -183,7 +183,6 @@ extension MediaPlayerItem {
     }
 
     // TODO: audio type stream
-    // TODO: build live tv stream from Paths.getLiveHlsStream?
     private static func streamURL(
         item: BaseItemDto,
         mediaSource: MediaSourceInfo,
@@ -206,7 +205,7 @@ extension MediaPlayerItem {
             return url
         }
 
-        if item.mediaType == .video, !item.isLiveStream {
+        if item.mediaType == .video {
 
             logger.trace("Making video stream URL for item \(itemID)")
 
@@ -214,7 +213,8 @@ extension MediaPlayerItem {
                 isStatic: true,
                 tag: mediaSource.eTag ?? item.etag,
                 playSessionID: playSessionID,
-                mediaSourceID: mediaSource.id ?? itemID
+                mediaSourceID: mediaSource.id ?? itemID,
+                liveStreamID: mediaSource.liveStreamID
             )
 
             let videoStreamRequest = Paths.getVideoStream(

--- a/Shared/Objects/VideoPlayerType/VideoPlayerType+Native.swift
+++ b/Shared/Objects/VideoPlayerType/VideoPlayerType+Native.swift
@@ -68,23 +68,6 @@ extension VideoPlayerType {
 
         DirectPlayProfile(type: .video) {
             AudioCodec.aac
-            AudioCodec.ac3
-            AudioCodec.eac3
-            AudioCodec.mp3
-        } videoCodecs: {
-
-            VideoCodec.h264
-
-            if PlaybackCapabilities.supportsHEVC {
-                VideoCodec.hevc
-            }
-
-        } containers: {
-            MediaContainer.mpegts
-        }
-
-        DirectPlayProfile(type: .video) {
-            AudioCodec.aac
             AudioCodec.amr_nb
         } videoCodecs: {
             VideoCodec.h264


### PR DESCRIPTION
### Summary

Resolves: https://github.com/jellyfin/Swiftfin/issues/1948
Resolves: https://github.com/jellyfin/Swiftfin/issues/2278

I ended up finding the `LiveStreamId` was all that we were missing.

Originally, there was a TODO to use an endpoint that appears to have been removed by: https://github.com/jellyfin/jellyfin/pull/16715. As a result, my change in https://github.com/jellyfin/jellyfin-sdk-swift/pull/62 didn't end up being needed for this although that change may be needed later. Tested on VLC, MPV, and AVPlayer although I found `.ts` never worked for AVPlayer so I have removed that from the `.auto` device profile. If, anyone finds their `.ts` is functional, this can be added via a custom profile. 

I generated 16 test tuners with varying `.ts` configurations (see AI disclaimer) that direct play without issue on MPV and VLC so it could be a generation issue but I'm leaning towards being over zealous on transcoding for AVPlayer since adding a profile to existing is easier than creating a full profile from scratch.

### AI Disclaimer

Creation of Live TV M3U8 and fake tuner for testing. All tests were synthentic but were funcitonal in both Jellyfin-Web and Swiftfin. This was tested in addition to https://iptv-org.github.io channels to test forcing transcodes and external sources.

Testing may not reflect other Live TV Tuners but I attempted to be very thorough in the types of streams. I've added the `Release Highlight` flag just so this shows up in the TestFlight so people know to test this. I don't really think this is a big feature but that flag was what gets pulled into the release notes for TF.

### Videos of `DirectPlay`

#### VLC

https://github.com/user-attachments/assets/e358656b-a3b4-4a38-8a62-2cc3c4c13774

#### MPV

https://github.com/user-attachments/assets/4c0c20a2-fa40-4627-90eb-d5d6c3b4a1f3

#### AVPlayer (Remux)

Remuxing because of `.ts`.

https://github.com/user-attachments/assets/77f45daf-6fed-4c8b-9f83-50a5789926c9

---

These images are from internal streams but please note that internal streams that `DirectPlay` do not show up in the dashboard as they fallback directly to the tuner.