### PR TITLE
Nested Edit Glass

### DIFF
--- a/Shared/Components/ButtonStyles/BackportGlassButtonStyles.swift
+++ b/Shared/Components/ButtonStyles/BackportGlassButtonStyles.swift
@@ -92,7 +92,9 @@ private struct BackportGlassButtonStyleBody: View {
         switch prominence {
         case .standard:
             nativeButton
-                .buttonStyle(.glass)
+                #if !os(iOS)
+                    .buttonStyle(.glass)
+                #endif
         case .prominent:
             nativeButton
                 .buttonStyle(.glassProminent)


### PR DESCRIPTION
### Summary

Fixes the Edit Buttons having nested button inside of glass. iOS 26+ puts buttons in glass then we are putting it inside another glass. Prominent doesn't seem to have this same issue so that was left untouched.

| Before | After |
| :---: | :---: |
| <img width="300" alt="Simulator Screenshot - iPhone 17 Pro - 2026-09-12 at 12 22 42" src="https://github.com/user-attachments/assets/2a225e0e-552a-40ba-a28b-5302c3f1fb30" /> | <img width="300" alt="Simulator Screenshot - iPhone 17 Pro - 2026-09-12 at 12 24 35" src="https://github.com/user-attachments/assets/a6bcaf26-2ee7-4195-90d8-f63deb4d0a15" /> |

---

tvOS seems to handle this differently so tvOS was left intact as well:

<img width="769" height="174" alt="Screenshot 2026-09-12 at 12 31 08" src="https://github.com/user-attachments/assets/802e6b26-bdcb-492d-b86a-1089b8341f2a" />

<img width="769" height="171" alt="Screenshot 2026-09-12 at 12 31 01" src="https://github.com/user-attachments/assets/652865db-d2b2-4a08-a78c-3730f7e8e03b" />
